### PR TITLE
Throw exception in c# 10 way Issue#611

### DIFF
--- a/source/DasBlog.Web.Core/Common/Comments/MatchedTag.cs
+++ b/source/DasBlog.Web.Core/Common/Comments/MatchedTag.cs
@@ -69,10 +69,7 @@ namespace DasBlog.Core.Common.Comments
 		/// <param name="needsClosing">The tag needs to be self-closed before rendering.</param>
 		public MatchedTag(Match m, bool isValid, bool needsClosing)
 		{
-			if (m == null)
-			{
-				throw new ArgumentNullException("m");
-			}
+			ArgumentNullException.ThrowIfNull(m, nameof(m));
 			this.match = m;
 			this.isValid = isValid;
 			this.needsClosing = needsClosing;

--- a/source/DasBlog.Web.Core/Common/Comments/MatchedTagCollection.cs
+++ b/source/DasBlog.Web.Core/Common/Comments/MatchedTagCollection.cs
@@ -39,11 +39,9 @@
 
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 
 namespace DasBlog.Core.Common.Comments
@@ -56,10 +54,8 @@ namespace DasBlog.Core.Common.Comments
 	{
 		public MatchedTagCollection(ValidCommentTags[] allowedTags)
 		{
-
 			// param validation
-			if (allowedTags == null) { throw new ArgumentNullException("allowedTags"); }
-
+			ArgumentNullException.ThrowIfNull(allowedTags, nameof(allowedTags));
 			this.allowedTags = allowedTags[0];
 		}
 
@@ -71,7 +67,7 @@ namespace DasBlog.Core.Common.Comments
 		{
 
 			// param validation
-			if (matches == null) { throw new ArgumentNullException("matches"); }
+			ArgumentNullException.ThrowIfNull(matches, nameof(matches));
 
 			// holds the tags in the order they were matched
 			store = new ArrayList(matches.Count);

--- a/source/DasBlog.Web.Core/Security/UserCollection.cs
+++ b/source/DasBlog.Web.Core/Security/UserCollection.cs
@@ -65,11 +65,8 @@ namespace DasBlog.Core.Security
         public UserCollection(IList<User> items)
             : base()
         {
-            if (items == null)
-            {
-                throw new ArgumentNullException("items");
-            }
-
+			// checking items for null
+			ArgumentNullException.ThrowIfNull(items, nameof(items));
             this.AddRange(items);
         }
 
@@ -81,12 +78,9 @@ namespace DasBlog.Core.Security
         /// </param>
         public virtual void AddRange(IEnumerable<User> items)
         {
-            if (items == null)
-            {
-                throw new ArgumentNullException("items");
-            }
-
-            foreach (User item in items)
+			// checking items for null
+			ArgumentNullException.ThrowIfNull(items, nameof(items));
+			foreach (User item in items)
             {
                 this.Add(item);
             }

--- a/source/DasBlog.Web.Repositories/XmlRpcManager.cs
+++ b/source/DasBlog.Web.Repositories/XmlRpcManager.cs
@@ -731,8 +731,8 @@ namespace DasBlog.Managers
 
 		private MetaWeblog.Post Create(Entry entry)
 		{
-			if (entry == null) throw new ArgumentNullException(nameof(entry));
-
+			// checking entry for null
+			ArgumentNullException.ThrowIfNull(entry, nameof(entry));
 			var post = new MetaWeblog.Post();
 			post.description = entry.Content ?? "";
 			post.mt_excerpt = entry.Description ?? "";

--- a/source/DasBlog.Web.UI/Identity/DasBlogUserStore.cs
+++ b/source/DasBlog.Web.UI/Identity/DasBlogUserStore.cs
@@ -25,21 +25,15 @@ namespace DasBlog.Web.Identity
 
 		public Task<string> GetUserIdAsync(DasBlogUser user, CancellationToken cancellationToken)
 		{
-			if (user == null)
-			{
-				throw new ArgumentNullException(nameof(user));
-			}
-
+			// checking user for null
+			ArgumentNullException.ThrowIfNull(user, nameof(user));
 			return Task.FromResult(user.UserName);
 		}
 
 		public Task<string> GetUserNameAsync(DasBlogUser user, CancellationToken cancellationToken)
 		{
-			if (user == null)
-			{
-				throw new ArgumentNullException(nameof(user));
-			}
-
+			// checking user for null
+			ArgumentNullException.ThrowIfNull(user, nameof(user));
 			return Task.FromResult(user.DisplayName);
 		}
 
@@ -50,10 +44,8 @@ namespace DasBlog.Web.Identity
 		public Task SetNormalizedUserNameAsync(DasBlogUser user, string normalizedName, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			if (user == null)
-			{
-				throw new ArgumentNullException(nameof(user));
-			}
+			// checking user for null
+			ArgumentNullException.ThrowIfNull(user, nameof(user));
 
 			user.NormalizedUserName = normalizedName ?? throw new ArgumentNullException(nameof(normalizedName));
 			return Task.FromResult<object>(null);
@@ -62,11 +54,8 @@ namespace DasBlog.Web.Identity
 		public Task<IdentityResult> CreateAsync(DasBlogUser user, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			if (user == null)
-			{
-				throw new ArgumentNullException(nameof(user));
-			}
-
+			// checking user for null
+			ArgumentNullException.ThrowIfNull(user, nameof(user));
 			try
 			{
 				var mappedUser = mapper.Map<User>(user);
@@ -93,10 +82,8 @@ namespace DasBlog.Web.Identity
 		public Task<DasBlogUser> FindByNameAsync(string normalizedUserName, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			if (normalizedUserName == null)
-			{
-				throw new ArgumentNullException(nameof(normalizedUserName));
-			}
+			// checking normalizedUserName for null
+			ArgumentNullException.ThrowIfNull(normalizedUserName, nameof(normalizedUserName));
 
 			var user = dasBlogSettings.SecurityConfiguration.Users.Find(u => u.EmailAddress.Equals(normalizedUserName, StringComparison.InvariantCultureIgnoreCase));
 			var dasBlogUser = mapper.Map<DasBlogUser>(user);
@@ -115,11 +102,8 @@ namespace DasBlog.Web.Identity
 		public Task<string> GetEmailAsync(DasBlogUser user, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			if (user == null)
-			{
-				throw new ArgumentNullException(nameof(user));
-			}
-
+			// checking user for null
+			ArgumentNullException.ThrowIfNull(user, nameof(user));
 			return Task.FromResult(user.Email);
 		}
 
@@ -143,21 +127,16 @@ namespace DasBlog.Web.Identity
 		public Task<string> GetNormalizedEmailAsync(DasBlogUser user, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			if (user == null)
-			{
-				throw new ArgumentNullException(nameof(user));
-			}
-
+			// checking user for null
+			ArgumentNullException.ThrowIfNull(user, nameof(user));
 			return Task.FromResult(user.NormalizedEmail);
 		}
 
 		public Task SetNormalizedEmailAsync(DasBlogUser user, string normalizedEmail, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			if (user == null)
-			{
-				throw new ArgumentNullException(nameof(user));
-			}
+			// checking user for null
+			ArgumentNullException.ThrowIfNull(user, nameof(user));
 
 			user.NormalizedEmail = normalizedEmail ?? throw new ArgumentNullException(nameof(normalizedEmail));
 			return Task.FromResult<object>(null);
@@ -170,10 +149,8 @@ namespace DasBlog.Web.Identity
 		public Task SetPasswordHashAsync(DasBlogUser user, string passwordHash, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			if (user == null)
-			{
-				throw new ArgumentNullException(nameof(user));
-			}
+			// checking user for null
+			ArgumentNullException.ThrowIfNull(user, nameof(user));
 
 			user.PasswordHash = passwordHash ?? throw new ArgumentNullException(nameof(passwordHash));
 			return Task.FromResult<object>(null);
@@ -182,10 +159,8 @@ namespace DasBlog.Web.Identity
 		public Task<string> GetPasswordHashAsync(DasBlogUser user, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			if (user == null)
-			{
-				throw new ArgumentNullException(nameof(user));
-			}
+			// checking user for null
+			ArgumentNullException.ThrowIfNull(user, nameof(user));
 
 			return Task.FromResult(user.PasswordHash);
 		}
@@ -198,11 +173,8 @@ namespace DasBlog.Web.Identity
 		public Task<IList<Claim>> GetClaimsAsync(DasBlogUser user, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
-			if (user == null)
-			{
-				throw new ArgumentNullException(nameof(user));
-			}
-
+			// checking user for null
+			ArgumentNullException.ThrowIfNull(user, nameof(user));
 			IList<Claim> claims = DefineClaims(user.Role);
 
 			return Task.FromResult(claims);

--- a/source/newtelligence.DasBlog.Runtime/Attachment.cs
+++ b/source/newtelligence.DasBlog.Runtime/Attachment.cs
@@ -1,4 +1,4 @@
-#region Copyright (c) 2003, newtelligence AG. All rights reserved.
+﻿#region Copyright (c) 2003, newtelligence AG. All rights reserved.
 
 /*
 // Copyright (c) 2003, newtelligence AG. (http://www.newtelligence.com)
@@ -123,11 +123,10 @@ namespace newtelligence.DasBlog.Runtime
         public AttachmentCollection(IList<Attachment> items)
             : base()
         {
-            if (items == null) {
-                throw new ArgumentNullException("items");
-            }
+			// checking items for null
+			ArgumentNullException.ThrowIfNull(items, nameof(items));
 
-            this.AddRange(items);
+			this.AddRange(items);
         }
 
         /// <summary>

--- a/source/newtelligence.DasBlog.Runtime/CollectionFilter.cs
+++ b/source/newtelligence.DasBlog.Runtime/CollectionFilter.cs
@@ -34,12 +34,10 @@ namespace newtelligence.DasBlog.Runtime
         public static U FindAll(U source, Predicate<T> include, int maxResults)
         {
 
-            if (source == null)
-            {
-                throw new ArgumentNullException("source");
-            }
+			// checking source for null
+			ArgumentNullException.ThrowIfNull(source, nameof(source));
 
-            U filteredCollection = new U();
+			U filteredCollection = new U();
             bool includeThisItem;
 
             foreach (T entry in source)

--- a/source/newtelligence.DasBlog.Runtime/CommentFile.cs
+++ b/source/newtelligence.DasBlog.Runtime/CommentFile.cs
@@ -1,4 +1,4 @@
-#region Copyright (c) 2003, newtelligence AG. All rights reserved.
+﻿#region Copyright (c) 2003, newtelligence AG. All rights reserved.
 
 /*
 // Copyright (c) 2003, newtelligence AG. (http://www.newtelligence.com)
@@ -113,10 +113,8 @@ namespace newtelligence.DasBlog.Runtime {
 		/// <param name="comment">The comment to add.</param>
 		public void AddComment( Comment comment ){
 
-			// parameter check
-			if(comment== null){
-				throw new ArgumentNullException( "comment");
-			}
+			// parameter check			
+			ArgumentNullException.ThrowIfNull(comment, nameof(comment));
 
 			// get the lock
 			fileLock.AcquireWriterLock(100);
@@ -149,9 +147,8 @@ namespace newtelligence.DasBlog.Runtime {
 		/// <param name="comment">The new version of the comment.</param>
 		public void UpdateComment( Comment comment ){
 			// parameter check
-			if(comment== null){
-				throw new ArgumentNullException( "comment");
-			}
+			// checking user for null
+			ArgumentNullException.ThrowIfNull(comment, nameof(comment));
 
 			// get the lock
 			fileLock.AcquireWriterLock(100);

--- a/source/newtelligence.DasBlog.Runtime/Crosspost.cs
+++ b/source/newtelligence.DasBlog.Runtime/Crosspost.cs
@@ -1,4 +1,4 @@
-#region Copyright (c) 2003, newtelligence AG. All rights reserved.
+﻿#region Copyright (c) 2003, newtelligence AG. All rights reserved.
 /*
 // Copyright (c) 2003, newtelligence AG. (http://www.newtelligence.com)
 // Original BlogX Source Code: Copyright (c) 2003, Chris Anderson (http://simplegeek.com)
@@ -81,11 +81,10 @@ namespace newtelligence.DasBlog.Runtime
         public CrosspostCollection(IList<Crosspost> items)
             : base()
         {
-            if (items == null) {
-                throw new ArgumentNullException("items");
-            }
-            
-            this.AddRange(items);
+			// checking items for null
+			ArgumentNullException.ThrowIfNull(items, nameof(items));
+
+			this.AddRange(items);
         }
 
         /// <summary>
@@ -96,12 +95,10 @@ namespace newtelligence.DasBlog.Runtime
         /// </param>
         public virtual void AddRange(IEnumerable<Crosspost> items)
         {
-            if (items == null)
-            {
-                throw new ArgumentNullException("items");
-            }
+			// checking items for null
+			ArgumentNullException.ThrowIfNull(items, nameof(items));
 
-            foreach (Crosspost item in items)
+			foreach (Crosspost item in items)
             {
                 this.Items.Add(item);
             }

--- a/source/newtelligence.DasBlog.Runtime/DayExtraCollection.cs
+++ b/source/newtelligence.DasBlog.Runtime/DayExtraCollection.cs
@@ -1,4 +1,4 @@
-#region Copyright (c) 2003, newtelligence AG. All rights reserved.
+﻿#region Copyright (c) 2003, newtelligence AG. All rights reserved.
 /*
 // Copyright (c) 2003, newtelligence AG. (http://www.newtelligence.com)
 // Original BlogX Source Code: Copyright (c) 2003, Chris Anderson (http://simplegeek.com)
@@ -68,11 +68,10 @@ namespace newtelligence.DasBlog.Runtime
         public DayExtraCollection(IList<DayExtra> items)
             : base()
         {
-            if (items == null) {
-                throw new ArgumentNullException("items");
-            }
+			// checking items for null
+			ArgumentNullException.ThrowIfNull(items, nameof(items));
 
-            this.AddRange(items);
+			this.AddRange(items);
         }
 
         /// <summary>
@@ -83,12 +82,10 @@ namespace newtelligence.DasBlog.Runtime
         /// </param>
         public virtual void AddRange(IEnumerable<DayExtra> items)
         {
-            if (items != null)
-            {
-                throw new ArgumentNullException("items");
-            }
+			// checking items for null
+			ArgumentNullException.ThrowIfNull(items, nameof(items));
 
-            foreach (DayExtra item in items)
+			foreach (DayExtra item in items)
             {
                 this.Items.Add(item);
             }

--- a/source/newtelligence.DasBlog.Runtime/EventDataItemCollection.cs
+++ b/source/newtelligence.DasBlog.Runtime/EventDataItemCollection.cs
@@ -1,4 +1,4 @@
-#region Copyright (c) 2003, newtelligence AG. All rights reserved.
+﻿#region Copyright (c) 2003, newtelligence AG. All rights reserved.
 /*
 // Copyright (c) 2003, newtelligence AG. (http://www.newtelligence.com)
 // Original BlogX Source Code: Copyright (c) 2003, Chris Anderson (http://simplegeek.com)
@@ -69,11 +69,10 @@ namespace newtelligence.DasBlog.Runtime
         public EventDataItemCollection(IList<EventDataItem> items)
             : base()
         {
-            if (items == null) {
-                throw new ArgumentNullException("items");
-            }
+			// checking items for null
+			ArgumentNullException.ThrowIfNull(items, nameof(items));
 
-            this.AddRange(items);
+			this.AddRange(items);
         }
 
         /// <summary>
@@ -84,12 +83,10 @@ namespace newtelligence.DasBlog.Runtime
         /// </param>
         public virtual void AddRange(IEnumerable<EventDataItem> items)
         {
-            if (items == null)
-            {
-                throw new ArgumentNullException("items");
-            }
+			// checking items for null
+			ArgumentNullException.ThrowIfNull(items, nameof(items));
 
-            foreach (EventDataItem item in items)
+			foreach (EventDataItem item in items)
             {
                 this.Items.Add(item);
             }

--- a/source/newtelligence.DasBlog.Runtime/FileSystemBinaryDataService.cs
+++ b/source/newtelligence.DasBlog.Runtime/FileSystemBinaryDataService.cs
@@ -74,13 +74,12 @@ namespace newtelligence.DasBlog.Runtime
             {
                 throw new ArgumentNullException("loggingService");
             }
+			// checking loggingService for null
+			ArgumentNullException.ThrowIfNull(loggingService, nameof(loggingService));
+			// checking binaryRootUrl for null
+			ArgumentNullException.ThrowIfNull(binaryRootUrl, nameof(binaryRootUrl));
 
-            if (binaryRootUrl == null )
-            {
-                throw new ArgumentNullException("binaryRootUrl");
-            }
-
-            this.contentLocation = contentLocation;
+			this.contentLocation = contentLocation;
             this.loggingService = loggingService;
             this.binaryRoot = binaryRootUrl;
         }

--- a/source/newtelligence.DasBlog.Runtime/LoggingDataService.cs
+++ b/source/newtelligence.DasBlog.Runtime/LoggingDataService.cs
@@ -322,10 +322,8 @@ namespace newtelligence.DasBlog.Runtime
 				throw new ArgumentOutOfRangeException("logFilePath");
 			}
 
-			if (lockObject == null)
-			{
-				throw new ArgumentNullException("lockObject");
-			}
+			// checking locakObject for null
+			ArgumentNullException.ThrowIfNull(lockObject, nameof(lockObject));
 
 			string result = String.Empty;
 
@@ -424,20 +422,12 @@ namespace newtelligence.DasBlog.Runtime
 		void WriteLogDataItem(LogDataItem logItem, LogCategory category, ReaderWriterLock lockObject,
 		                      LogDataItemFormatter formatter)
 		{
-			if (logItem == null)
-			{
-				throw new ArgumentNullException("logItem");
-			}
-
-			if (lockObject == null)
-			{
-				throw new ArgumentNullException("lockObject");
-			}
-
-			if (formatter == null)
-			{
-				throw new ArgumentNullException("formatter");
-			}
+			// checking logItem for null
+			ArgumentNullException.ThrowIfNull(logItem, nameof(logItem));
+			// checking lockObject for null
+			ArgumentNullException.ThrowIfNull(lockObject, nameof(lockObject));
+			// checking items for null
+			ArgumentNullException.ThrowIfNull(formatter, nameof(formatter));
 
 			try
 			{
@@ -467,20 +457,12 @@ namespace newtelligence.DasBlog.Runtime
 		void WriteEventDataItem(EventDataItem logItem, LogCategory category, ReaderWriterLock lockObject,
 		                        EventDataItemFormatter formatter)
 		{
-			if (logItem == null)
-			{
-				throw new ArgumentNullException("logItem");
-			}
-
-			if (lockObject == null)
-			{
-				throw new ArgumentNullException("lockObject");
-			}
-
-			if (formatter == null)
-			{
-				throw new ArgumentNullException("formatter");
-			}
+			// checking logItem for null
+			ArgumentNullException.ThrowIfNull(logItem, nameof(logItem));
+			// checking lockObject for null
+			ArgumentNullException.ThrowIfNull(lockObject, nameof(lockObject));
+			// checking items for null
+			ArgumentNullException.ThrowIfNull(formatter, nameof(formatter));
 
 			try
 			{
@@ -557,10 +539,8 @@ namespace newtelligence.DasBlog.Runtime
 					throw new ArgumentOutOfRangeException("fileName");
 				}
 
-				if (lockObject == null)
-				{
-					throw new ArgumentNullException("lockObject");
-				}
+				// checking lockObject for null
+				ArgumentNullException.ThrowIfNull(lockObject, nameof(lockObject));
 
 				FileName = fileName;
 				LockObject = lockObject;
@@ -577,15 +557,10 @@ namespace newtelligence.DasBlog.Runtime
 
 			public WriterThreadParams(T logItem, LogCategory category, ReaderWriterLock lockObject)
 			{
-				if (logItem == null)
-				{
-					throw new ArgumentNullException("logItem");
-				}
-
-				if (lockObject == null)
-				{
-					throw new ArgumentNullException("lockObject");
-				}
+				// checking logItem for null
+				ArgumentNullException.ThrowIfNull(logItem, nameof(logItem));
+				// checking lockObject for null
+				ArgumentNullException.ThrowIfNull(lockObject, nameof(lockObject));
 
 				LogItem = logItem;
 				Category = category;

--- a/source/newtelligence.DasBlog.Runtime/PingService.cs
+++ b/source/newtelligence.DasBlog.Runtime/PingService.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Xml.Serialization;
@@ -112,11 +112,10 @@ namespace newtelligence.DasBlog.Runtime
         public PingServiceCollection(IList<PingService> items)
             : base()
         {
-            if (items == null) {
-                throw new ArgumentNullException("items");
-            }
+			// checking items for null
+			ArgumentNullException.ThrowIfNull(items, nameof(items));
 
-            this.AddRange(items);
+			this.AddRange(items);
 
         }
 
@@ -128,12 +127,10 @@ namespace newtelligence.DasBlog.Runtime
         /// </param>
         public virtual void AddRange(IEnumerable<PingService> items)
         {
-            if (items == null)
-            {
-                throw new ArgumentNullException("items");
-            }
+			// checking items for null
+			ArgumentNullException.ThrowIfNull(items, nameof(items));
 
-            foreach (PingService item in items)
+			foreach (PingService item in items)
             {
                 this.Items.Add(item);
             }


### PR DESCRIPTION
Instead of check for null and then throwing exception we can do both in single line in c# 10

Example :
// let say we have a variable abc
// we want to throw exception in case if its null

Old Way:

      if (abc == null)
      {
           throw new ArgumentNullException("abc");
       }
New Way:

       // in c# 10 we can do it in this way
       ArgumentNullException.ThrowIfNull(abc, nameof(abc));

Created issue for that : https://github.com/poppastring/dasblog-core/issues/611