### PR TITLE
issue:#601:comment content tag helper throws null exception

### DIFF
--- a/source/DasBlog.Tests/UnitTests/UI/CommentContentTagHelperTest.cs
+++ b/source/DasBlog.Tests/UnitTests/UI/CommentContentTagHelperTest.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DasBlog.Web.Models.BlogViewModels;
+using DasBlog.Web.TagHelpers.Comments;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Xunit;
+
+namespace DasBlog.Tests.UnitTests.UI;
+
+public class CommentContentTagHelperTest
+{
+
+	[Fact]
+	[Trait("Category", "UnitTest")]
+	public void CommentContentTagHelper_WhenCommentIsNull_ShouldNotThrow()
+	{
+		var dasBlogSettings = new DasBlogSettingTest();
+
+		var helper = new CommentContentTagHelper(dasBlogSettings);
+		var context = new TagHelperContext(new TagHelperAttributeList(), new Dictionary<object, object>(), Guid.NewGuid().ToString("N"));
+		var output = new TagHelperOutput(string.Empty, new TagHelperAttributeList(), (_, _) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
+
+		helper.Process(context, output);
+
+		Assert.Same("div", output.TagName);
+		Assert.Equal("dbc-comment-content", output.Attributes[0].Value.ToString());
+		Assert.Equal("", output.Content.GetContent().Trim());
+	}
+
+	[Fact]
+	[Trait("Category", "UnitTest")]
+	public void CommentContentTagHelper_WhenCommentTextIsNull_ShouldNotThrow()
+	{
+		var dasBlogSettings = new DasBlogSettingTest();
+
+		var helper = new CommentContentTagHelper(dasBlogSettings)
+		{
+			Comment = new CommentViewModel()
+		};
+		var context = new TagHelperContext(new TagHelperAttributeList(), new Dictionary<object, object>(), Guid.NewGuid().ToString("N"));
+		var output = new TagHelperOutput(string.Empty, new TagHelperAttributeList(), (_, _) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
+
+		helper.Process(context, output);
+
+		Assert.Same("div", output.TagName);
+		Assert.Equal("dbc-comment-content", output.Attributes[0].Value.ToString());
+		Assert.Equal("", output.Content.GetContent().Trim());
+	}
+}

--- a/source/DasBlog.Web.UI/TagHelpers/Comments/CommentContentTagHelper.cs
+++ b/source/DasBlog.Web.UI/TagHelpers/Comments/CommentContentTagHelper.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Web;
@@ -28,8 +26,9 @@ namespace DasBlog.Web.TagHelpers.Comments
 			output.TagName = "div";
 			output.TagMode = TagMode.StartTagAndEndTag;
 
-      output.Attributes.SetAttribute("class", Css);
-			Comment.Text = dasBlogSettings.FilterHtml(Comment.Text);
+			output.Attributes.SetAttribute("class", Css);
+			Comment ??= new CommentViewModel();
+			Comment.Text = dasBlogSettings.FilterHtml(Comment.Text ?? string.Empty);
 			Comment.Text = Regex.Replace(Comment.Text, "\n", "<br />");
 			output.Content.SetHtmlContent(HttpUtility.HtmlDecode(Comment.Text));
 		}


### PR DESCRIPTION
## Description

This PR addresses an issue in the comment content tag helper where an exception is thrown when the comment text is null

## Related Issue
[Issue 601](https://github.com/poppastring/dasblog-core/issues/601)