### PR TITLE
Binaries folder fixes

### DIFF
--- a/source/DasBlog.Services/Site/SiteRepairer.cs
+++ b/source/DasBlog.Services/Site/SiteRepairer.cs
@@ -9,7 +9,7 @@ namespace DasBlog.Services.Site
 		public SiteRepairer(IDasBlogSettings dasBlogSettings)
 		{
 			_binariesPath = Path.Combine(dasBlogSettings.WebRootDirectory,
-							dasBlogSettings.SiteConfiguration.BinariesDir.TrimStart('~', '/'));
+								dasBlogSettings.SiteConfiguration.BinariesDir.TrimStart('~', '/'));
 		}
 		public (bool result, string errorMessage) RepairSite()
 		{

--- a/source/DasBlog.Web.UI/Config/site.Development.config
+++ b/source/DasBlog.Web.UI/Config/site.Development.config
@@ -50,7 +50,7 @@
   <AdjustDisplayTimeZone>true</AdjustDisplayTimeZone>
   <ContentDir>content</ContentDir>
   <LogDir>logs</LogDir>
-  <BinariesDir>binary</BinariesDir>
+  <BinariesDir>content/binary</BinariesDir>
 
   <EnableTitlePermaLink>true</EnableTitlePermaLink>
   <EnableTitlePermaLinkUnique>false</EnableTitlePermaLinkUnique>
@@ -90,7 +90,7 @@
   <ShowCommentsWhenViewingEntry>true</ShowCommentsWhenViewingEntry>
   <TitlePermalinkSpaceReplacement>-</TitlePermalinkSpaceReplacement>
 
-  <EntryEditControl>Froala</EntryEditControl>
+  <EntryEditControl>TinyMce</EntryEditControl>
   <!-- TinyMce, NicEdit, TextArea or Froala -->
 
   <EnableBloggerApi>true</EnableBloggerApi>

--- a/source/DasBlog.Web.UI/Config/site.config
+++ b/source/DasBlog.Web.UI/Config/site.config
@@ -51,7 +51,7 @@
   
   <ContentDir>content</ContentDir>
   <LogDir>logs</LogDir>
-  <BinariesDir>binary</BinariesDir>
+  <BinariesDir>content/binary</BinariesDir>
 
   <EnableTitlePermaLink>true</EnableTitlePermaLink>
   <EnableTitlePermaLinkUnique>false</EnableTitlePermaLinkUnique>
@@ -91,7 +91,7 @@
   <ShowCommentsWhenViewingEntry>true</ShowCommentsWhenViewingEntry>
   <TitlePermalinkSpaceReplacement>-</TitlePermalinkSpaceReplacement>
 
-  <EntryEditControl>Froala</EntryEditControl>
+  <EntryEditControl>TinyMce</EntryEditControl>
   <!-- TinyMce, NicEdit, TextArea or Froala -->
 
   <EnableBloggerApi>true</EnableBloggerApi>

--- a/source/DasBlog.Web.UI/Models/AdminViewModels/SiteViewModel.cs
+++ b/source/DasBlog.Web.UI/Models/AdminViewModels/SiteViewModel.cs
@@ -185,6 +185,13 @@ namespace DasBlog.Web.Models.AdminViewModels
 		[Required(AllowEmptyStrings = false, ErrorMessage = "Enter a value for Logging Directory")]
 		public string LogDir { get; set; }
 
+
+		[DisplayName("Binaries directory")]
+		[Description("")]
+		[StringLength(300, MinimumLength = 1, ErrorMessage = "{0} should be between 1 to 300 characters")]
+		[Required(AllowEmptyStrings = false, ErrorMessage = "Enter a value for Binaries Directory")]
+		public string BinariesDir { get; set; }
+
 		[DisplayName("Adjust time zone")]
 		[Description("")]
 		public bool AdjustDisplayTimeZone { get; set; }
@@ -231,7 +238,6 @@ namespace DasBlog.Web.Models.AdminViewModels
 		[Description("")]
 		public ValidCommentTagsViewModel [] ValidCommentTags { get;  set; }
 
-		public string BinariesDir { get; set; }
 		public bool EntryTitleAsLink { get; set; }
 		public bool ObfuscateEmail { get; set; }
 		public bool SendReferralsByEmail { get; set; }

--- a/source/DasBlog.Web.UI/Startup.cs
+++ b/source/DasBlog.Web.UI/Startup.cs
@@ -56,9 +56,12 @@ namespace DasBlog.Web
 		{
 			Configuration = configuration;
 			hostingEnvironment = env;
-			BinariesPath = Configuration.GetValue<string>("ContentDir").TrimStart('~', '/');
+
+			var binarypath = Configuration.GetValue<string>("BinariesDir").TrimStart('~', '/');
+
+			BinariesPath = new DirectoryInfo(Path.Combine(env.ContentRootPath, binarypath)).FullName;
 			ThemeFolderPath = Path.Combine("Themes", Configuration.GetSection("Theme").Value);
-			BinariesUrlRelativePath = string.Format("{0}/{1}", Configuration.GetValue<string>("ContentDir"), "binary");
+			BinariesUrlRelativePath = "content/binary";
 			
 			var envname = string.IsNullOrWhiteSpace(hostingEnvironment.EnvironmentName) ? 
 									"." : string.Format($".{hostingEnvironment.EnvironmentName}.");
@@ -93,7 +96,7 @@ namespace DasBlog.Web
 				options.SecurityConfigFilePath = Path.Combine(hostingEnvironment.ContentRootPath, SiteSecurityConfigPath);
 				options.IISUrlRewriteFilePath = Path.Combine(hostingEnvironment.ContentRootPath, IISUrlRewriteConfigPath);
 				options.ThemesFolder = Path.Combine(hostingEnvironment.ContentRootPath, ThemeFolderPath);
-				options.BinaryFolder = Path.Combine(hostingEnvironment.ContentRootPath, BinariesPath);
+				options.BinaryFolder = BinariesPath;
 				options.BinaryUrlRelative = string.Format("{0}/", BinariesUrlRelativePath);
 			});
 
