### PR TITLE
remove id attribute from PostCommentLink TagHelper

### DIFF
--- a/source/DasBlog.Tests/UnitTests/UI/TagHelperTest.cs
+++ b/source/DasBlog.Tests/UnitTests/UI/TagHelperTest.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using DasBlog.Web.Models.BlogViewModels;
-using DasBlog.Web.TagHelpers;
 using DasBlog.Web.TagHelpers.Post;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Xunit;
@@ -37,6 +37,7 @@ namespace DasBlog.Tests.UnitTests.UI
 			Assert.Same("a", output.TagName);
 			Assert.Same("href", output.Attributes[0].Name);
 			Assert.Contains(blogPost, output.Attributes[0].Value.ToString());
+			Assert.DoesNotContain("id", output.Attributes.Select(a => a.Name));
 			Assert.Equal(tagContent, output.Content.GetContent().Trim());
 		}
 

--- a/source/DasBlog.Web.UI/TagHelpers/Post/PostCommentLinkTagHelper.cs
+++ b/source/DasBlog.Web.UI/TagHelpers/Post/PostCommentLinkTagHelper.cs
@@ -23,7 +23,6 @@ namespace DasBlog.Web.TagHelpers.Post
 			output.TagName = "a";
 			output.TagMode = TagMode.StartTagAndEndTag;
 			output.Attributes.SetAttribute("href", dasBlogSettings.GetCommentViewUrl(Post.PermaLink));
-			output.Attributes.SetAttribute("id", Constants.CommentOnThisPostId);
 			output.Attributes.SetAttribute("class", "dbc-comment-on-post-link");
 
 			var content = "Comment on this post";


### PR DESCRIPTION
Removed line from PostCommentLinkTagHelper that added the ID attribute
Modified unit test to check ID attribute was not present