### PR TITLE
Another TagHelper fix

### DIFF
--- a/source/DasBlog.Web.UI/TagHelpers/TitleLinkTagHelper.cs
+++ b/source/DasBlog.Web.UI/TagHelpers/TitleLinkTagHelper.cs
@@ -35,7 +35,7 @@ namespace DasBlog.Web.TagHelpers
 
 			if (string.IsNullOrWhiteSpace(title))
 			{
-				title = Post.PermaLink;			
+				title = Post.Title;			
 			}
 
 			output.Attributes.SetAttribute("href", dasBlogSettings.RelativeToRoot(Post.PermaLink));


### PR DESCRIPTION
Fixed default name of the Title TagHelper to title rather than the permalink.