### PR TITLE
Check categories value before trimming it

### DIFF
--- a/source/newtelligence.DasBlog.Runtime/Entry.cs
+++ b/source/newtelligence.DasBlog.Runtime/Entry.cs
@@ -132,7 +132,7 @@ namespace newtelligence.DasBlog.Runtime
 		public string Categories
 		{
 			get { return _categories; }
-			set { _categories = value.TrimEnd(';'); }
+			set { _categories = string.IsNullOrWhiteSpace(value) ? string.Empty : value.TrimEnd(';'); }
 		}
 
 		public string Author


### PR DESCRIPTION
Publishing from OLW without ay categories set for the post causes an exception to be thrown, as the code just attempts to trim a possible trailing semi-colon from a null object.

Added check so only trim the value if it is a valid string.