### PR TITLE
fix facebook tag helper to use more robust mechanism for href formatting

### DIFF
--- a/source/DasBlog.Tests/UnitTests/UI/PostToFacebookTagHelperTest.cs
+++ b/source/DasBlog.Tests/UnitTests/UI/PostToFacebookTagHelperTest.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using DasBlog.Web.Models.BlogViewModels;
+using DasBlog.Web.TagHelpers;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Xunit;
+
+namespace DasBlog.Tests.UnitTests.UI
+{
+	public class PostToFacebookTagHelperTest
+	{
+		/// <summary>
+		/// All test methods should follow this naming pattern
+		/// </summary>
+		[Fact]
+		public void UnitOfWork_StateUnderTest_ExpectedBehavior()
+		{
+		}
+
+		[Fact]
+		[Trait("Category", "UnitTest")]
+		public async Task PostToFacebookTagHelper_GeneratedTagHelper_BlogPostRendersAsAnchorTag()
+		{
+			var postLink = "some-great-post";
+			var dasBlogSettings = new DasBlogSettingTest();
+
+			var sut = new PostToFacebookTagHelper(dasBlogSettings) { Post = new PostViewModel { PermaLink = postLink, EntryId = "F79DCB23-1536-4496-B6F3-109F05DEEE10" } };
+
+			var context = new TagHelperContext(new TagHelperAttributeList(), new Dictionary<object, object>(), Guid.NewGuid().ToString("N"));
+			var output = new TagHelperOutput("editpost", new TagHelperAttributeList(), (useCachedResult, htmlEncoder) =>
+			{
+				var tagHelperContent = new DefaultTagHelperContent();
+				tagHelperContent.SetContent(string.Empty);
+				return Task.FromResult<TagHelperContent>(tagHelperContent);
+			});
+
+			await sut.ProcessAsync(context, output);
+
+			Assert.Same("a", output.TagName);
+
+			var href = output.Attributes.FirstOrDefault(a => a.Name == "href")?.Value.ToString();
+			Assert.NotNull(href);
+			Assert.StartsWith("https://facebook.com/", href);
+
+			var urlencodedBaseUrl = UrlEncoder.Default.Encode(dasBlogSettings.GetBaseUrl());
+			Assert.Contains($"={urlencodedBaseUrl}{postLink}", href);
+		}
+	}
+}
+

--- a/source/DasBlog.Web.UI/TagHelpers/Post/PostToFacebookTagHelper.cs
+++ b/source/DasBlog.Web.UI/TagHelpers/Post/PostToFacebookTagHelper.cs
@@ -1,15 +1,16 @@
-﻿using DasBlog.Core;
+﻿using System;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
 using DasBlog.Services;
 using DasBlog.Web.Models.BlogViewModels;
 using Microsoft.AspNetCore.Razor.TagHelpers;
-using System.Threading.Tasks;
 
 namespace DasBlog.Web.TagHelpers
 {
 	public class PostToFacebookTagHelper : TagHelper
 	{
 		private const string FACEBOOK_SHARE_URL = "https://facebook.com/sharer.php?u={0}";
-		private IDasBlogSettings dasBlogSettings;
+		private readonly IDasBlogSettings dasBlogSettings;
 		public PostViewModel Post { get; set; }
 
 		public PostToFacebookTagHelper(IDasBlogSettings dasBlogSettings)
@@ -22,7 +23,8 @@ namespace DasBlog.Web.TagHelpers
 			output.TagName = "a";
 			output.TagMode = TagMode.StartTagAndEndTag;
 			output.Attributes.SetAttribute("class", "dasblog-a-share-facebook");
-			output.Attributes.SetAttribute("href", string.Format(FACEBOOK_SHARE_URL, dasBlogSettings.GetBaseUrl() + Post.PermaLink));
+			output.Attributes.SetAttribute("href", string.Format(FACEBOOK_SHARE_URL, 
+				UrlEncoder.Default.Encode(new Uri(new Uri(dasBlogSettings.GetBaseUrl()), Post.PermaLink).AbsoluteUri)));
 
 			var content = await output.GetChildContentAsync();
 


### PR DESCRIPTION
Fixed href formatting to use Uri and UrlEncoder classes
Added unit tests

Fixes poppastring/dasblog-core#451