@@ -255,7 +258,7 @@ namespace DasBlog.Web
 
 			app.UseStaticFiles(new StaticFileOptions()
 			{
-				FileProvider = new PhysicalFileProvider(Path.Combine(env.ContentRootPath, BinariesPath)),
+				FileProvider = new PhysicalFileProvider(BinariesPath),
 				RequestPath = string.Format("/{0}", BinariesUrlRelativePath)
 			});
 

--- a/source/DasBlog.Web.UI/Startup.cs
+++ b/source/DasBlog.Web.UI/Startup.cs
@@ -56,7 +56,7 @@ namespace DasBlog.Web
 		{
 			Configuration = configuration;
 			hostingEnvironment = env;
-			BinariesPath = Path.Combine(Configuration.GetValue<string>("ContentDir"), "binary");
+			BinariesPath = Configuration.GetValue<string>("ContentDir").TrimStart('~', '/');
 			ThemeFolderPath = Path.Combine("Themes", Configuration.GetSection("Theme").Value);
 			BinariesUrlRelativePath = string.Format("{0}/{1}", Configuration.GetValue<string>("ContentDir"), "binary");
 			
@@ -210,7 +210,8 @@ namespace DasBlog.Web
 		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
 		public void Configure(IApplicationBuilder app, IWebHostEnvironment env, IOptions<RouteOptions> routeOptionsAccessor, IDasBlogSettings dasBlogSettings)
 		{
-			(var siteOk, string siteError) = RepairSite(app);
+			(var siteOk, var siteError) = RepairSite(app);
+
 			if (env.IsDevelopment() || env.IsStaging())
 			{
 				app.UseDeveloperExceptionPage();
@@ -234,8 +235,8 @@ namespace DasBlog.Web
 			app.UseRouting();
 
 			//if you've configured it at /blog or /whatever, set that pathbase so ~ will generate correctly
-			Uri rootUri = new Uri(dasBlogSettings.SiteConfiguration.Root);
-			string path = rootUri.AbsolutePath;
+			var rootUri = new Uri(dasBlogSettings.SiteConfiguration.Root);
+			var path = rootUri.AbsolutePath;
 
 			//Deal with path base and proxies that change the request path
 			//https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/proxy-load-balancer?view=aspnetcore-2.2#deal-with-path-base-and-proxies-that-change-the-request-path

--- a/source/DasBlog.Web.UI/Views/Admin/Settings.cshtml
+++ b/source/DasBlog.Web.UI/Views/Admin/Settings.cshtml
@@ -447,6 +447,15 @@
 
     <div class="dasblog-form-group row">
 
+        @Html.LabelFor(m => @Model.SiteConfig.BinariesDir, null, new { @class = "dasblog-col-form-label col-3" })
+        @Html.TextBoxFor(m => @Model.SiteConfig.BinariesDir, null, new { @class = "form-control col-9" })
+        @Html.ValidationMessageFor(m => m.SiteConfig.BinariesDir, null, new { @class = "text-danger" })
+
+    </div>
+
+
+    <div class="dasblog-form-group row">
+
         @Html.LabelFor(m => @Model.SiteConfig.LogDir, null, new { @class = "dasblog-col-form-label col-3" })
         @Html.TextBoxFor(m => @Model.SiteConfig.LogDir, null, new { @class = "form-control col-9" })
         @Html.ValidationMessageFor(m => m.SiteConfig.LogDir, null, new { @class = "text-danger" })
@@ -493,7 +502,6 @@
     @Html.HiddenFor(@m => m.SiteConfig.EntryTitleAsLink)
     @Html.HiddenFor(@m => m.SiteConfig.ObfuscateEmail)
 
-    @Html.HiddenFor(@m => m.SiteConfig.BinariesDir)
     @Html.HiddenFor(@m => m.SiteConfig.CommentsAllowHtml)
     @Html.HiddenFor(@m => m.SiteConfig.SendReferralsByEmail)
     @Html.HiddenFor(@m => m.SiteConfig.SendTrackbacksByEmail)


### PR DESCRIPTION
We are, correctly, back to using **BinariesDir**
Changed the default value to "content/binary" (was "~/content/binary"). If you have the old value you will be fine.
**BinariesDir** is modifiable via the settings page
We create the binaries folder on startup if it does not already exist (I broke this in the last build).
I use the DirectoryInfo object to ensure we have consistent file path to the binaries folder (which should also be more consistent for Linux).