### PR TITLE
config file resiliency

### DIFF
--- a/source/DasBlog.Web.UI/Program.cs
+++ b/source/DasBlog.Web.UI/Program.cs
@@ -26,9 +26,16 @@ namespace DasBlog.Web.UI
 				{
 					env = hostingContext.HostingEnvironment;
 
-					configBuilder.AddXmlFile(Path.Combine(env.ContentRootPath, "Config", $"site.{env.EnvironmentName}.config"), optional: true, reloadOnChange: true)
+					configBuilder
+						.AddXmlFile(Path.Combine(env.ContentRootPath, "Config", $"site.config"), optional: false, reloadOnChange: true)
+						.AddXmlFile(Path.Combine(env.ContentRootPath, "Config", $"site.{env.EnvironmentName}.config"), optional: true, reloadOnChange: true)
+
+						.AddXmlFile(Path.Combine(env.ContentRootPath, "Config", $"meta.config"), optional: false, reloadOnChange: true)
 						.AddXmlFile(Path.Combine(env.ContentRootPath, "Config", $"meta.{env.EnvironmentName}.config"), optional: true, reloadOnChange: true)
-						.AddJsonFile(Path.Combine(env.ContentRootPath, $"appsettings.{env.EnvironmentName}.json"), optional: true)
+
+						.AddJsonFile(Path.Combine(env.ContentRootPath, $"appsettings.json"), optional: false, reloadOnChange: true)
+						.AddJsonFile(Path.Combine(env.ContentRootPath, $"appsettings.{env.EnvironmentName}.json"), optional: true, reloadOnChange: true)
+						
 						.AddEnvironmentVariables();
 
 					MaybeOverrideRootUrl(configBuilder);

--- a/source/DasBlog.Web.UI/Startup.cs
+++ b/source/DasBlog.Web.UI/Startup.cs
@@ -57,12 +57,17 @@ namespace DasBlog.Web
 			Configuration = configuration;
 			hostingEnvironment = env;
 			BinariesPath = Path.Combine(Configuration.GetValue<string>("ContentDir"), "binary");
-			BinariesUrlRelativePath = string.Format("{0}/{1}", Configuration.GetValue<string>("ContentDir"), "binary");
-			SiteSecurityConfigPath = $"Config/siteSecurity.{hostingEnvironment.EnvironmentName}.config";
-			IISUrlRewriteConfigPath = $"Config/IISUrlRewrite.{hostingEnvironment.EnvironmentName}.config";
-			SiteConfigPath = $"Config/site.{hostingEnvironment.EnvironmentName}.config";
-			MetaConfigPath = $"Config/meta.{hostingEnvironment.EnvironmentName}.config";
 			ThemeFolderPath = Path.Combine("Themes", Configuration.GetSection("Theme").Value);
+			BinariesUrlRelativePath = string.Format("{0}/{1}", Configuration.GetValue<string>("ContentDir"), "binary");
+			
+			var envname = string.IsNullOrWhiteSpace(hostingEnvironment.EnvironmentName) ? 
+									"." : string.Format($".{hostingEnvironment.EnvironmentName}.");
+
+			SiteSecurityConfigPath = Path.Combine("Config", $"siteSecurity{envname}config");
+			IISUrlRewriteConfigPath = Path.Combine("Config", $"IISUrlRewrite{envname}config");
+
+			SiteConfigPath = Path.Combine("Config", $"site{envname}config");
+			MetaConfigPath = Path.Combine("Config", $"meta{envname}config");
 		}
 
 		public IConfiguration Configuration { get; }


### PR DESCRIPTION
This fix ensures that if an environment name is not defined we default to standard config files. 
Additional  usage of path combine to help xplat