### PR TITLE
broken build - windows 10 being picky about capitalisation

### DIFF
--- a/source/DasBlog All.sln
+++ b/source/DasBlog All.sln
@@ -17,8 +17,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "newtelligence.DasBlog.Util"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "newtelligence.DasBlog.Runtime.Proxies", "newtelligence.DasBlog.Runtime.Proxies\newtelligence.DasBlog.Runtime.Proxies.csproj", "{9BAD4DCD-3C05-4716-A406-8B561EF0633F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "newtelligence.DasBlog.Runtime.Test", "newtelligence.DasBlog.Runtime\Test\newtelligence.DasBlog.Runtime.Test.csproj", "{48BC208B-59CE-4BE2-BA3A-72AEE7F205CB}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "newtelligence.DasBlog.Util.Test", "newtelligence.DasBlog.Util\Test\newtelligence.DasBlog.Util.Test.csproj", "{5139B077-EC05-4F6D-BA08-27991B4E7185}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Subtext.Akismet", "Subtext.Akismet\Subtext.Akismet.csproj", "{4DC29536-2515-4B8D-AEB6-EC397B950881}"
@@ -61,6 +59,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Resources", "DasBlog.Tests\Resources\Resources.csproj", "{2CEF017A-0670-4C33-92E0-E644FE82B765}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NetEscapades.Extensions.Logging.RollingFile", "NetEscapades.Extensions.Logging.RollingFile\NetEscapades.Extensions.Logging.RollingFile.csproj", "{EB90F5F5-0028-45DA-AA4D-0205C5CE73DF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "newtelligence.DasBlog.runtime.Test", "newtelligence.DasBlog.Runtime\Test\newtelligence.DasBlog.runtime.Test.csproj", "{48BC208B-59CE-4BE2-BA3A-72AEE7F205CB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -109,12 +109,6 @@ Global
 		{9BAD4DCD-3C05-4716-A406-8B561EF0633F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9BAD4DCD-3C05-4716-A406-8B561EF0633F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9BAD4DCD-3C05-4716-A406-8B561EF0633F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{48BC208B-59CE-4BE2-BA3A-72AEE7F205CB}.Debug - All|Any CPU.ActiveCfg = Debug|Any CPU
-		{48BC208B-59CE-4BE2-BA3A-72AEE7F205CB}.Debug - All|Any CPU.Build.0 = Debug|Any CPU
-		{48BC208B-59CE-4BE2-BA3A-72AEE7F205CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{48BC208B-59CE-4BE2-BA3A-72AEE7F205CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{48BC208B-59CE-4BE2-BA3A-72AEE7F205CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{48BC208B-59CE-4BE2-BA3A-72AEE7F205CB}.Release|Any CPU.Build.0 = Release|Any CPU
 		{5139B077-EC05-4F6D-BA08-27991B4E7185}.Debug - All|Any CPU.ActiveCfg = Debug|Any CPU
 		{5139B077-EC05-4F6D-BA08-27991B4E7185}.Debug - All|Any CPU.Build.0 = Debug|Any CPU
 		{5139B077-EC05-4F6D-BA08-27991B4E7185}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -192,6 +186,12 @@ Global
 		{EB90F5F5-0028-45DA-AA4D-0205C5CE73DF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EB90F5F5-0028-45DA-AA4D-0205C5CE73DF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EB90F5F5-0028-45DA-AA4D-0205C5CE73DF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{48BC208B-59CE-4BE2-BA3A-72AEE7F205CB}.Debug - All|Any CPU.ActiveCfg = Debug|Any CPU
+		{48BC208B-59CE-4BE2-BA3A-72AEE7F205CB}.Debug - All|Any CPU.Build.0 = Debug|Any CPU
+		{48BC208B-59CE-4BE2-BA3A-72AEE7F205CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{48BC208B-59CE-4BE2-BA3A-72AEE7F205CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{48BC208B-59CE-4BE2-BA3A-72AEE7F205CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{48BC208B-59CE-4BE2-BA3A-72AEE7F205CB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -203,7 +203,6 @@ Global
 		{7A9A0C81-84AE-4C6F-9489-528B5B97F426} = {4383190A-97AC-435E-9FBB-E203AC4497ED}
 		{15C1672E-92A2-4FAF-977A-D7EBC008EC42} = {4383190A-97AC-435E-9FBB-E203AC4497ED}
 		{9BAD4DCD-3C05-4716-A406-8B561EF0633F} = {4383190A-97AC-435E-9FBB-E203AC4497ED}
-		{48BC208B-59CE-4BE2-BA3A-72AEE7F205CB} = {4383190A-97AC-435E-9FBB-E203AC4497ED}
 		{5139B077-EC05-4F6D-BA08-27991B4E7185} = {4383190A-97AC-435E-9FBB-E203AC4497ED}
 		{B734F9FD-539D-4FD3-9343-5BD5C18FF699} = {800E3AC8-FF13-43CE-8C09-6F4A2867D445}
 		{3EA4B6D5-6AC0-4235-AAD3-27FFBD158FC6} = {F0F076E7-9863-46B7-8C3C-5C220D4BC118}
@@ -212,6 +211,7 @@ Global
 		{85B28FFC-EBB9-4E18-A1F4-9C352789725F} = {F0F076E7-9863-46B7-8C3C-5C220D4BC118}
 		{09F7AFA8-D450-4308-831E-3D895BF7B180} = {F0F076E7-9863-46B7-8C3C-5C220D4BC118}
 		{2CEF017A-0670-4C33-92E0-E644FE82B765} = {F0F076E7-9863-46B7-8C3C-5C220D4BC118}
+		{48BC208B-59CE-4BE2-BA3A-72AEE7F205CB} = {4383190A-97AC-435E-9FBB-E203AC4497ED}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8F3ACFB8-CB52-4953-A1CF-4151E2789889}

--- a/source/newtelligence.DasBlog.Runtime/Test/newtelligence.DasBlog.runtime.Test.csproj
+++ b/source/newtelligence.DasBlog.Runtime/Test/newtelligence.DasBlog.runtime.Test.csproj
@@ -148,9 +148,7 @@
     <Compile Include="AppTest.cs">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="AssemblyInfo.cs">
-      <SubType>Code</SubType>
-    </Compile>
+    <Compile Include="assemblyinfo.cs" />
     <Compile Include="BlogDataServiceTests.cs">
       <SubType>Code</SubType>
     </Compile>


### PR DESCRIPTION
I'm not sure why this started happening on Surfface Pro 4/Windows 10 - dotnet build objected (but in any case we need to be case sensitive to simplify future move to posix).  No problem on IMac/Windows 10