### PR TITLE
Fix zip output to remove unnecessary folders

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,6 +70,7 @@ steps:
   inputs:
     rootFolderOrFile: $(Build.ArtifactStagingDirectory)/DasBlog.Web.UI
     archiveType: 'zip'
+    includeRootFolder: false
     archiveFile: '$(Build.ArtifactStagingDirectory)/$(System.TeamProject)_$(Build.BuildNumber).zip'
     replaceExistingArchive: true
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,6 +63,7 @@ steps:
   inputs:
     command: publish
     publishWebProjects: True
+    zipAfterPublish: false
     arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) --self-contained --no-build --no-restore'
 
 - task: ArchiveFiles@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,11 +63,18 @@ steps:
   inputs:
     command: publish
     publishWebProjects: True
-    zipAfterPublish: true
+    zipAfterPublish: false
     arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)/$(System.TeamProject)_$(Build.BuildNumber) --self-contained --no-build --no-restore'
+
+- task: ArchiveFiles@2
+  inputs:
+    rootFolderOrFile: $(Build.ArtifactStagingDirectory)/$(System.TeamProject)_$(Build.BuildNumber)
+    archiveType: 'zip'
+    archiveFile: '$(Build.ArtifactStagingDirectory)/$(System.TeamProject)_$(Build.BuildNumber).zip'
+    replaceExistingArchive: true
 
 - task: PublishPipelineArtifact@1
   condition: and(succeeded(), eq(variables['imageName'], 'windows-2019'))
   inputs:
-    targetPath: $(Build.ArtifactStagingDirectory)/$(System.TeamProject)_$(Build.BuildNumber)
+    targetPath: '$(Build.ArtifactStagingDirectory)/$(System.TeamProject)_$(Build.BuildNumber).zip'
     artifactName: $(System.TeamProject)_$(Build.BuildNumber)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,11 +64,12 @@ steps:
     command: publish
     publishWebProjects: True
     zipAfterPublish: false
-    arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) --self-contained --no-build --no-restore'
+    modifyOutputPath: false
+    arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)/$(System.TeamProject)_$(Build.BuildNumber) --self-contained --no-build --no-restore'
 
 - task: ArchiveFiles@2
   inputs:
-    rootFolderOrFile: $(Build.ArtifactStagingDirectory)/DasBlog.Web.UI
+    rootFolderOrFile: $(Build.ArtifactStagingDirectory)/$(System.TeamProject)_$(Build.BuildNumber)
     archiveType: 'zip'
     includeRootFolder: false
     archiveFile: '$(Build.ArtifactStagingDirectory)/$(System.TeamProject)_$(Build.BuildNumber).zip'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,8 +63,15 @@ steps:
   inputs:
     command: publish
     publishWebProjects: True
-    zipAfterPublish: true
-    arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)/$(System.TeamProject)_$(Build.BuildNumber) --self-contained --no-build --no-restore'
+    zipAfterPublish: false
+    arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) --self-contained --no-build --no-restore'
+
+- task: ArchiveFiles@2
+  inputs:
+    rootFolderOrFile: $(Build.ArtifactStagingDirectory)/DasBlog.Web.UI
+    archiveType: 'zip'
+    archiveFile: '$(Build.ArtifactStagingDirectory)/$(System.TeamProject)_$(Build.BuildNumber).zip'
+    replaceExistingArchive: true
 
 - task: PublishPipelineArtifact@1
   condition: and(succeeded(), eq(variables['imageName'], 'windows-2019'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,15 +63,8 @@ steps:
   inputs:
     command: publish
     publishWebProjects: True
-    zipAfterPublish: false
+    zipAfterPublish: true
     arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)/$(System.TeamProject)_$(Build.BuildNumber) --self-contained --no-build --no-restore'
-
-- task: ArchiveFiles@2
-  inputs:
-    rootFolderOrFile: $(Build.ArtifactStagingDirectory)/$(System.TeamProject)_$(Build.BuildNumber)
-    archiveType: 'zip'
-    archiveFile: '$(Build.ArtifactStagingDirectory)/$(System.TeamProject)_$(Build.BuildNumber).zip'
-    replaceExistingArchive: true
 
 - task: PublishPipelineArtifact@1
   condition: and(succeeded(), eq(variables['imageName'], 'windows-2019'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,17 +63,11 @@ steps:
   inputs:
     command: publish
     publishWebProjects: True
-    zipAfterPublish: false
-    arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory) --self-contained --no-build --no-restore'
-
-- task: ArchiveFiles@2
-  inputs:
-    archiveType: 'zip'
-    archiveFile: '$(System.TeamProject)_$(Build.BuildNumber).zip'
-    replaceExistingArchive: true
+    zipAfterPublish: true
+    arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)/$(System.TeamProject)_$(Build.BuildNumber) --self-contained --no-build --no-restore'
 
 - task: PublishPipelineArtifact@1
   condition: and(succeeded(), eq(variables['imageName'], 'windows-2019'))
   inputs:
-    targetPath: $(Build.ArtifactStagingDirectory)
+    targetPath: $(Build.ArtifactStagingDirectory)/$(System.TeamProject)_$(Build.BuildNumber)
     artifactName: $(System.TeamProject)_$(Build.BuildNumber)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,14 +68,12 @@ steps:
 
 - task: ArchiveFiles@2
   inputs:
-    rootFolderOrFile: '$(Build.ArtifactStagingDirectory)'
-    includeRootFolder: true
     archiveType: 'zip'
-    archiveFile: '$(Build.ArtifactStagingDirectory)/$(imageName)/$(System.TeamProject)_$(Build.BuildNumber).zip'
+    archiveFile: '$(System.TeamProject)_$(Build.BuildNumber).zip'
     replaceExistingArchive: true
 
 - task: PublishPipelineArtifact@1
   condition: and(succeeded(), eq(variables['imageName'], 'windows-2019'))
   inputs:
-    targetPath: $(Build.ArtifactStagingDirectory)/$(imageName)
+    targetPath: $(Build.ArtifactStagingDirectory)
     artifactName: $(System.TeamProject)_$(Build.BuildNumber)


### PR DESCRIPTION
Fixed #512

- disable dotnet publish task from creating zip file
- specify specific folder to add to zip file
- exclude root folder from zip file
- update archiveFile name to remove `imageName`
- update publish targetPath to remove `imageName`