### PR TITLE
Implemented SiteRepairer to handle minor site problems at startup

### DIFF
--- a/source/DasBlog.Web.Core/DasBlog.Core.csproj
+++ b/source/DasBlog.Web.Core/DasBlog.Core.csproj
@@ -1,21 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\newtelligence.DasBlog.Runtime\newtelligence.DasBlog.Runtime.csproj" />
     <ProjectReference Include="..\newtelligence.DasBlog.Web.Core\newtelligence.DasBlog.Web.Core.csproj" />
     <ProjectReference Include="..\newtelligence.DasBlog.Web.Services\newtelligence.DasBlog.Web.Services.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <Folder Include="Settings\" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="xmlrpcnet" Version="2.5.0" />
   </ItemGroup>
-
 </Project>

--- a/source/DasBlog.Web.Core/Services/Interfaces/ISiteRepairer.cs
+++ b/source/DasBlog.Web.Core/Services/Interfaces/ISiteRepairer.cs
@@ -1,0 +1,7 @@
+﻿namespace DasBlog.Core.Services.Interfaces
+{
+	public interface ISiteRepairer
+	{
+		(bool result, string errorMessage)  RepairSite();
+	}
+}

--- a/source/DasBlog.Web.Core/Services/SiteRepairer.cs
+++ b/source/DasBlog.Web.Core/Services/SiteRepairer.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.IO;
+using DasBlog.Core.Services.Interfaces;
+
+namespace DasBlog.Core.Services
+{
+	public class SiteRepairer : ISiteRepairer
+	{
+		private string _binariesPath = "";
+		public SiteRepairer(IDasBlogSettings dasBlogSettings)
+		{
+			_binariesPath = Path.Combine(dasBlogSettings.WebRootDirectory
+			  ,dasBlogSettings.SiteConfiguration.BinariesDir.TrimStart('~', '/'));
+		}
+		public (bool result, string errorMessage) RepairSite()
+		{
+			try
+			{
+				if (!Directory.Exists(_binariesPath))
+				{
+					// TODO log activity
+					Directory.CreateDirectory(_binariesPath);
+				}
+
+				return (true, "");
+			}
+			catch (Exception e)
+			{
+				// TODO log error and cause error page to be shown
+				return (false, $"Failed to start service.  Failed to create {_binariesPath}.  Detail: {e.Message}");
+			}
+		}
+	}
+}


### PR DESCRIPTION
addresses: newly installed app throws exception at startup due to missing binary dir #114

@poppastring I suggest you prioritise this over PR #113 which I will then rebase.  We don't want any aspiring contributors to be discouraged by a breaking app - the worst sin.

