### PR TITLE
Fault tolerant startup for Production/Staging

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,20 +1,16 @@
-# Build on multiple platforms - https://docs.microsoft.com/azure/devops/pipelines/get-started-multiplatform?view=azure-devops&WT.mc_id=devops-github-shboyer
 strategy:
   matrix:
     linux:
       imageName: 'ubuntu-18.04'
-#    mac:
-#      imageName: 'macos-10.13'
     windows:
       imageName: 'windows-2019'
 
 pool:
   vmImage: $(imageName)
-  #vmImage: 'windows-2019'
 
 variables:
   buildConfiguration: 'Release'
-  version: 2.20
+  version: 2.21
 
 steps:
 - task: UseDotNet@2

--- a/source/DasBlog.Web.UI/Startup.cs
+++ b/source/DasBlog.Web.UI/Startup.cs
@@ -49,11 +49,15 @@ namespace DasBlog.Web
 		private readonly string IISUrlRewriteConfigPath;
 		private readonly string SiteConfigPath;
 		private readonly string MetaConfigPath;
-		private readonly string AppSettingsConfigPath;
 		private readonly string ThemeFolderPath;
 		private readonly string LogFolderPath;
 		private readonly string BinariesPath;
 		private readonly string BinariesUrlRelativePath;
+
+		private readonly string DefaultSiteConfigPath;
+		private readonly string DefaultMetaConfigPath;
+		private readonly string DefaultSiteSecurityConfigPath;
+		private readonly string DefaultIISUrlRewriteConfigPath;
 
 		private readonly IWebHostEnvironment hostingEnvironment;
 
@@ -64,14 +68,23 @@ namespace DasBlog.Web
 			hostingEnvironment = env;
 
 			SiteSecurityConfigPath = Path.Combine("Config", $"siteSecurity.{env.EnvironmentName}.config");
+			DefaultSiteSecurityConfigPath = Path.Combine("Config", "siteSecurity.config");
 			IISUrlRewriteConfigPath = Path.Combine("Config", $"IISUrlRewrite.{env.EnvironmentName}.config");
+			DefaultIISUrlRewriteConfigPath = Path.Combine("Config", "IISUrlRewrite.config");
+
 			SiteConfigPath = Path.Combine("Config", $"site.{env.EnvironmentName}.config");
+			DefaultSiteConfigPath = Path.Combine("Config", $"site.config");
 			MetaConfigPath = Path.Combine("Config", $"meta.{env.EnvironmentName}.config");
+			DefaultMetaConfigPath = Path.Combine("Config", $"meta.config");
+
+			ConfigFileInitializationPrep();
 
 			var builder = new ConfigurationBuilder()
 				.SetBasePath(env.ContentRootPath)
-				.AddXmlFile(SiteConfigPath, optional: false, reloadOnChange: true)
-				.AddXmlFile(MetaConfigPath, optional: false, reloadOnChange: true)
+				.AddXmlFile(DefaultSiteConfigPath, optional: false, reloadOnChange: true)
+				.AddXmlFile(SiteConfigPath, optional: true, reloadOnChange: true)
+				.AddXmlFile(DefaultMetaConfigPath, optional: false, reloadOnChange: true)
+				.AddXmlFile(MetaConfigPath, optional: true, reloadOnChange: true)
 				.AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
 				.AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
 				.AddEnvironmentVariables();
@@ -487,6 +500,19 @@ namespace DasBlog.Web
 			}
 
 			return richEditBuilder;
+		}
+
+		private void ConfigFileInitializationPrep()
+		{
+			if (!File.Exists(Path.Combine(hostingEnvironment.ContentRootPath, SiteSecurityConfigPath)))
+			{
+				File.Copy(Path.Combine(hostingEnvironment.ContentRootPath, DefaultSiteSecurityConfigPath), Path.Combine(hostingEnvironment.ContentRootPath, SiteSecurityConfigPath));
+			}
+
+			if (!File.Exists(Path.Combine(hostingEnvironment.ContentRootPath, IISUrlRewriteConfigPath)))
+			{
+				File.Copy(Path.Combine(hostingEnvironment.ContentRootPath, DefaultIISUrlRewriteConfigPath), Path.Combine(hostingEnvironment.ContentRootPath, IISUrlRewriteConfigPath));
+			}
 		}
 	}
 }


### PR DESCRIPTION
This allows you to startup immediately following deployment in a "Production" (or Staging, etc.) environment without having to manual create the environment config files.

site.[Environment].config, meta.[Environment].Config,  and appSettings.[Environment].Config become optional files [`in ConfigurationBuilder()..AddXmlFile()`], So if they are missing you will not fail, login and save settings will create new files.

siteSecurity.[Environment].Config and IISUrlRewrite.[Environment].Config are now created as part of the start up checks.

This will not impact existing deployments. 