### PR TITLE
Bug/blank comments

### DIFF
--- a/source/DasBlog.Tests/FunctionalTests/BrowserBasedTests/BrowserBasedTests.md
+++ b/source/DasBlog.Tests/FunctionalTests/BrowserBasedTests/BrowserBasedTests.md
@@ -211,3 +211,6 @@ To change the data environment set up the following environment variable:
 ```
 DAS_BLOG_DATA_ROOT=<projects>/dasblog-core/source/DasBlog.Tests/Resources/Environments/Vanilla
 ```
+
+Remember to commit all changes in the Environments directory tree and remove any un-tracked files created 
+such as the logs to avoid subsequent tests failing

--- a/source/DasBlog.Tests/FunctionalTests/BrowserBasedTests/PrototypeBrowserBasedTests.cs
+++ b/source/DasBlog.Tests/FunctionalTests/BrowserBasedTests/PrototypeBrowserBasedTests.cs
@@ -199,6 +199,14 @@ namespace DasBlog.Tests.FunctionalTests.BrowserBasedTests
 			{
 			}
 		}
+		/**
+		 * This test is living on borrowed time.  It relies on the fact that the BlogPostController uses
+		 * the dasBlogSettings which has EnableComments=true (as it does not respond to config changes
+		 * at runtime whereas the BlogManager does honour the runtime config change.
+		 * When the controller's config usage becomes responsive to runtime changes then
+		 * only the first three steps will be required and the third step will be changed to
+		 * verify that the NameTextBox does NOT exist.
+		 */
 		[Fact(Skip="")]
 		[Trait(Constants.CategoryTraitType, Constants.BrowserBasedTestTraitValue )]
 		public void AddComment_AfterDeactivatingComments_DoesNotAddComment()

--- a/source/DasBlog.Tests/FunctionalTests/BrowserBasedTests/PrototypeBrowserBasedTests.cs
+++ b/source/DasBlog.Tests/FunctionalTests/BrowserBasedTests/PrototypeBrowserBasedTests.cs
@@ -163,6 +163,13 @@ namespace DasBlog.Tests.FunctionalTests.BrowserBasedTests
 			{
 			}
 		}
+		/**
+		 * all the AddComment tests currently pass on my Imac/Parallels/Windows 10/1803 installation
+		 * but fail on my Surface Pro/Windows 10/1803.  Both with latest of everything as far as I know.
+		 * Selenium appears to take no action on the Click() step.
+		 *
+		 * Note that some of the AddComment tests appear to pass under these circumstances which is misleading.
+		 */
 		[Fact(Skip="")]
 		[Trait(Constants.CategoryTraitType, Constants.BrowserBasedTestTraitValue )]
 		public void AddComment_AfterActivatingComments_AddsComment()

--- a/source/DasBlog.Tests/FunctionalTests/BrowserBasedTests/PrototypeBrowserBasedTests.cs
+++ b/source/DasBlog.Tests/FunctionalTests/BrowserBasedTests/PrototypeBrowserBasedTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Linq;
+using System.Xml.Linq;
 using DasBlog.Core.XmlRpc.Blogger;
 using DasBlog.Tests.Automation.Selenium;
 using DasBlog.Tests.FunctionalTests.Common;
@@ -223,6 +225,45 @@ namespace DasBlog.Tests.FunctionalTests.BrowserBasedTests
 				platform.TestExecutor.Execute(testSteps, results);
 				platform.Publisher.Publish(results.Results);
 				Assert.True(results.TestPassed);
