### PR TITLE
Removed Unused Exception Variable ex.

### DIFF
--- a/source/DasBlog.Tests/DasBlog.Test.Integration/SeleniumPageTests.cs
+++ b/source/DasBlog.Tests/DasBlog.Test.Integration/SeleniumPageTests.cs
@@ -253,7 +253,7 @@ namespace DasBlog.Test.Integration
 				createpostSelector = By.Id("CreatePostLink");
 				createpostlink = Browser.FindElement(createpostSelector);
 			}
-			catch(Exception ex)
+			catch(Exception)
 			{
 				Assert.StartsWith("My DasBlog!", Browser.Title);
 			}


### PR DESCRIPTION
This was creating a minor annoying warning while firing a build about an unused variable and was causing vs code to highlight the issue. Basically removed the unused exception variable to get rid of the warning.