### PR TITLE
Removed max length validation on blog post title

### DIFF
--- a/source/DasBlog.Web.UI/Models/BlogViewModels/PostViewModel.cs
+++ b/source/DasBlog.Web.UI/Models/BlogViewModels/PostViewModel.cs
@@ -9,7 +9,7 @@ namespace DasBlog.Web.Models.BlogViewModels
 	public class PostViewModel
 	{
 		[Required]
-		[StringLength(60, MinimumLength = 1)]
+		[MinLength(1)]
 		public string Title { get; set; }
 
 		[DataType(DataType.MultilineText)]


### PR DESCRIPTION
Changed it to a MinLength attribute, to maintain that validation check from the original.