### PR TITLE
Configure Double Decoding

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ pool:
 
 variables:
   buildConfiguration: 'Release'
-  version: 2.32
+  version: 2.40
 
 steps:
 - task: UseDotNet@2

--- a/source/DasBlog.CLI/DasBlog.CLI.csproj
+++ b/source/DasBlog.CLI/DasBlog.CLI.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>dasblog-core</AssemblyName>
+    <Version>2.40.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/DasBlog.Services/ConfigFile/Interfaces/ISiteConfig.cs
+++ b/source/DasBlog.Services/ConfigFile/Interfaces/ISiteConfig.cs
@@ -348,6 +348,8 @@ namespace DasBlog.Services.ConfigFile.Interfaces
 
 		bool CookieConsentEnabled { get; set; }
 
+		bool EnableDoubleDecode { get; set; }
+
 		[XmlAnyElement]
         XmlElement[] anyElements { get; set; }
 

--- a/source/DasBlog.Services/ConfigFile/SiteConfig.cs
+++ b/source/DasBlog.Services/ConfigFile/SiteConfig.cs
@@ -215,5 +215,6 @@ namespace DasBlog.Services.ConfigFile
 		public string SecurityScriptSources { get; set; }
 
 		public string SecurityStyleSources { get; set; }
+		public bool EnableDoubleDecode { get; set; }
 	}
 }

--- a/source/DasBlog.Services/DasBlog.Services.csproj
+++ b/source/DasBlog.Services/DasBlog.Services.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <Version>2.40.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\DasBlog.Web.Core\DasBlog.Core.csproj" />

--- a/source/DasBlog.Tests/UnitTests/SiteConfigTest.cs
+++ b/source/DasBlog.Tests/UnitTests/SiteConfigTest.cs
@@ -165,5 +165,6 @@ namespace DasBlog.Tests.UnitTests
 		public string SecurityScriptSources { get; set; }
 
 		public string SecurityStyleSources { get; set; }
+		public bool EnableDoubleDecode { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 	}
 }

--- a/source/DasBlog.Web.Core/DasBlog.Core.csproj
+++ b/source/DasBlog.Web.Core/DasBlog.Core.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>
+    <Version>2.40.0</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <NoWarn>1701;1702;NU1701</NoWarn>

--- a/source/DasBlog.Web.Repositories/DasBlog.Managers.csproj
+++ b/source/DasBlog.Web.Repositories/DasBlog.Managers.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>
+    <Version>2.40.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NodaTime" Version="3.0.3" />

--- a/source/DasBlog.Web.UI/Config/site.Development.config
+++ b/source/DasBlog.Web.UI/Config/site.Development.config
@@ -112,7 +112,9 @@
 
   <SecurityStyleSources>cloud.tinymce.com;cdn.tiny.cloud;cdn.jsdelivr.net;js.nicedit.com;www.google.com;platform.twitter.com;cdn.syndication.twimg.com;fonts.googleapis.com;maxcdn.bootstrapcdn.com</SecurityStyleSources>
   <SecurityScriptSources>cloud.tinymce.com;cdn.tiny.cloud;cdn.jsdelivr.net;js.nicedit.com;www.google.com;cse.google.com;cdn.syndication.twimg.com;platform.twitter.com;apis.google.com;www.google-analytics.com;www.googletagservices.com;adservice.google.com;securepubads.g.doubleclick.net;ajax.aspnetcdn.com;ssl.google-analytics.com</SecurityScriptSources>
-  
+
+  <EnableDoubleDecode>false</EnableDoubleDecode>
+
   <!-- Settings below this line are not currently in use -->
   <!-- _________________________________________________ -->
   <CommentsAllowHtml>true</CommentsAllowHtml>

--- a/source/DasBlog.Web.UI/Config/site.config
+++ b/source/DasBlog.Web.UI/Config/site.config
@@ -115,6 +115,8 @@
   <SecurityStyleSources>cloud.tinymce.com;cdn.tiny.cloud;cdn.jsdelivr.net;js.nicedit.com;www.google.com;platform.twitter.com;cdn.syndication.twimg.com;fonts.googleapis.com;maxcdn.bootstrapcdn.com</SecurityStyleSources>
   <SecurityScriptSources>cloud.tinymce.com;cdn.tiny.cloud;cdn.jsdelivr.net;js.nicedit.com;www.google.com;cse.google.com;cdn.syndication.twimg.com;platform.twitter.com;apis.google.com;www.google-analytics.com;www.googletagservices.com;adservice.google.com;securepubads.g.doubleclick.net;ajax.aspnetcdn.com;ssl.google-analytics.com</SecurityScriptSources>
 
