### PR TITLE
Remove the NullException catch from the ProcessAsync method.

### DIFF
--- a/source/DasBlog.Web.UI/TagHelpers/Site/SitePageControlTagHelper.cs
+++ b/source/DasBlog.Web.UI/TagHelpers/Site/SitePageControlTagHelper.cs
@@ -32,16 +32,8 @@ namespace DasBlog.Web.TagHelpers.Layout
 
 		public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
 		{
-			try
-			{
-				PostCount = (int)ViewContext.ViewData[Constants.PostCount];
-				PageNumber = (int)ViewContext.ViewData[Constants.PageNumber];
-			}
-			catch (NullReferenceException)
-			{
-				PostCount = 0;
-				PageNumber = 0;
-			}
+			PostCount = (int?)ViewContext.ViewData[Constants.PostCount] ?? 0;
+			PageNumber = (int?)ViewContext.ViewData[Constants.PageNumber] ?? 0;
 
 			var pagecontrol = string.Empty;
 


### PR DESCRIPTION
Replaced the setting of PostCount and PageNumber with a try catch block, which was catching for nulls, to using the null-coalescing operator by way of casting to nullable ints.

(I know this wasn't an Issue, but it was one of those things that popped up when I first started to debug some things.  Thought the change would make debugging less annoying, what with VS breaking if you have the break on exceptions set.)