### PR TITLE
Fixing default comment links behavior

### DIFF
--- a/source/DasBlog.Web.UI/Controllers/BlogPostController.cs
+++ b/source/DasBlog.Web.UI/Controllers/BlogPostController.cs
@@ -298,7 +298,8 @@ namespace DasBlog.Web.Controllers
 						Comments = blogManager.GetComments(entry.EntryId, false)
 							.Select(comment => mapper.Map<CommentViewModel>(comment)).ToList(),
 						PostId = entry.EntryId,
-						PostDate = entry.CreatedUtc
+						PostDate = entry.CreatedUtc,
+						CommentUrl = dasBlogSettings.GetCommentViewUrl(posttitle)
 					};
 
 					lpvm.Posts.First().Comments = lcvm;

--- a/source/DasBlog.Web.UI/Controllers/BlogPostController.cs
+++ b/source/DasBlog.Web.UI/Controllers/BlogPostController.cs
@@ -281,8 +281,19 @@ namespace DasBlog.Web.Controllers
 		public IActionResult Comment(string posttitle)
 		{
 			ListPostsViewModel lpvm = null;
+			Entry entry = null;
+			var postguid = Guid.Empty;
 
-			var entry = blogManager.GetBlogPost(posttitle, null);
+			entry = blogManager.GetBlogPost(posttitle, null);
+
+			if (entry == null && Guid.TryParse(posttitle, out postguid))
+			{
+				entry = blogManager.GetBlogPostByGuid(postguid);
+
+				var pvm = mapper.Map<PostViewModel>(entry);
+
+				return RedirectPermanent(dasBlogSettings.GetCommentViewUrl(pvm.PermaLink));
+			}
 
 			if (entry != null)
 			{

--- a/source/DasBlog.Web.UI/Models/BlogViewModels/ListCommentsViewModel.cs
+++ b/source/DasBlog.Web.UI/Models/BlogViewModels/ListCommentsViewModel.cs
@@ -12,5 +12,7 @@ namespace DasBlog.Web.Models.BlogViewModels
 		public string PostId { get; set; }
 
 		public DateTime PostDate { get; set; }
+
+		public string CommentUrl { get; set; }
 	}
 }

--- a/source/DasBlog.Web.UI/Views/Shared/_CommentBlockPartial.cshtml
+++ b/source/DasBlog.Web.UI/Views/Shared/_CommentBlockPartial.cshtml
@@ -1,14 +1,13 @@
 ﻿@using DasBlog.Web.Models.BlogViewModels;
-@using Constants = DasBlog.Core.Common.Constants;
-@using Microsoft.VisualBasic
 
 @model ListCommentsViewModel
 @inject IDasBlogSettings dasBlogSettings
 
 @if (Model != null && Model.Comments != null)
 {
-@*     <div id="@Constants.CommentsStart" >here</div> *@
     <hr />
+    <a class="comment-section-title" href="@Model.CommentUrl" >Comment Section</a>
+
     <div class="post-comments">
         <div class="post-comments-list">
             @if (Model.Comments.Count > 0)
@@ -25,7 +24,7 @@
             @await Html.PartialAsync("_CommentAddPartial", new AddCommentViewModel() { Content = string.Empty, Email = string.Empty, HomePage = string.Empty, Name = string.Empty, TargetEntryId = Model.PostId })
         }
         else
-        { 
+        {
             <p>Comments are closed.</p>
         }
     </div>


### PR DESCRIPTION
Wanted to ensure the default behavior would redirect GUID based URLs to the title based URLs.