### PR TITLE
Remove "post" from comments URL

### DIFF
--- a/source/DasBlog.Web.UI/Controllers/BlogPostController.cs
+++ b/source/DasBlog.Web.UI/Controllers/BlogPostController.cs
@@ -276,8 +276,8 @@ namespace DasBlog.Web.Controllers
 		}
 
 		[AllowAnonymous]
-		[HttpGet("post/{posttitle}/comments")]
-		[HttpGet("post/{posttitle}/comments/{commentid:guid}")]
+		[HttpGet("{posttitle}/comments")]
+		[HttpGet("{posttitle}/comments/{commentid:guid}")]
 		public IActionResult Comment(string posttitle)
 		{
 			ListPostsViewModel lpvm = null;

--- a/source/DasBlog.Web.UI/Controllers/FeedController.cs
+++ b/source/DasBlog.Web.UI/Controllers/FeedController.cs
@@ -93,6 +93,24 @@ namespace DasBlog.Web.Controllers
 			return Content(blogger);
 		}
 
+		[HttpGet("feed/pingback")]
+		public ActionResult PingBack()
+		{
+			return Ok();
+		}
+
+		[HttpGet("feed/rss/comments/{entryid}")]
+		public ActionResult RssComments(string entryid)
+		{
+			return Ok();
+		}
+
+		[HttpGet("feed/trackback/{entryid}")]
+		public ActionResult TrackBack(string entryid)
+		{
+			return Ok();
+		}
+
 		private void BreakSiteCache()
 		{
 			memoryCache.Remove(CACHEKEY_RSS);

--- a/source/DasBlog.Web.UI/Settings/DasBlogSettings.cs
+++ b/source/DasBlog.Web.UI/Settings/DasBlogSettings.cs
@@ -123,7 +123,7 @@ namespace DasBlog.Web.Settings
 		}
 		public string GetCommentViewUrl(string entryId)
         {
-            return GetPermaLinkUrl(entryId) + $"/comments#{Constants.CommentsStartId}";
+            return RelativeToRoot(entryId) + $"/comments#{Constants.CommentsStartId}";
         }
 
         public string GetTrackbackUrl(string entryId)


### PR DESCRIPTION
Removing "post" from the comment links URI.
Added endpoints for trackback/pingbacks (although they do nothing).

