### PR TITLE
Only send an email if configured.

### DIFF
--- a/source/DasBlog.Web.Repositories/BlogManager.cs
+++ b/source/DasBlog.Web.Repositories/BlogManager.cs
@@ -364,9 +364,17 @@ namespace DasBlog.Managers
 					return CommentSaveState.PostCommentsDisabled;
 				}
 
-				var actions = ComposeMailForUsers(entry, comment);
+				if (dasBlogSettings.SiteConfiguration.SendCommentsByEmail)
+				{
+					var actions = ComposeMailForUsers(entry, comment);
+					dataService.AddComment(comment, actions);
+				}
+				else
+				{
+					dataService.AddComment(comment);
+				}
 
-				dataService.AddComment(comment, actions);
+				
 				saveState = CommentSaveState.Added;
 			}
 			else


### PR DESCRIPTION
My latest changes attempted to send an alert email even if we were not configured to do so. This is the fix.