### PR TITLE
Name build output artifacts based on variables

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,6 +23,12 @@ steps:
     version: '3.1.x'
     installationPath: $(Agent.ToolsDirectory)/dotnet
 
+- task: PowerShell@2
+  condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'main'))
+  inputs:
+    targetType: 'inline'
+    script: |
+      Write-Host "##vso[build.updatebuildnumber]2.11.$(Build.BuildId)"
 
 - task: DotNetCoreCLI@2
   displayName: Restoring Packages for Solution
@@ -64,5 +70,4 @@ steps:
 - task: PublishBuildArtifacts@1
   inputs:
     pathtoPublish: '$(Build.ArtifactStagingDirectory)' 
-    artifactName: 'DasBlog-Build-Artifacts-$(Build.BuildId)'
   

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,12 @@ pool:
 variables:
   buildConfiguration: 'Release'
 
+parameters:
+- name: Version
+  displayName: Version
+  type: string
+  default: 2.20
+
 steps:
 - task: UseDotNet@2
   displayName: Installing .NET Core 3.1
@@ -24,11 +30,12 @@ steps:
     installationPath: $(Agent.ToolsDirectory)/dotnet
 
 - task: PowerShell@2
+  displayName: Set build number
   condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'main'))
   inputs:
     targetType: 'inline'
     script: |
-      Write-Host "##vso[build.updatebuildnumber]2.20.$(Build.BuildId)"
+      Write-Host "##vso[build.updatebuildnumber]${{ parameters.Version }}.$(Build.BuildId)"
 
 - task: DotNetCoreCLI@2
   displayName: Restoring Packages for Solution
@@ -46,7 +53,7 @@ steps:
   inputs:
     command: build
     projects: '**/*.sln'
-    arguments: '--no-restore --configuration $(BuildConfiguration) -p:VersionPrefix=2.20.$(Build.BuildId) -p:FileVersion=2.20.$(Build.BuildId).0 -p:SourceRevisionId=$(Build.SourceVersion)'
+    arguments: '--no-restore --configuration $(BuildConfiguration) -p:VersionPrefix=$(Build.BuildNumber) -p:FileVersion=$(Build.BuildNumber).0 -p:SourceRevisionId=$(Build.SourceVersion)'
 
 - script: dotnet test source/DasBlog.Tests/UnitTests/ --logger trx;LogfileName=test_results.xml --results-directory $(System.DefaultWorkingDirectory)/test_results --filter Category=UnitTest
   displayName: Run Unit Tests on Windows
@@ -70,4 +77,4 @@ steps:
 - task: PublishPipelineArtifact@1
   inputs:
     targetPath: $(Build.ArtifactStagingDirectory)
-    artifactName: $(System.TeamProject)_$(Build.BuildNumber)
+    artifactName: $(Build.ImageName)/$(System.TeamProject)_$(Build.BuildNumber)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ steps:
     installationPath: $(Agent.ToolsDirectory)/dotnet
 
 - task: PowerShell@2
-  displayName: Set build number
+  displayName: Set Build Number
   condition: and(succeeded(), eq(variables['Build.SourceBranchName'], 'main'))
   inputs:
     targetType: 'inline'
@@ -75,6 +75,7 @@ steps:
     zipAfterPublish: True
 
 - task: PublishPipelineArtifact@1
+  condition: and(succeeded(), eq(variables['imageName'], 'windows-2019'))
   inputs:
     targetPath: $(Build.ArtifactStagingDirectory)
-    artifactName: $(Build.ImageName)/$(System.TeamProject)_$(Build.BuildNumber)
+    artifactName: $(System.TeamProject)_$(Build.BuildNumber)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,12 +14,7 @@ pool:
 
 variables:
   buildConfiguration: 'Release'
-
-parameters:
-- name: Version
-  displayName: Version
-  type: string
-  default: 2.20
+  version: 2.20
 
 steps:
 - task: UseDotNet@2
@@ -35,7 +30,7 @@ steps:
   inputs:
     targetType: 'inline'
     script: |
-      Write-Host "##vso[build.updatebuildnumber]${{ parameters.Version }}.$(Build.BuildId)"
+      Write-Host "##vso[build.updatebuildnumber]${{ variables.version }}.$(Build.BuildId)"
 
 - task: DotNetCoreCLI@2
   displayName: Restoring Packages for Solution

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,7 +71,7 @@ steps:
   inputs:
     command: publish
     publishWebProjects: True
-    arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) --self-contained --no-build --no-restore --version-suffix $(Build.BuildNumber)'
+    arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)/$(Build.BuildNumber) --self-contained --no-build --no-restore'
     zipAfterPublish: True
 
 - task: PublishPipelineArtifact@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,11 +71,18 @@ steps:
   inputs:
     command: publish
     publishWebProjects: True
-    arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)/$(Build.BuildNumber) --self-contained --no-build --no-restore'
-    zipAfterPublish: True
+    arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) --self-contained --no-build --no-restore'
+
+- task: ArchiveFiles@2
+  inputs:
+    rootFolderOrFile: '$(Build.ArtifactStagingDirectory)'
+    includeRootFolder: true
+    archiveType: 'zip'
+    archiveFile: '$(Build.ArtifactStagingDirectory)/$(imageName)/$(System.TeamProject)_$(Build.BuildNumber).zip'
+    replaceExistingArchive: true
 
 - task: PublishPipelineArtifact@1
   condition: and(succeeded(), eq(variables['imageName'], 'windows-2019'))
   inputs:
-    targetPath: $(Build.ArtifactStagingDirectory)
+    targetPath: $(Build.ArtifactStagingDirectory)/$(imageName)
     artifactName: $(System.TeamProject)_$(Build.BuildNumber)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ steps:
   inputs:
     targetType: 'inline'
     script: |
-      Write-Host "##vso[build.updatebuildnumber]2.11.$(Build.BuildId)"
+      Write-Host "##vso[build.updatebuildnumber]2.20.$(Build.BuildId)"
 
 - task: DotNetCoreCLI@2
   displayName: Restoring Packages for Solution
@@ -64,10 +64,10 @@ steps:
   inputs:
     command: publish
     publishWebProjects: True
-    arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) --self-contained --no-build --no-restore'
+    arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) --self-contained --no-build --no-restore --version-suffix $(Build.BuildNumber)'
     zipAfterPublish: True
 
-- task: PublishBuildArtifacts@1
+- task: PublishPipelineArtifact@1
   inputs:
-    pathtoPublish: '$(Build.ArtifactStagingDirectory)' 
-  
+    targetPath: $(Build.ArtifactStagingDirectory)
+    artifactName: $(System.TeamProject)_$(Build.BuildNumber)


### PR DESCRIPTION
Fixes poppastring/dasblog-core#459

- Use variable for major.minor version string
- Only use Major.Minor versioning for Main branch builds
- Use ProjectName for artifact prefix
- Add additional build step to control of zip filename
- Publish only Windows build
  - Publishing both Windows and Linux will cause an Artifact name clash

Draft releases have been deprecated in Azure DevOps
https://docs.microsoft.com/en-us/azure/devops/pipelines/release/?view=azure-devops#what-is-a-draft-release

You need to modify you Release pipeline to manage release types. 