### PR TITLE
Resolves the issue of configuring DasBlog locally before uploading to a host

### DIFF
--- a/source/DasBlog.CLI/Program.cs
+++ b/source/DasBlog.CLI/Program.cs
@@ -26,6 +26,11 @@ namespace DasBlog.CLI
 
 		static int Main(string[] args)
         {
+			if (string.IsNullOrWhiteSpace(ASPNETCORE_ENVIRONMENT))
+			{
+				ASPNETCORE_ENVIRONMENT = "Production";
+			}
+
 			DefineConfigNames();
 
 			Configuration = DasBlogConfigurationBuilder();


### PR DESCRIPTION
This assumes that we are configuring DasBlog for a Production environment in the absence of the "ASPNETCORE_ENVIRONMENT" environment variable.