### PR TITLE
Added setting for from email address

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ pool:
 
 variables:
   buildConfiguration: 'Release'
-  version: 2.42
+  version: 2.43
 
 steps:
 - task: UseDotNet@2

--- a/source/DasBlog.Services/ConfigFile/Interfaces/ISiteConfig.cs
+++ b/source/DasBlog.Services/ConfigFile/Interfaces/ISiteConfig.cs
@@ -236,6 +236,7 @@ namespace DasBlog.Services.ConfigFile.Interfaces
         bool EnableSmtpAuthentication { get; set; }
 
         string SmtpUserName { get; set; }
+        string SmtpFromEmail { get; set; }
 
         string SmtpPassword { get; set; }
 

--- a/source/DasBlog.Services/ConfigFile/SiteConfig.cs
+++ b/source/DasBlog.Services/ConfigFile/SiteConfig.cs
@@ -146,6 +146,7 @@ namespace DasBlog.Services.ConfigFile
         public bool EncryptLoginPassword { get; set; }
         public bool EnableSmtpAuthentication { get; set; }
         public string SmtpUserName { get; set; }
+        public string SmtpFromEmail { get; set; }
         public string SmtpPassword { get; set; }
         public string RssLanguage { get; set; }
         public bool EnableSearchHighlight { get; set; }

--- a/source/DasBlog.Services/DasBlog.Services.csproj
+++ b/source/DasBlog.Services/DasBlog.Services.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>3.1.0</Version>
+    <Version>3.2.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\DasBlog.Web.Core\DasBlog.Core.csproj" />

--- a/source/DasBlog.Tests/UnitTests/SiteConfigTest.cs
+++ b/source/DasBlog.Tests/UnitTests/SiteConfigTest.cs
@@ -106,6 +106,7 @@ namespace DasBlog.Tests.UnitTests
 		public bool EnableSmtpAuthentication { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 		public string SmtpUserName { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 		public string SmtpPassword { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+		public string SmtpFromEmail { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 		public string RssLanguage { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 		public bool EnableSearchHighlight { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 		public bool EnableEntryReferrals { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }

--- a/source/DasBlog.Web.Repositories/BlogManager.cs
+++ b/source/DasBlog.Web.Repositories/BlogManager.cs
@@ -447,10 +447,19 @@ namespace DasBlog.Managers
 			return dataService.GetCategories();
 		}
 
+		private string GetFromEmail()
+		{
+			if (string.IsNullOrWhiteSpace(dasBlogSettings.SiteConfiguration.SmtpFromEmail))
+			{
+				return dasBlogSettings.SiteConfiguration.SmtpUserName;
+			}
+
+			return dasBlogSettings.SiteConfiguration.SmtpFromEmail.Trim();
+		}
 		public bool SendTestEmail()
 		{
 			var emailMessage = new MailMessage();
-			emailMessage.From = new MailAddress(dasBlogSettings.SiteConfiguration.SmtpUserName);
+			emailMessage.From = new MailAddress(GetFromEmail());
 			emailMessage.To.Add(dasBlogSettings.SiteConfiguration.NotificationEMailAddress);
 			emailMessage.To.Add(dasBlogSettings.SiteConfiguration.Contact);
 
@@ -539,7 +548,7 @@ namespace DasBlog.Managers
 			emailMessage.IsBodyHtml = false;
 			emailMessage.BodyEncoding = System.Text.Encoding.UTF8;
 
-			emailMessage.From = new MailAddress(dasBlogSettings.SiteConfiguration.SmtpUserName);
+			emailMessage.From = new MailAddress(GetFromEmail());
 
 			return dasBlogSettings.GetMailInfo(emailMessage);
 		}

--- a/source/DasBlog.Web.Repositories/DasBlog.Managers.csproj
+++ b/source/DasBlog.Web.Repositories/DasBlog.Managers.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>
-    <Version>2.40.0</Version>
+    <Version>2.41.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NodaTime" Version="3.0.3" />

--- a/source/DasBlog.Web.UI/Config/site.Development.config
+++ b/source/DasBlog.Web.UI/Config/site.Development.config
@@ -105,6 +105,7 @@
   <SmtpPort>25</SmtpPort>
   <SmtpUserName />
   <SmtpPassword />
+  <SmtpFromEmail />
   <UseSSLForSMTP>false</UseSSLForSMTP>
   <EnableSmtpAuthentication>true</EnableSmtpAuthentication>
 

--- a/source/DasBlog.Web.UI/Config/site.config
+++ b/source/DasBlog.Web.UI/Config/site.config
@@ -107,6 +107,7 @@
   <SmtpPort>25</SmtpPort>
   <SmtpUserName />
   <SmtpPassword />
+  <SmtpFromEmail />
   <UseSSLForSMTP>false</UseSSLForSMTP>
   <EnableSmtpAuthentication>true</EnableSmtpAuthentication>
 

--- a/source/DasBlog.Web.UI/DasBlog.Web.csproj
+++ b/source/DasBlog.Web.UI/DasBlog.Web.csproj
@@ -14,7 +14,7 @@
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <UserSecretsId>d3583964-0aca-4de4-9521-c74cdf42f990</UserSecretsId>
-    <Version>2.42.0</Version>
+    <Version>2.43.0</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="9.0.0" />

--- a/source/DasBlog.Web.UI/Models/AdminViewModels/SiteViewModel.cs
+++ b/source/DasBlog.Web.UI/Models/AdminViewModels/SiteViewModel.cs
@@ -252,7 +252,10 @@ namespace DasBlog.Web.Models.AdminViewModels
 		[DisplayName("SMTP user name")]
 		[Description("")]
 		public string SmtpUserName { get; set; }
-
+		
+		[DisplayName("From email, user name when blank")]
+		[Description("The from email address used for sending an email.  If this is blank, the SMTP User Name will be used.")]
+		public string SmtpFromEmail { get; set; }
 		[DisplayName("SMTP password")]
 		[Description("")]
 		[DataType(DataType.Password)]

--- a/source/DasBlog.Web.UI/Views/Admin/Settings.cshtml
+++ b/source/DasBlog.Web.UI/Views/Admin/Settings.cshtml
@@ -441,7 +441,15 @@
 
     </div>
 
-    <div class="dbc-form-check row">
+    <div class="dbc-form-group row">
+
+        @Html.LabelFor(m => @Model.SiteConfig.SmtpFromEmail, null, new { @class = "dbc-col-form-label col-3" })
+        @Html.TextBoxFor(m => @Model.SiteConfig.SmtpFromEmail, null, new { @class = "form-control col-9" })
+        @Html.ValidationMessageFor(m => m.SiteConfig.SmtpFromEmail, null, new { @class = "text-danger" })
+
+    </div>
+
+<div class="dbc-form-check row">
 
         <label class="dbc-col-form-label col-3">SMTP Test</label>
         <input asp-controller="Admin" asp-action="TestEmail" type="submit" name="submit" value="Send test Email" class="btn-default" />


### PR DESCRIPTION
Added a new SMTP setting for the from email address to use when sending an email.  This new setting will allow support for email services like SendGrid that does not use a valid email address for the SMTP user name  If this new setting is null or blank then the email Send user name setting will be used for the from email address to maintain backward compatibility with existing blogs.

This fixes #526 