### PR TITLE
Posting a blogs fails, this should resolve it.

### DIFF
--- a/source/DasBlog.Web.UI/Controllers/FeedController.cs
+++ b/source/DasBlog.Web.UI/Controllers/FeedController.cs
@@ -94,7 +94,7 @@ namespace DasBlog.Web.Controllers
 			{
 				using (var mem = new MemoryStream())
 				{
-					Request.Body.CopyTo(mem);
+					Request.Body.CopyToAsync(mem);
 					blogger = xmlRpcManager.Invoke(mem);
 				}
 			}


### PR DESCRIPTION
Starting with ASP.NET Core 3.0, synchronous server operations are disabled by default.