### PR TITLE
Fixing image/binary folder issues

### DIFF
--- a/source/DasBlog.Services/FileManagement/ConfigFilePathsDataOption.cs
+++ b/source/DasBlog.Services/FileManagement/ConfigFilePathsDataOption.cs
@@ -17,5 +17,7 @@ namespace DasBlog.Services.FileManagement
 		public string ThemesFolder { get; set; }
 
 		public string BinaryFolder { get; set; }
+
+		public string BinaryUrlRelative { get; set; }
 	}
 }

--- a/source/DasBlog.Web.Repositories/XmlRpcManager.cs
+++ b/source/DasBlog.Web.Repositories/XmlRpcManager.cs
@@ -631,7 +631,7 @@ namespace DasBlog.Managers
 
 			var urlInfo = new MetaWeblog.UrlInfo
 			{
-				url = Path.Combine(dasBlogSettings.RelativeToRoot(dasBlogSettings.SiteConfiguration.BinariesDir.TrimStart('~', '/')), enc.name)
+				url = filePath
 			};
 
 			return urlInfo;

--- a/source/DasBlog.Web.UI/Startup.cs
+++ b/source/DasBlog.Web.UI/Startup.cs
@@ -46,6 +46,7 @@ namespace DasBlog.Web
 		private readonly string MetaConfigPath;
 		private readonly string ThemeFolderPath;
 		private readonly string BinariesPath;
+		private readonly string BinariesUrlRelativePath;
 
 		private readonly IWebHostEnvironment hostingEnvironment;
 		
@@ -55,8 +56,8 @@ namespace DasBlog.Web
 		{
 			Configuration = configuration;
 			hostingEnvironment = env;
-			BinariesPath = Configuration.GetValue<string>("binariesDir");
-			BinariesPath = Path.Combine(Configuration.GetValue<string>("ContentDir"), Configuration.GetValue<string>("binariesDir")); 
+			BinariesPath = Path.Combine(Configuration.GetValue<string>("ContentDir"), "binary");
+			BinariesUrlRelativePath = string.Format("{0}/{1}", Configuration.GetValue<string>("ContentDir"), "binary");
 			SiteSecurityConfigPath = $"Config/siteSecurity.{hostingEnvironment.EnvironmentName}.config";
 			IISUrlRewriteConfigPath = $"Config/IISUrlRewrite.{hostingEnvironment.EnvironmentName}.config";
 			SiteConfigPath = $"Config/site.{hostingEnvironment.EnvironmentName}.config";
@@ -88,6 +89,7 @@ namespace DasBlog.Web
 				options.IISUrlRewriteFilePath = Path.Combine(hostingEnvironment.ContentRootPath, IISUrlRewriteConfigPath);
 				options.ThemesFolder = Path.Combine(hostingEnvironment.ContentRootPath, ThemeFolderPath);
 				options.BinaryFolder = Path.Combine(hostingEnvironment.ContentRootPath, BinariesPath);
+				options.BinaryUrlRelative = string.Format("{0}/", BinariesUrlRelativePath);
 			});
 
 			services.Configure<ActivityRepoOptions>(options
@@ -248,7 +250,7 @@ namespace DasBlog.Web
 			app.UseStaticFiles(new StaticFileOptions()
 			{
 				FileProvider = new PhysicalFileProvider(Path.Combine(env.ContentRootPath, BinariesPath)),
-				RequestPath = "/binaries"
+				RequestPath = string.Format("/{0}", BinariesUrlRelativePath)
 			});
 
 			app.UseStaticFiles(new StaticFileOptions

--- a/source/newtelligence.DasBlog.Runtime/FileSystemBinaryDataService.cs
+++ b/source/newtelligence.DasBlog.Runtime/FileSystemBinaryDataService.cs
@@ -151,13 +151,13 @@ namespace newtelligence.DasBlog.Runtime
 
         private string GetAbsoluteFileUri(string fullPath, out string relFileUri)
         {
-            string relPath = fullPath.Replace(contentLocation, "");
+			var relPath = fullPath.Replace(contentLocation, "").TrimStart('\\') ;
 
-            Uri relUri = new Uri( relPath, UriKind.Relative);
+			var relUri = new Uri( relPath, UriKind.Relative);
 
             relFileUri = relUri.ToString();
 
-            return new Uri(binaryRoot, relUri).ToString();
+            return new Uri(binaryRoot, relPath).ToString();
         }
 
         public bool DeleteFile(string path)


### PR DESCRIPTION
By default images are always placed in a "binary" folder which is now always placed as a subdirectory of the content folder. (previously defined in an used setting).

Fixed static folder for serving images (I broke this yesterday).

Fixed uploading of images via live writer and the create/post url (I broke this yesterday).


I really need a comprehensive integration testing framework to avoid dumb mistakes.