### PR TITLE
comments aren't loaded, null check for /post/guid URLs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,8 +5,8 @@ strategy:
       imageName: 'ubuntu-18.04'
 #    mac:
 #      imageName: 'macos-10.13'
-    windows:
-      imageName: 'windows-2019'
+#    windows:
+#      imageName: 'windows-2019'
 
 pool:
   vmImage: $(imageName)

--- a/source/DasBlog.Web.UI/Controllers/BlogPostController.cs
+++ b/source/DasBlog.Web.UI/Controllers/BlogPostController.cs
@@ -99,8 +99,21 @@ namespace DasBlog.Web.Controllers
 			var entry = blogManager.GetBlogPostByGuid(postid);
 			if (entry != null)
 			{
-				lpvm.Posts = new List<PostViewModel>() { mapper.Map<PostViewModel>(entry) };
 
+				/*
+				 * Very old DasBlog links like
+				 * /PermaLink.aspx?guid=b5790285-2eb7-4198-ac1d-6cfbf20735a4
+				 * turn into 
+				 * /post/b5790285-2eb7-4198-ac1d-6cfbf20735a4 
+				 * (given correct IISrewrites)
+				 * but fails to render because the Comments are never loaded, 
+				 * so you'll get the post but it shows ZERO comments. 
+				 * Better to just redirect to the right URL
+				 * I can't figure how to redirect 302 correctly given a /blog baseURL, so for now at least it doesn't break 
+				 * and has the right canonical
+				 * 				//return RedirectToAction("Post", "BlogPost", new { title = lpvm?.Posts?.First().PermaLink });
+				 */
+				lpvm.Posts = new List<PostViewModel>() { mapper.Map<PostViewModel>(entry) };
 				return SinglePostView(lpvm);
 			}
 			else

--- a/source/DasBlog.Web.UI/Controllers/DasBlogBaseController.cs
+++ b/source/DasBlog.Web.UI/Controllers/DasBlogBaseController.cs
@@ -62,7 +62,7 @@ namespace DasBlog.Web.Settings
 
         private void ShowErrors(PostViewModel post)
         {
-            if(post != null && post.Comments.CurrentComment != null && post.ErrorMessages != null && post.ErrorMessages.Count > 0)
+            if(post != null && post.Comments != null && post.Comments.CurrentComment != null && post.ErrorMessages != null && post.ErrorMessages.Count > 0)
             {
                 foreach(string ErrorMessage in post.ErrorMessages)
                 {


### PR DESCRIPTION
When very old links come in like 

`https://www.hanselman.com/blog/PermaLink.aspx?guid=b5790285-2eb7-4198-ac1d-6cfbf20735a4
`
and you have an a redirect in IISExpress.xml like this:

```
    <rule name="Very old perm;alink style (guid)" stopProcessing="true">
      <match url="^PermaLink.aspx" />
      <conditions>
        <add input="{QUERY_STRING}" pattern="&amp;?guid=(.*)" />
      </conditions>
      <action type="Redirect" url="/blog/post/{C:1}" redirectType="Permanent" />
    </rule>
```

You'll end up on 

```
http://hanselman.com/blog/post/b5790285-2eb7-4198-ac1d-6cfbf20735a4
```

and get a null error because comments aren't loaded (see the DasBlogBaseController) so this fixes the null check, but the larger issue of "302 redirect to the canonical URL" remains, but I got lost in BlogPostController.
