### PR TITLE
Fix issue #103 - ensure DasBlog.Runtime uses snake-case for category url

### DIFF
--- a/source/DasBlog.Web.UI/Common/Utils.cs
+++ b/source/DasBlog.Web.UI/Common/Utils.cs
@@ -4,6 +4,7 @@ namespace DasBlog.Web.Common
 {
 	internal static class Utils
 	{
+		/// DUPLICATE of newtelligence.DasBlog.Util.HtmlHelper.EncodeCategoryUrl
 		/// <summary>
 		/// converts a category display text to a safe url using separator (typically '-') to replace
 		/// dangwerous characters

--- a/source/newtelligence.DasBlog.Util/HttpHelper.cs
+++ b/source/newtelligence.DasBlog.Util/HttpHelper.cs
@@ -1,86 +1,32 @@
 ﻿using System.Text;
+using System.Text.RegularExpressions;
 
 namespace newtelligence.DasBlog.Util
 {
     public static class HttpHelper
     {
+	    /// <summary>
+	    /// replaces almost all non-alpha-numeric characters with '-'
+	    /// has asimilar effect to HtmlEncoding but produces more agreeable urls.
+	    /// Note that in dasBlog this function produced camel case for
+	    /// dasBlog-core it now produces snake case
+	    /// </summary>
+	    /// <param name="urlString">e.g. marks&spencer</param>
+	    /// <returns>e.g. marks-spencer</returns>
         public static string GetURLSafeString(string urlString)
         {
-            if (urlString == null || urlString.Length == 0) return "";
-
-            StringBuilder retVal = new StringBuilder(urlString.Length);
-
-            if (urlString != null)
-            {
-                bool upper = false;
-                bool pendingSpace = false;
-                bool tag = false;
-
-                for (int i = 0; i < urlString.Length; ++i)
-                {
-                    char c = urlString[i];
-
-                    if (tag)
-                    {
-                        if (c == '>')
-                        {
-                            tag = false;
-                        }
-                    }
-                    else if (c == '<')
-                    {
-                        // Discard everything between '<' and '>', inclusive.
-                        // If no '>', just discard the '<'.
-                        tag = (urlString.IndexOf('>', i) >= 0);
-                    }
-
-                    // Per RFC 2396 (URI syntax):
-                    //  delims   = "<" | ">" | "#" | "%" | <">
-                    //  reserved = ";" | "/" | "?" | ":" | "@" | "&" | "=" | "+" | "$" | ","
-                    // These characters should not appear in a URL
-                    else if ("#%\";/?:@&=$,".IndexOf(c) >= 0)
-                    {
-                        continue;
-                    }
-
-                    else if (char.IsWhiteSpace(c))
-                    {
-                        pendingSpace = true;
-                    }
-
-                    // The marks may appear in URLs
-                    //  mark = "-" | "_" | "." | "!" | "~" | "*" | "'" | "(" | ")"
-                    // as may all alphanumerics. (Tilde gets mangled by UrlEncode).
-                    // Here we are more lenient than RFC 2396, as we allow
-                    // all Unicode alphanumerics, not just the US-ASCII ones.
-                    // SDH: Update: it's really safer and maintains more permalinks if we stick with A-Za-z0-9.
-                    else if (char.IsLetterOrDigit(c) /* ||  "-_.!~*'()".IndexOf(c) >= 0 */ )
-                    {
-                        if (pendingSpace)
-                        {
-                            // Discard leading spaces
-                            if (retVal.Length > 0)
-                            {
-                                
-                            }
-                            upper = true;
-                            pendingSpace = false;
-                        }
-
-                        if (upper)
-                        {
-                            retVal.Append(char.ToUpper(c));
-                            upper = false;
-                        }
-                        else
-                        {
-                            retVal.Append(c);
-                        }
-                    }
-                }
-            }
-
-            return System.Web.HttpUtility.UrlEncode(retVal.ToString());
+	        return EncodeCategoryUrl(urlString, "-");
         }
+	    /// DUPLICATE of DasBlog.Web.Common.Utils.EncodeCategoryUrl
+	    /// <summary>
+	    /// converts a category display text to a safe url using separator (typically '-') to replace
+	    /// dangwerous characters
+	    /// </summary>
+	    /// <param name="displayText">e.g Pots&amp;Pans</param>
+	    /// <param name="separator">typically config TitlePermalinkSpaceReplacement - '-'</param>
+	    /// <returns>pots-pans</returns>
+	    public static string EncodeCategoryUrl(string displayText, string separator)
+		    => Regex.Replace(displayText.ToLower(), @"[^A-Za-z0-9_\.~]+", separator);
+
     }
 }


### PR DESCRIPTION
Links for categories which contain characters which would be converted by UrlEncode fail #103

This should not clash with #111 but if it does, and as a rule, push back for me to rebase.