### PR TITLE
Remove version reference for Microsoft.AspNetCore.App package

### DIFF
--- a/source/DasBlog.Tests/FunctionalTests/DasBlog.Tests.FunctionalTests.csproj
+++ b/source/DasBlog.Tests/FunctionalTests/DasBlog.Tests.FunctionalTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>

--- a/source/DasBlog.Tests/FunctionalTests/DasBlog.Tests.FunctionalTests.csproj
+++ b/source/DasBlog.Tests/FunctionalTests/DasBlog.Tests.FunctionalTests.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="2.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />

--- a/source/DasBlog.Tests/UnitTests/DasBlog.Tests.UnitTests.csproj
+++ b/source/DasBlog.Tests/UnitTests/DasBlog.Tests.UnitTests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -12,8 +12,6 @@
   </ItemGroup>
   <ItemGroup>
     <None Remove="Config\metaConfig.xml" />
-    <None Remove="Config\site.config" />
-    <None Remove="Config\siteSecurity.config" />
     <None Remove="TestContent\2003-07-31.dayentry.xml" />
     <None Remove="TestContent\2003-08-01.dayentry.xml" />
     <None Remove="TestContent\2004-01-13.dayentry.xml" />
@@ -27,12 +25,6 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Config\metaConfig.xml" />
-    <Content Include="Config\site.config">
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </Content>
-    <Content Include="Config\siteSecurity.config">
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
-    </Content>
     <Content Include="TestContent\2003-07-31.dayentry.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/source/DasBlog.Tests/UnitTests/DasBlog.Tests.UnitTests.csproj
+++ b/source/DasBlog.Tests/UnitTests/DasBlog.Tests.UnitTests.csproj
@@ -65,6 +65,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="Moq" Version="4.8.2" />

--- a/source/DasBlog.Web.UI/DasBlog.Web.csproj
+++ b/source/DasBlog.Web.UI/DasBlog.Web.csproj
@@ -28,7 +28,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="6.2.2" />
     <!--<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="3.2.0" />-->
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.0" />

--- a/source/DasBlog.Web.UI/DasBlog.Web.csproj
+++ b/source/DasBlog.Web.UI/DasBlog.Web.csproj
@@ -29,9 +29,7 @@
     <PackageReference Include="AutoMapper" Version="6.2.2" />
     <!--<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="3.2.0" />-->
     <PackageReference Include="Microsoft.AspNetCore.App" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Formatters.Xml" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.1.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.1.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.0" />
     <!--<PackageReference Include="NetEscapades.Extensions.Logging.RollingFile" Version="1.0.0" />-->


### PR DESCRIPTION
As per the [official migratrion guide](https://docs.microsoft.com/en-us/aspnet/core/migration/20_21?view=aspnetcore-2.2#update-the-project-file-to-use-21-versions), this package should not be versioned.

This should also fix issue #214.