+			}
+			catch (Exception e)
+			{
+				_ = e;
+				throw;
+			}
+			finally
+			{
+			}
+		}
+		[Fact(Skip="")]
+		[Trait(Constants.CategoryTraitType, Constants.BrowserBasedTestTraitValue )]
+		public void AddComment_IfBlankForm_DoesNotAddPermanentComment()
+		{
+			try
+			{
+				var dp = platform.CreateTestDataProcessor();
+				dp.SetSiteConfigValue("EnableComments", "true");
+				List<TestStep> testSteps = new List<TestStep>
+				{
+					new ActionStep(() => platform.Browser.Goto("post/5125c596-d6d5-46fe-9f9b-c13f851d8b0d/comments")),
+					new VerificationStep(() => platform.Pages.HomePage.IsDisplayed()),
+					new VerificationStep(() => platform.Pages.HomePage.NameTextBox != null),
+					new VerificationStep(() => platform.Pages.HomePage.EmailTextBox != null),
+					new VerificationStep(() => platform.Pages.HomePage.ContentTextBox != null),
+					new VerificationStep(() => platform.Pages.HomePage.SaveContentButton != null),
+					new ActionStep(() => platform.Pages.HomePage.NameTextBox.SetText( string.Empty)),
+					new ActionStep(() => platform.Pages.HomePage.EmailTextBox.SetText( string.Empty)),
+					new ActionStep(() => platform.Pages.HomePage.ContentTextBox.SetText( string.Empty)),
+					new ActionStep(() => platform.Pages.HomePage.SaveContentButton.Click()),
+					new VerificationStep(() => platform.Pages.HomePage.IsDisplayed())
+				};
+				var results = new TestResults();
+				platform.TestExecutor.Execute(testSteps, results);
+				platform.Publisher.Publish(results.Results);
+				Assert.True(results.TestPassed);
+				var comments = dp.GetDayExtraFileContents(new DateTime(2018, 8, 3)).data;
+				var list = comments.Descendants().ToList();
+				Assert.False(comments.HasElements);
 			}
 			catch (Exception e)
 			{

--- a/source/DasBlog.Tests/FunctionalTests/BrowserBasedTests/PrototypeBrowserBasedTests.cs
+++ b/source/DasBlog.Tests/FunctionalTests/BrowserBasedTests/PrototypeBrowserBasedTests.cs
@@ -213,6 +213,7 @@ namespace DasBlog.Tests.FunctionalTests.BrowserBasedTests
 		 * When the controller's config usage becomes responsive to runtime changes then
 		 * only the first three steps will be required and the third step will be changed to
 		 * verify that the NameTextBox does NOT exist.
+		 * 
 		 */
 		[Fact(Skip="")]
 		[Trait(Constants.CategoryTraitType, Constants.BrowserBasedTestTraitValue )]

--- a/source/DasBlog.Tests/FunctionalTests/BrowserBasedTests/PrototypeBrowserBasedTests.cs
+++ b/source/DasBlog.Tests/FunctionalTests/BrowserBasedTests/PrototypeBrowserBasedTests.cs
@@ -262,7 +262,6 @@ namespace DasBlog.Tests.FunctionalTests.BrowserBasedTests
 				platform.Publisher.Publish(results.Results);
 				Assert.True(results.TestPassed);
 				var comments = dp.GetDayExtraFileContents(new DateTime(2018, 8, 3)).data;
-				var list = comments.Descendants().ToList();
 				Assert.False(comments.HasElements);
 			}
 			catch (Exception e)

--- a/source/DasBlog.Tests/FunctionalTests/Common/ITestDataProcessor.cs
+++ b/source/DasBlog.Tests/FunctionalTests/Common/ITestDataProcessor.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using System.Xml.Linq;
 using newtelligence.DasBlog.Runtime;
 
 namespace DasBlog.Tests.FunctionalTests.Common
@@ -24,11 +25,20 @@ namespace DasBlog.Tests.FunctionalTests.Common
 		/// <param name="key">e.g. "Role"</param>
 		/// <returns>e.g. "admin", if operation fails then value is null otherwise it is the value identified by key</returns>
 		(bool success, string value) GetSiteSecurityConfigValue(string email, string key);
+		// TODO: what is the behaviour for an empty file?
 		/// <param name="dt">The date of the blog entry - should match the date in the file name</param>
 		/// <param name="entryId">typically a GUID</param>
 		/// <param name="key">e.g. "IsPublic"</param>
 		/// <returns>e.g. "false", if operation fails then value is null otherwise it is the value identified by key</returns>
 		(bool success, string value) GetBlogPostValue(DateTime dt, string entryId, string key);
+
+		/// <summary>
+		/// gets the complete contents of the dayentry xml file for the specified date
+		/// </summary>
+		/// <param name="dt">should match the date stamp on a dayentry file</param>
+		/// <returns>success=true, if the file exists otherwise false
+		///   data=linq ready tree starting at "DayEntry", immediate children "Date" and "Entries"</returns>
+		(bool success, XElement data) GetBlogPostFileContents(DateTime dt);
 /*
 		/// <summary>
 		/// set values in config and entry files
@@ -55,7 +65,16 @@ namespace DasBlog.Tests.FunctionalTests.Common
 		/// <param name="key">e.g. "IsPublic"</param>
 		/// <param name="value">.e.g "false"</param>
 		/// <exception cref="Exception">throown if the operation fails.  Message provides reason</exception>
-		void SetBlogPostValue(DateTime dt, Expression<Func<Entry, bool>> pred, string key);
+		void SetBlogPostValue(DateTime dt, Expression<Func<Entry, bool>> pred, string key, object value);
+
+		// TODO: what is the behaviour for an empty file?
+		/// <summary>
+		/// gets the complete contents of the dayfeedback xml file for the specified date
+		/// </summary>
+		/// <param name="dt">should match the date stamp on a dayfeedback file</param>
+		/// <returns>success=true, if the file exists otherwise false
+		///   data=linq ready tree starting at DayExtra, immediate children "Date" and "Comments"</returns>
+		(bool success, XElement data) GetDayExtraFileContents(DateTime dt);
 
 		/// <summary>
 		/// typically used to get comments - maybe other stuff - I don't know

--- a/source/DasBlog.Tests/FunctionalTests/Common/TestDataProcesor.cs
+++ b/source/DasBlog.Tests/FunctionalTests/Common/TestDataProcesor.cs
@@ -1,9 +1,11 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Net.Http;
 using System.Security.Cryptography.Xml;
 using System.Xml;
+using System.Xml.Linq;
 using System.Xml.XPath;
 using System.Xml.Xsl;
 using DasBlog.Tests.Support;
@@ -84,6 +86,16 @@ namespace DasBlog.Tests.FunctionalTests.Common
 			return GetValue(Path.Combine(Constants.ContentDirectory, fileName)
 				, $"/post:DayEntry/post:Entries/post:Entry[post:EntryId='{entryId}']/post:{key}");
 		}
+		/// <inheritdoc cref="ITestDataProcessor.GetBlogPostValue"/>
+		public (bool success, XElement data) GetBlogPostFileContents(DateTime dt)
+		{
+			string fileName = GetBlogEntryFileName(dt);
+			var path = CombinePaths(Path.Combine(Constants.ContentDirectory, fileName));
+			if (!File.Exists(path))
+				return (false, new XElement("empty"));
+			var str = File.ReadAllText(path);
+			return (true, XElement.Parse(str));
+		}
 
 /*
 		/// <inheritdoc cref="ITestDataProcessor.SetValue"/>
@@ -112,7 +124,7 @@ namespace DasBlog.Tests.FunctionalTests.Common
 			SetValueUsingTemplate(Constants.SiteSecurityConfigPathFragment, siteSecurityConfigTransform, email, key, value);
 		}
 		/// <inheritdoc cref="ITestDataProcessor.SetBlogPostValue"/>
-		public void SetBlogPostValue(DateTime dt, Expression<Func<Entry, bool>> pred, string key)
+		public void SetBlogPostValue(DateTime dt, Expression<Func<Entry, bool>> pred, string key, object value)
 		{
 			throw new NotImplementedException();
 		}
@@ -122,6 +134,15 @@ namespace DasBlog.Tests.FunctionalTests.Common
 			return GetValue(Path.Combine(Constants.ContentDirectory, GetDayExtraFileName(dt))
 			  , $"/post:DayExtra/post:Comments/post:Comment[post:EntryId=\"{entryId}\"]/post:{key}");
 		}
+		/// <inheritdoc cref="ITestDataProcessor.GetDayExtraFileContents"/>
+		public (bool success, XElement data) GetDayExtraFileContents(DateTime dt)
+		{
+			var path = CombinePaths(Path.Combine(Constants.ContentDirectory, GetDayExtraFileName(dt)));
+			if (!File.Exists(path))
+				return (false, new XElement("empty"));
+			var str = File.ReadAllText(path);
+			return (true, XElement.Parse(str));
+		}
 		/// <inheritdoc cref="ITestDataProcessor.GetDayExtraValue"/>
 		public void SetDayExtraValue(DateTime dt, string entryId, string key, string value)
 		{
@@ -129,7 +150,8 @@ namespace DasBlog.Tests.FunctionalTests.Common
 			  Path.Combine(Constants.ContentDirectory, GetDayExtraFileName(dt))
 			  , dayExtraTransform, entryId, key, value);
 		}
-
+		/// <param name="filePathRelativeToEnvironment">e.g. contents/2018-2-8.dayentry.xml</param>
+		/// <returns>e.g. c:/projects/dasblog/.../Environments/Vanilla/Contents/2108-2-8.dayentry.xml</returns>
 		private string CombinePaths(string filePathRelativeToEnvironment)
 		{
 			return Path.Combine(testDataPath, filePathRelativeToEnvironment);

--- a/source/DasBlog.Tests/FunctionalTests/Common/TestSupportPlatform.cs
+++ b/source/DasBlog.Tests/FunctionalTests/Common/TestSupportPlatform.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit.Abstractions;
 using Constants = DasBlog.Tests.Support.Common.Constants;
-using Utils = DasBlog.Tests.Support.Common.Utils;
+using SupportUtils = DasBlog.Tests.Support.Common.Utils;
 
 namespace DasBlog.Tests.FunctionalTests.Common
 {
@@ -83,7 +83,7 @@ namespace DasBlog.Tests.FunctionalTests.Common
 				opts =>
 				{
 					opts.ScriptDirectory =
-						Path.Combine(Utils.GetProjectRootDirectory(),Constants.ScriptsRelativePath);
+						Path.Combine(SupportUtils.GetProjectRootDirectory(),Constants.ScriptsRelativePath);
 					opts.ScriptTimeout = Constants.DefaultScriptTimeout;
 					if (Int32.TryParse(Environment.GetEnvironmentVariable(Constants.DasBlogTestScriptTimeout),
 						out var envScriptTimeout))
@@ -101,7 +101,7 @@ namespace DasBlog.Tests.FunctionalTests.Common
 			services.Configure<GitVersionedFileServiceOptions>(
 				opts =>
 				{
-					opts.GitRepoDirectory = Utils.GetProjectRootDirectory();
+					opts.GitRepoDirectory = SupportUtils.GetProjectRootDirectory();
 					opts.TestDataDirectroy = Constants.TestDataDirectory;
 				});
 			if (new DasBlog.Core.Common.StdOSDetector().DetectOS() == Os.Windows)
@@ -118,12 +118,12 @@ namespace DasBlog.Tests.FunctionalTests.Common
 			services.AddSingleton<ITestDataProcesorFactory, TestDataProcesorFactory>();
 			ConfigurationBuilder configBuilder = new ConfigurationBuilder();
 			configBuilder.AddJsonFile(
-				Path.Combine(Utils.GetProjectRootDirectory(), Constants.FunctionalTestsRelativeToProject, "appsettings.json")
+				Path.Combine(SupportUtils.GetProjectRootDirectory(), Constants.FunctionalTestsRelativeToProject, "appsettings.json")
 				, optional: false, reloadOnChange: false);
 			// the derived platform app settings will have precedence over the more general ones
 			// by dint of being added to the configuration later
 			configBuilder.AddJsonFile(
-				Path.Combine(Utils.GetProjectRootDirectory(), AppSettingsPathRelativeToProject, "appsettings.json")
+				Path.Combine(SupportUtils.GetProjectRootDirectory(), AppSettingsPathRelativeToProject, "appsettings.json")
 				, optional: false, reloadOnChange: false);
 			IConfigurationRoot config = configBuilder.Build();
 			services.Configure<ILoggerFactory>(config);

--- a/source/DasBlog.Tests/FunctionalTests/Common/Utils.Templates.cs
+++ b/source/DasBlog.Tests/FunctionalTests/Common/Utils.Templates.cs
@@ -1,6 +1,6 @@
-namespace DasBlog.Tests.FunctionalTests.ComponentTests
+namespace DasBlog.Tests.FunctionalTests.Common
 {
-	public partial class BlogManagerTests
+	internal static partial class Utils
 	{
 		private const string minimalBlogPostXml = @"
 <DayEntry xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xmlns:xsd='http://www.w3.org/2001/XMLSchema' xmlns='urn:newtelligence-com:dasblog:runtime:data'>

--- a/source/DasBlog.Tests/FunctionalTests/Common/Utils.cs
+++ b/source/DasBlog.Tests/FunctionalTests/Common/Utils.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Globalization;
+using System.IO;
+using DasBlog.Managers.Interfaces;
+using newtelligence.DasBlog.Runtime;
+
+namespace DasBlog.Tests.FunctionalTests.Common
+{
+	internal static partial class Utils
+	{
+		/// <summary>
+		/// writes day entry file into the content directory 
+		/// </summary>
+		/// <param name="blogManager"></param>
+		/// <param name="directory">e.g. c:/projects/dasblog-core.../Environments/Vanilla/content</param>
+		/// <param name="entryId"></param>
+		public static void SaveEntryDirect(string directory, string entryId = null)
+		{
+			var fileName = TestDataProcesor.GetBlogEntryFileName(DateTime.Today);
+			var path = Path.Combine(directory, fileName);
+			var str = string.Format(minimalBlogPostXml
+				, DateTime.Today.ToString("s", CultureInfo.InvariantCulture)
+				, DateTime.Now.ToString("s", CultureInfo.InvariantCulture)
+				, DateTime.Now.ToString("s", CultureInfo.InvariantCulture)
+				, entryId ?? Guid.NewGuid().ToString());
+			File.WriteAllText(path, str);
+//			new CacheFixer().InvalidateCache(blogManager);
+		}
+
+		public static void DeleteDirectoryContentsDirect(string directory, string fileSpec = "*.*")
+		{
+			foreach (var file in Directory.EnumerateFiles(directory, fileSpec))
+			{
+				File.Delete(file);
+			}
+		}
+		public static bool DayEntryFileExists(string directory, DateTime dt)
+		{
+			var fileName = TestDataProcesor.GetBlogEntryFileName(dt);
+			var path = Path.Combine(directory, fileName);
+			return File.Exists(path);
+		}
+		public static bool DayFeedbackFileExists(string directory, DateTime dt)
+		{
+			var fileName = TestDataProcesor.GetBlogFeedbackFileName(dt);
+			var path = Path.Combine(directory, fileName);
+			return File.Exists(path);
+		}
+		
+		public static Entry MakeMiniimalEntry()
+		{
+			Entry entry = new Entry();
+			entry.Initialize();
+			entry.Title = string.Empty;
+			entry.Content = string.Empty;
+			entry.Description = string.Empty;
+			entry.Categories = string.Empty;
+			return entry;
+		}
+	}
+}

--- a/source/DasBlog.Tests/FunctionalTests/ComponentTests/BlogManagerTests.CreateUpdateDelete.cs
+++ b/source/DasBlog.Tests/FunctionalTests/ComponentTests/BlogManagerTests.CreateUpdateDelete.cs
@@ -8,8 +8,10 @@ using DasBlog.Tests.FunctionalTests.Common;
 using DasBlog.Tests.Support.Common;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.DependencyInjection;
-using newtelligence.DasBlog.Runtime;
 using Xunit;
+using Utils = DasBlog.Tests.Support.Common.Utils;
+using TestUtils = DasBlog.Tests.FunctionalTests.Common.Utils;
+using newtelligence.DasBlog.Runtime;
 
 namespace DasBlog.Tests.FunctionalTests.ComponentTests
 {
@@ -180,46 +182,17 @@ namespace DasBlog.Tests.FunctionalTests.ComponentTests
 		/// <param name="entryId"></param>
 		private void SaveEntryDirect(IBlogManager blogManager, string directory, string entryId = null)
 		{
-			var fileName = TestDataProcesor.GetBlogEntryFileName(DateTime.Today);
-			var path = Path.Combine(directory, fileName);
-			var str = string.Format(minimalBlogPostXml
-			  , DateTime.Today.ToString("s", CultureInfo.InvariantCulture)
-			  , DateTime.Now.ToString("s", CultureInfo.InvariantCulture)
-			  , DateTime.Now.ToString("s", CultureInfo.InvariantCulture)
-			  , entryId ?? Guid.NewGuid().ToString());
-			File.WriteAllText(path, str);
-//			new CacheFixer().InvalidateCache(blogManager);
+			TestUtils.SaveEntryDirect(directory, entryId);
 		}
 
-		private void DeleteDirectoryContentsDirect(string directory, string fileSpec = "*.*")
-		{
-			foreach (var file in Directory.EnumerateFiles(directory, fileSpec))
-			{
-				File.Delete(file);
-			}
-		}
-		private bool DayEntryFileExists(string directory, DateTime dt)
-		{
-			var fileName = TestDataProcesor.GetBlogEntryFileName(dt);
-			var path = Path.Combine(directory, fileName);
-			return File.Exists(path);
-		}
 		private bool DayFeedbackFileExists(string directory, DateTime dt)
 		{
-			var fileName = TestDataProcesor.GetBlogFeedbackFileName(dt);
-			var path = Path.Combine(directory, fileName);
-			return File.Exists(path);
+			return TestUtils.DayFeedbackFileExists(directory, dt);
 		}
 		
 		private static Entry MakeMiniimalEntry()
 		{
-			Entry entry = new Entry();
-			entry.Initialize();
-			entry.Title = string.Empty;
-			entry.Content = string.Empty;
-			entry.Description = string.Empty;
-			entry.Categories = string.Empty;
-			return entry;
+			return TestUtils.MakeMiniimalEntry();
 		}
 
 

--- a/source/DasBlog.Web.UI/Controllers/BlogPostController.cs
+++ b/source/DasBlog.Web.UI/Controllers/BlogPostController.cs
@@ -312,7 +312,7 @@ namespace DasBlog.Web.Controllers
 
 			if (!ModelState.IsValid)
 			{
-				Comment(new Guid(addcomment.TargetEntryId));
+				return Comment(new Guid(addcomment.TargetEntryId));
 			}
 
 			addcomment.Content = dasBlogSettings.FilterHtml(addcomment.Content);


### PR DESCRIPTION
Addresses: system allows empty comment to be added #245

@poppastring you need to change the filter on your appVeyor component tests to --filter Category=ComponentTest.

browser based tests are not working at all now on AppVeyor.  Maybe a step too far.  Selenium tests continue to be very problematic locally as well although they run 9 times out of 10.