### PR TITLE
Added the ability to use the Home/About page

### DIFF
--- a/source/DasBlog.Services/ConfigFile/Interfaces/ISiteConfig.cs
+++ b/source/DasBlog.Services/ConfigFile/Interfaces/ISiteConfig.cs
@@ -98,6 +98,7 @@ namespace DasBlog.Services.ConfigFile.Interfaces
         bool SendPingbacksByEmail { get; set; }
 
         bool SendPostsByEmail { get; set; }
+        bool EnableAboutView { get; set; }
 
         bool EnableBloggerApi { get; set; }
 

--- a/source/DasBlog.Services/ConfigFile/SiteConfig.cs
+++ b/source/DasBlog.Services/ConfigFile/SiteConfig.cs
@@ -79,6 +79,7 @@ namespace DasBlog.Services.ConfigFile
         public bool SendTrackbacksByEmail { get; set; }
         public bool SendPingbacksByEmail { get; set; }
         public bool SendPostsByEmail { get; set; }
+        public bool EnableAboutView { get; set; }
         public bool EnableBloggerApi { get; set; }
         public bool EnableComments { get; set; }
         public bool EnableCommentApi { get; set; }

--- a/source/DasBlog.Web.UI/Controllers/HomeController.cs
+++ b/source/DasBlog.Web.UI/Controllers/HomeController.cs
@@ -102,10 +102,11 @@ namespace DasBlog.Web.Controllers
 
 		public IActionResult About()
 		{
-			DefaultPage();
-
-			ViewData["Message"] = "Your application description page.";
-
+			if (dasBlogSettings.SiteConfiguration.EnableAboutView)
+			{
+				DefaultPage("About");
+				return View();
+			}
 			return NoContent();
 		}
 

--- a/source/DasBlog.Web.UI/Models/AdminViewModels/SiteViewModel.cs
+++ b/source/DasBlog.Web.UI/Models/AdminViewModels/SiteViewModel.cs
@@ -84,6 +84,10 @@ namespace DasBlog.Web.Models.AdminViewModels
 		[Description("This allows you to design a summary view for each blog post on the home page")]
 		public bool ShowItemSummaryInAggregatedViews { get; set; }
 
+		[DisplayName("Enable the About page ")]
+		[Description("This enables the Home/About view and allows you to customize this in the site theme.")]
+		public bool EnableAboutView { get; set; }
+
 		[DisplayName("RSS day count")]
 		[Description("Maximum number of days to appear in your RSS feed")]
 		[Required(AllowEmptyStrings = false, ErrorMessage = "Enter a value for RSS Day Count")]

--- a/source/DasBlog.Web.UI/Views/Admin/Settings.cshtml
+++ b/source/DasBlog.Web.UI/Views/Admin/Settings.cshtml
@@ -75,6 +75,13 @@
 
     </div>
 
+    <div class="dbc-form-check row">
+
+        @Html.LabelFor(m => @Model.SiteConfig.EnableAboutView, null, new { @class = "dbc-col-form-label col-3" })
+        @Html.CheckBoxFor(m => @Model.SiteConfig.EnableAboutView, new { @class = "dbc-form-check-input" })
+
+    </div>
+
     <h3>Front Page</h3>
 
     <div class="dbc-form-group row">

--- a/source/DasBlog.Web.UI/Views/Home/About.cshtml
+++ b/source/DasBlog.Web.UI/Views/Home/About.cshtml
@@ -1,7 +1,4 @@
-﻿@{
-    ViewData["Title"] = "About";
-}
-<h2>@ViewData["Title"]</h2>
-<h3>@ViewData["Message"]</h3>
+﻿<h2>@ViewData["PageTitle"]</h2>
+<h3><site-sub-title/></h3>
 
-<p>Use this area to provide additional information.</p>
+<p><site-description/></p>


### PR DESCRIPTION
Added a site setting to allow the About view to be enabled, default is disabled and returns NoContent.  

Using the default ViewData["PageTitle"] for the title and the tag helpers for site-sub-title and site-description for the content.