### PR TITLE
Removing the additional HTML Decode 

### DIFF
--- a/source/DasBlog.Web.UI/TagHelpers/Post/PostContentTagHelper.cs
+++ b/source/DasBlog.Web.UI/TagHelpers/Post/PostContentTagHelper.cs
@@ -2,7 +2,6 @@
 using DasBlog.Web.Models.BlogViewModels;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using System.Threading.Tasks;
-using System.Web;
 
 namespace DasBlog.Web.TagHelpers.Post
 {
@@ -16,7 +15,7 @@ namespace DasBlog.Web.TagHelpers.Post
 
 		public override void Process(TagHelperContext context, TagHelperOutput output)
 		{
-			var content = HttpUtility.HtmlDecode(Post.Content);
+			var content = Post.Content;
 			output.TagName = "div";
 			output.TagMode = TagMode.StartTagAndEndTag;
 			output.Attributes.SetAttribute("class", "dbc-post-content");


### PR DESCRIPTION
as this appears to be breaking correctly encoded entries especially when trying to demonstrate HTML, XML, etc..