+  <EnableDoubleDecode>false</EnableDoubleDecode>
+
   <!-- Settings below this line are not currently in use -->
   <!-- _________________________________________________ -->
   <CommentsAllowHtml>true</CommentsAllowHtml>

--- a/source/DasBlog.Web.UI/DasBlog.Web.csproj
+++ b/source/DasBlog.Web.UI/DasBlog.Web.csproj
@@ -14,6 +14,7 @@
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <UserSecretsId>d3583964-0aca-4de4-9521-c74cdf42f990</UserSecretsId>
+    <Version>2.40.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="9.0.0" />

--- a/source/DasBlog.Web.UI/Models/AdminViewModels/SiteViewModel.cs
+++ b/source/DasBlog.Web.UI/Models/AdminViewModels/SiteViewModel.cs
@@ -282,6 +282,10 @@ namespace DasBlog.Web.Models.AdminViewModels
 		[Description("Help meet some of the EU General Data Protection Regulation (GDPR) requirements")]
 		public bool CookieConsentEnabled { get; set; }
 
+		[DisplayName("Double decode")]
+		[Description("")]
+		public bool EnableDoubleDecode { get; set; }
+
 		public bool EntryTitleAsLink { get; set; }
 		public bool ObfuscateEmail { get; set; }
 		public bool SendReferralsByEmail { get; set; }

--- a/source/DasBlog.Web.UI/TagHelpers/Post/PostContentTagHelper.cs
+++ b/source/DasBlog.Web.UI/TagHelpers/Post/PostContentTagHelper.cs
@@ -1,7 +1,9 @@
 ﻿using DasBlog.Core.Extensions;
+using DasBlog.Services;
 using DasBlog.Web.Models.BlogViewModels;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using System.Threading.Tasks;
+using System.Web;
 
 namespace DasBlog.Web.TagHelpers.Post
 {
@@ -13,9 +15,22 @@ namespace DasBlog.Web.TagHelpers.Post
 
 		public int ContentLength { get; set; } = 100000;
 
+		private readonly IDasBlogSettings dasBlogSettings;
+
+		public PostContentTagHelper(IDasBlogSettings dasBlogSettings)
+		{
+			this.dasBlogSettings = dasBlogSettings;
+		}
+
 		public override void Process(TagHelperContext context, TagHelperOutput output)
 		{
 			var content = Post.Content;
+
+			if(dasBlogSettings.SiteConfiguration.EnableDoubleDecode)
+			{
+				content = HttpUtility.HtmlDecode(Post.Content);
+			}
+
 			output.TagName = "div";
 			output.TagMode = TagMode.StartTagAndEndTag;
 			output.Attributes.SetAttribute("class", "dbc-post-content");

--- a/source/DasBlog.Web.UI/Views/Admin/Settings.cshtml
+++ b/source/DasBlog.Web.UI/Views/Admin/Settings.cshtml
@@ -490,6 +490,13 @@
 
     </div>
 
+    <div class="dbc-form-check row">
+
+        @Html.LabelFor(m => @Model.SiteConfig.EnableDoubleDecode, null, new { @class = "dbc-col-form-label col-3" })
+        @Html.CheckBoxFor(m => @Model.SiteConfig.EnableDoubleDecode, new { @class = "dbc-form-check-input" })
+
+    </div>
+
     <h3>Internal</h3>
 
     <div class="dbc-form-group row">

--- a/source/newtelligence.DasBlog.Runtime/newtelligence.DasBlog.Runtime.csproj
+++ b/source/newtelligence.DasBlog.Runtime/newtelligence.DasBlog.Runtime.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <Version>2.40.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Add a setting to allow for Double Decoding the content of a blog post.

It is false by default, meaning, if you want to double decode you need to configure it in the admin page.