### PR TITLE
Add the theme folder FIRST so themes can be overridden

### DIFF
--- a/source/DasBlog.Web.UI/Settings/DasBlogLocationExpander.cs
+++ b/source/DasBlog.Web.UI/Settings/DasBlogLocationExpander.cs
@@ -17,7 +17,7 @@ namespace DasBlog.Web.Settings
         public IEnumerable<string> ExpandViewLocations(ViewLocationExpanderContext context, IEnumerable<string> viewLocations)
         {
 			var listlocations = viewLocations.ToList();
-			listlocations.Add(theme);
+			listlocations.Insert(0, theme);
 			return listlocations;
 		}
 


### PR DESCRIPTION
I need to OVERRIDE _commentPartial and other views, but the theme is added to the end. If you add it to the BEGINNING then themes can optionally override things just by making a file with the same name. This is a cleaner fallback (test your site) so I can add a _CommentBlockPartial inside my theme folder AND not edit the /Views/Shared files!