### PR TITLE
fixed broken test of users

### DIFF
--- a/source/DasBlog.Tests/FunctionalTests/IntegrationTests/PrototypeIntegrationTests.cs
+++ b/source/DasBlog.Tests/FunctionalTests/IntegrationTests/PrototypeIntegrationTests.cs
@@ -28,7 +28,7 @@ namespace DasBlog.Tests.FunctionalTests.IntegrationTests
 		public void UsersTest()
 		{
 			var userService = serviceResolver.GetService<IUserService>();
-			(var found, var user) = userService.FindMatchingUser("shula@TheStables.com");
+			(var found, var user) = userService.FindMatchingUser("myemail@myemail.com");
 			Assert.True(found);
 		}
 	}


### PR DESCRIPTION
It was/is my intention to give the functional/integration tests their own sandbox in terms of content and config directories which should prevent this nonsense recurring (test was relying on a specific user in the production config).  It's pretty much in the existing code.  I will activate it when I fix the users bugs or when I do some refactoring.