### PR TITLE
Rolling back the option to double decode. 

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ pool:
 
 variables:
   buildConfiguration: 'Release'
-  version: 2.41
+  version: 2.42
 
 steps:
 - task: UseDotNet@2

--- a/source/DasBlog.Services/ConfigFile/Interfaces/ISiteConfig.cs
+++ b/source/DasBlog.Services/ConfigFile/Interfaces/ISiteConfig.cs
@@ -350,8 +350,6 @@ namespace DasBlog.Services.ConfigFile.Interfaces
 
 		bool CookieConsentEnabled { get; set; }
 
-		bool EnableDoubleDecode { get; set; }
-
 		[XmlAnyElement]
         XmlElement[] anyElements { get; set; }
 

--- a/source/DasBlog.Services/ConfigFile/SiteConfig.cs
+++ b/source/DasBlog.Services/ConfigFile/SiteConfig.cs
@@ -217,7 +217,5 @@ namespace DasBlog.Services.ConfigFile
 		public string SecurityStyleSources { get; set; }
 
 		public string DefaultSources { get; set; }
-
-		public bool EnableDoubleDecode { get; set; }		
 	}
 }

--- a/source/DasBlog.Services/DasBlog.Services.csproj
+++ b/source/DasBlog.Services/DasBlog.Services.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\DasBlog.Web.Core\DasBlog.Core.csproj" />

--- a/source/DasBlog.Tests/UnitTests/SiteConfigTest.cs
+++ b/source/DasBlog.Tests/UnitTests/SiteConfigTest.cs
@@ -165,7 +165,6 @@ namespace DasBlog.Tests.UnitTests
 		public string SecurityScriptSources { get; set; }
 
 		public string SecurityStyleSources { get; set; }
-		public bool EnableDoubleDecode { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 		public string DefaultSources { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 	}
 }

--- a/source/DasBlog.Web.UI/Config/site.Development.config
+++ b/source/DasBlog.Web.UI/Config/site.Development.config
@@ -113,8 +113,6 @@
   <SecurityStyleSources>cloud.tinymce.com;cdn.tiny.cloud;cdn.jsdelivr.net;js.nicedit.com;www.google.com;platform.twitter.com;cdn.syndication.twimg.com;fonts.googleapis.com;maxcdn.bootstrapcdn.com</SecurityStyleSources>
   <SecurityScriptSources>cloud.tinymce.com;cdn.tiny.cloud;cdn.jsdelivr.net;js.nicedit.com;www.google.com;cse.google.com;cdn.syndication.twimg.com;platform.twitter.com;apis.google.com;www.google-analytics.com;www.googletagservices.com;adservice.google.com;securepubads.g.doubleclick.net;ajax.aspnetcdn.com;ssl.google-analytics.com</SecurityScriptSources>
 
-  <EnableDoubleDecode>false</EnableDoubleDecode>
-
   <!-- Settings below this line are not currently in use -->
   <!-- _________________________________________________ -->
   <CommentsAllowHtml>true</CommentsAllowHtml>

--- a/source/DasBlog.Web.UI/Config/site.config
+++ b/source/DasBlog.Web.UI/Config/site.config
@@ -116,8 +116,6 @@
   <SecurityStyleSources>cloud.tinymce.com;cdn.tiny.cloud;cdn.jsdelivr.net;js.nicedit.com;www.google.com;platform.twitter.com;cdn.syndication.twimg.com;fonts.googleapis.com;maxcdn.bootstrapcdn.com</SecurityStyleSources>
   <SecurityScriptSources>cloud.tinymce.com;cdn.tiny.cloud;cdn.jsdelivr.net;js.nicedit.com;www.google.com;cse.google.com;cdn.syndication.twimg.com;platform.twitter.com;apis.google.com;www.google-analytics.com;www.googletagservices.com;adservice.google.com;securepubads.g.doubleclick.net;ajax.aspnetcdn.com;ssl.google-analytics.com</SecurityScriptSources>
 
-  <EnableDoubleDecode>false</EnableDoubleDecode>
-
   <!-- Settings below this line are not currently in use -->
   <!-- _________________________________________________ -->
   <CommentsAllowHtml>true</CommentsAllowHtml>

--- a/source/DasBlog.Web.UI/DasBlog.Web.csproj
+++ b/source/DasBlog.Web.UI/DasBlog.Web.csproj
@@ -14,7 +14,7 @@
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <UserSecretsId>d3583964-0aca-4de4-9521-c74cdf42f990</UserSecretsId>
-    <Version>2.41.0</Version>
+    <Version>2.42.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="9.0.0" />

--- a/source/DasBlog.Web.UI/Models/AdminViewModels/SiteViewModel.cs
+++ b/source/DasBlog.Web.UI/Models/AdminViewModels/SiteViewModel.cs
@@ -282,10 +282,6 @@ namespace DasBlog.Web.Models.AdminViewModels
 		[Description("Help meet some of the EU General Data Protection Regulation (GDPR) requirements")]
 		public bool CookieConsentEnabled { get; set; }
 
-		[DisplayName("Double decode")]
-		[Description("")]
-		public bool EnableDoubleDecode { get; set; }
-
 		[DisplayName("Default Sources (seperated by semi colon")]
 		[Description("")]
 		[StringLength(50, MinimumLength = 1, ErrorMessage = "{0} should be between 1 to 50 characters")]

--- a/source/DasBlog.Web.UI/TagHelpers/Post/PostContentTagHelper.cs
+++ b/source/DasBlog.Web.UI/TagHelpers/Post/PostContentTagHelper.cs
@@ -24,12 +24,7 @@ namespace DasBlog.Web.TagHelpers.Post
 
 		public override void Process(TagHelperContext context, TagHelperOutput output)
 		{
-			var content = Post.Content;
-
-			if(dasBlogSettings.SiteConfiguration.EnableDoubleDecode)
-			{
-				content = HttpUtility.HtmlDecode(Post.Content);
-			}
+			var content = HttpUtility.HtmlDecode(Post.Content);
 
 			output.TagName = "div";
 			output.TagMode = TagMode.StartTagAndEndTag;

--- a/source/DasBlog.Web.UI/Views/Admin/Settings.cshtml
+++ b/source/DasBlog.Web.UI/Views/Admin/Settings.cshtml
@@ -490,13 +490,6 @@
 
     </div>
 
-    <div class="dbc-form-check row">
-
-        @Html.LabelFor(m => @Model.SiteConfig.EnableDoubleDecode, null, new { @class = "dbc-col-form-label col-3" })
-        @Html.CheckBoxFor(m => @Model.SiteConfig.EnableDoubleDecode, new { @class = "dbc-form-check-input" })
-
-    </div>
-
     <h3>Internal</h3>
 
     <div class="dbc-form-group row">


### PR DESCRIPTION
We will always Double Decode to account for the code we place in the `<pre>` tag.