### PR TITLE
Logged errors that happen when attempting to edit or add a post.  Issue #138.

### DIFF
--- a/source/DasBlog.Web.Repositories/BlogManager.cs
+++ b/source/DasBlog.Web.Repositories/BlogManager.cs
@@ -9,6 +9,7 @@ using newtelligence.DasBlog.Util;
 using EventDataItem = DasBlog.Core.EventDataItem;
 using EventCodes = DasBlog.Core.EventCodes;
 using DasBlog.Core.Extensions;
+using DasBlog.Core.Exceptions;
 
 namespace DasBlog.Managers
 {
@@ -280,6 +281,11 @@ namespace DasBlog.Managers
 				//TODO: Do something with this????
 				// StackTrace st = new StackTrace();
 				// logService.AddEvent(new EventDataItem(EventCodes.Error, ex.ToString() + Environment.NewLine + st.ToString(), ""));
+
+				LoggedException le = new LoggedException("file failure", ex);
+				var edi = new EventDataItem(EventCodes.Error, null
+				  , "Failed to Save a Post on {date}", System.DateTime.Now.ToShortDateString());
+				logger.LogError(edi,le);
 			}
 
 			// we want to invalidate all the caches so users get the new post

--- a/source/DasBlog.Web.UI/Controllers/HomeController.cs
+++ b/source/DasBlog.Web.UI/Controllers/HomeController.cs
@@ -119,8 +119,9 @@ namespace DasBlog.Web.Controllers
 				return View(new ErrorViewModel { RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier });
 
 			}
-			catch (Exception e)
+			catch (Exception ex)
 			{
+				_logger.LogError(ex, ex.Message, null);
 				return Content(
 					"DasBlog - an error occurred (and reporting gailed) - Click the browser 'Back' button to try using the application");
 			}


### PR DESCRIPTION
Logged errors that happen when attempting to edit or add a post. These were being swallowed and were not getting logged. This should remove the three warnings of unused Exception variables while firing the build, as described in issue #138 - @poppastring - please feel free to review and do let me know if any added changes are required.