### PR TITLE
Changed img size rule to require a specific class name

### DIFF
--- a/source/DasBlog.Web.UI/wwwroot/css/site.css
+++ b/source/DasBlog.Web.UI/wwwroot/css/site.css
@@ -145,7 +145,7 @@
     
 }
 
-.dbc-post-content img {
+.dbc-post-image-full {
     width: 100%;
     height: 100%;
 }


### PR DESCRIPTION
Rather than just making all images in content marked with the dbc-post-content class 100% height and width, change that style to a class of its own.