### PR TITLE
Issue 492 deploytoazurebutton

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,6 @@ If you want to build and contribute code to DasBlog Core please fork this repo a
 
 You can deploy anywhere where .NET Core is hosted, here are instructions for Azure App Services:
 
-### Easiest Way: Click The Deploy To Azure Button
-
-Click the button below, answer some questions, and be up and running on your DasBlog instance in a few minutes. Once you've deployed, be sure to read the [post-deployment instructions here](#).
-
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Frumdood%2Fdasblog-core%2Fissue-492-deploytoazurebutton%2Fdeploy%2Fazuredeploy.json)
-
 ### Deploying Manually
 * [Deploying to Azure App Services for Windows](https://github.com/poppastring/dasblog-core/wiki/1.-Deployment#deploy-to-azure-app-services-for-windows)
 * [Deploying to Azure App Services for Linux](https://github.com/poppastring/dasblog-core/wiki/1.-Deployment#deploy-to-azure-app-services-for-linux)

--- a/README.md
+++ b/README.md
@@ -29,8 +29,16 @@ If you want to build and contribute code to DasBlog Core please fork this repo a
 ## Deployment
 
 You can deploy anywhere where .NET Core is hosted, here are instructions for Azure App Services:
-* [Deploying to Azure App Services for Linux](https://github.com/poppastring/dasblog-core/wiki/1.-Deployment#deploy-to-azure-app-services-for-linux)
+
+### Easiest Way: Click The Deploy To Azure Button
+
+Click the button below, answer some questions, and be up and running on your DasBlog instance in a few minutes. Once you've deployed, be sure to read the [post-deployment instructions here](#).
+
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Frumdood%2Fdasblog-core%2Fissue-492-deploytoazurebutton%2Fdeploy%2Fazuredeploy.json)
+
+### Deploying Manually
 * [Deploying to Azure App Services for Windows](https://github.com/poppastring/dasblog-core/wiki/1.-Deployment#deploy-to-azure-app-services-for-windows)
+* [Deploying to Azure App Services for Linux](https://github.com/poppastring/dasblog-core/wiki/1.-Deployment#deploy-to-azure-app-services-for-linux)
 * [Deploying to a web host](https://github.com/poppastring/dasblog-core/wiki/1.-Deployment#deploy-to-your-own-web-host)
 
 After deploying the app you should immediately [update  the security settings](https://github.com/poppastring/dasblog-core/wiki/2.-Configure-your-blog).   

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -1,0 +1,120 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.1",
+    "parameters": {
+        "siteName": {
+            "type": "string",
+            "defaultValue": "DasBlog",
+            "metadata": {
+                "description": "The name of your Web Site."
+            }
+        },
+        "location": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]",
+            "metadata": {
+                "description": "Location for all resources."
+            }
+        },
+        "sku": {
+            "type": "string",
+            "allowedValues": [
+                "F1",
+                "D1",
+                "B1",
+                "B2",
+                "B3",
+                "S1",
+                "S2",
+                "S3",
+                "P1",
+                "P2",
+                "P3",
+                "P4"
+            ],
+            "defaultValue": "B1",
+            "metadata": {
+                "description": "The pricing tier for the hosting plan."
+            }
+        },
+        "workerSize": {
+            "type": "string",
+            "allowedValues": [
+                "0",
+                "1",
+                "2"
+            ],
+            "defaultValue": "0",
+            "metadata": {
+                "description": "The instance size of the hosting plan (small, medium, or large)."
+            }
+        },
+        "repoURL": {
+            "type": "string",
+            "defaultValue": "https://github.com/poppastring/dasblog-core.git",
+            "metadata": {
+                "description": "The URL for the GitHub repository that contains the project to deploy."
+            }
+        },
+        "branch": {
+            "type": "string",
+            "defaultValue": "main",
+            "metadata": {
+                "description": "The branch of the GitHub repository to use."
+            }
+        }
+    },
+    "variables": {
+        "siteName": "[toLower(concat(parameters('siteName'), substring(uniqueString(resourceGroup().id), 0, 6)))]",
+        "hostingPlanName": "[concat('dbcHosting-', resourceGroup().name)]",
+        "netFrameworkVersion": "v6.0"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Web/serverfarms",
+            "apiVersion": "2020-12-01",
+            "name": "[variables('hostingPlanName')]",
+            "location": "[parameters('location')]",
+            "sku": {
+                "name": "[parameters('sku')]",
+                "capacity": "[parameters('workerSize')]"
+            },
+            "properties": {
+                "name": "[variables('hostingPlanName')]"
+            }
+        },
+        {
+            "type": "Microsoft.Web/sites",
+            "apiVersion": "2020-12-01",
+            "name": "[variables('siteName')]",
+            "location": "[parameters('location')]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]"
+            ],
+            "properties": {
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
+                "httpsOnly": true,
+                "siteconfig": {
+                    "netFrameworkVersion": "[variables('netFrameworkVersion')]"
+                }
+            },
+            "resources": [
+                {
+                    "type": "sourcecontrols",
+                    "apiVersion": "2020-12-01",
+                    "name": "web",
+                    "location": "[parameters('location')]",
+                    "dependsOn": [
+                        "[resourceId('Microsoft.Web/sites', variables('siteName'))]",
+                        "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]"
+                    ],
+                    "properties": {
+                        "repoUrl": "[parameters('repoURL')]",
+                        "branch": "[parameters('branch')]",
+                        "isManualIntegration": true
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -91,7 +91,13 @@
         "httpsOnly": true,
         "siteconfig": {
           "netFrameworkVersion": "[variables('netFrameworkVersion')]",
-          "use32BitWorkerProcess": false
+          "use32BitWorkerProcess": false,
+          "appSettings": [
+            {
+              "name": "ASPNETCORE_ENVIRONMENT",
+              "value": "Production"
+            }
+          ]
         }
       },
       "resources": [

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -6,7 +6,7 @@
       "type": "string",
       "defaultValue": "DasBlog",
       "metadata": {
-        "description": "The name of your Web Site."
+        "description": "The AzureWebSites name of your Web Site (some random text will be added at the end for uniqueness)"
       }
     },
     "sku": {
@@ -58,7 +58,7 @@
     }
   },
   "variables": {
-    "siteName": "[parameters('siteName')]",
+    "siteName": "[toLower(concat(parameters('siteName'), uniqueString(resourceGroup().id)))]",
     "hostingPlanName": "[concat('dbcHosting-', resourceGroup().name)]",
     "location": "[resourceGroup().location]",
     "netFrameworkVersion": "v6.0",

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -1,114 +1,116 @@
 {
-    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
-    "contentVersion": "1.0.0.1",
-    "parameters": {
-        "siteName": {
-            "type": "string",
-            "defaultValue": "DasBlog",
-            "metadata": {
-                "description": "The name of your Web Site."
-            }
-        },
-        "sku": {
-            "type": "string",
-            "allowedValues": [
-                "F1",
-                "D1",
-                "B1",
-                "B2",
-                "B3",
-                "S1",
-                "S2",
-                "S3",
-                "P1",
-                "P2",
-                "P3",
-                "P4"
-            ],
-            "defaultValue": "B1",
-            "metadata": {
-                "description": "The pricing tier for the hosting plan."
-            }
-        },
-        "workerSize": {
-            "type": "string",
-            "allowedValues": [
-                "0",
-                "1",
-                "2"
-            ],
-            "defaultValue": "0",
-            "metadata": {
-                "description": "The instance size of the hosting plan (small, medium, or large)."
-            }
-        },
-        "repoURL": {
-            "type": "string",
-            "defaultValue": "https://github.com/poppastring/dasblog-core.git",
-            "metadata": {
-                "description": "The URL for the GitHub repository that contains the project to deploy."
-            }
-        },
-        "branch": {
-            "type": "string",
-            "defaultValue": "main",
-            "metadata": {
-                "description": "The branch of the GitHub repository to use."
-            }
-        }
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.1",
+  "parameters": {
+    "siteName": {
+      "type": "string",
+      "defaultValue": "DasBlog",
+      "metadata": {
+        "description": "The name of your Web Site."
+      }
     },
-    "variables": {
-        "siteName": "[parameters('siteName')]",
-        "hostingPlanName": "[concat('dbcHosting-', resourceGroup().name)]",
-        "location": "[resourceGroup().location]",
-        "netFrameworkVersion": "v6.0"
+    "sku": {
+      "type": "string",
+      "allowedValues": [
+        "F1",
+        "D1",
+        "B1",
+        "B2",
+        "B3",
+        "S1",
+        "S2",
+        "S3",
+        "P1",
+        "P2",
+        "P3",
+        "P4"
+      ],
+      "defaultValue": "B1",
+      "metadata": {
+        "description": "The pricing tier for the hosting plan."
+      }
     },
-    "resources": [
-        {
-            "type": "Microsoft.Web/serverfarms",
-            "apiVersion": "2020-12-01",
-            "name": "[variables('hostingPlanName')]",
-            "location": "[variables('location')]",
-            "sku": {
-                "name": "[parameters('sku')]",
-                "capacity": "[parameters('workerSize')]"
-            },
-            "properties": {
-                "name": "[variables('hostingPlanName')]"
-            }
-        },
-        {
-            "type": "Microsoft.Web/sites",
-            "apiVersion": "2020-12-01",
-            "name": "[variables('siteName')]",
-            "location": "[variables('location')]",
-            "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]"
-            ],
-            "properties": {
-                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
-                "httpsOnly": true,
-                "siteconfig": {
-                    "netFrameworkVersion": "[variables('netFrameworkVersion')]"
-                }
-            },
-            "resources": [
-                {
-                    "type": "sourcecontrols",
-                    "apiVersion": "2020-12-01",
-                    "name": "web",
-                    "location": "[variables('location')]",
-                    "dependsOn": [
-                        "[resourceId('Microsoft.Web/sites', variables('siteName'))]",
-                        "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]"
-                    ],
-                    "properties": {
-                        "repoUrl": "[parameters('repoURL')]",
-                        "branch": "[parameters('branch')]",
-                        "isManualIntegration": true
-                    }
-                }
-            ]
+    "workerSize": {
+      "type": "string",
+      "allowedValues": [
+        "0",
+        "1",
+        "2"
+      ],
+      "defaultValue": "0",
+      "metadata": {
+        "description": "The instance size of the hosting plan (small, medium, or large)."
+      }
+    },
+    "repoURL": {
+      "type": "string",
+      "defaultValue": "https://github.com/poppastring/dasblog-core.git",
+      "metadata": {
+        "description": "The URL for the GitHub repository that contains the project to deploy."
+      }
+    },
+    "branch": {
+      "type": "string",
+      "defaultValue": "main",
+      "metadata": {
+        "description": "The branch of the GitHub repository to use."
+      }
+    }
+  },
+  "variables": {
+    "siteName": "[parameters('siteName')]",
+    "hostingPlanName": "[concat('dbcHosting-', resourceGroup().name)]",
+    "location": "[resourceGroup().location]",
+    "netFrameworkVersion": "v6.0",
+    "use32BitWorkerProcess": false
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Web/serverfarms",
+      "apiVersion": "2020-12-01",
+      "name": "[variables('hostingPlanName')]",
+      "location": "[variables('location')]",
+      "sku": {
+        "name": "[parameters('sku')]",
+        "capacity": "[parameters('workerSize')]"
+      },
+      "properties": {
+        "name": "[variables('hostingPlanName')]"
+      }
+    },
+    {
+      "type": "Microsoft.Web/sites",
+      "apiVersion": "2020-12-01",
+      "name": "[variables('siteName')]",
+      "location": "[variables('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]"
+      ],
+      "properties": {
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
+        "httpsOnly": true,
+        "siteconfig": {
+          "netFrameworkVersion": "[variables('netFrameworkVersion')]",
+          "use32BitWorkerProcess": false
         }
-    ]
+      },
+      "resources": [
+        {
+          "type": "sourcecontrols",
+          "apiVersion": "2020-12-01",
+          "name": "web",
+          "location": "[variables('location')]",
+          "dependsOn": [
+            "[resourceId('Microsoft.Web/sites', variables('siteName'))]",
+            "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]"
+          ],
+          "properties": {
+            "repoUrl": "[parameters('repoURL')]",
+            "branch": "[parameters('branch')]",
+            "isManualIntegration": true
+          }
+        }
+      ]
+    }
+  ]
 }

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -9,13 +9,6 @@
                 "description": "The name of your Web Site."
             }
         },
-        "location": {
-            "type": "string",
-            "defaultValue": "[resourceGroup().location]",
-            "metadata": {
-                "description": "Location for all resources."
-            }
-        },
         "sku": {
             "type": "string",
             "allowedValues": [
@@ -65,8 +58,9 @@
         }
     },
     "variables": {
-        "siteName": "[toLower(concat(parameters('siteName'), substring(uniqueString(resourceGroup().id), 0, 6)))]",
+        "siteName": "[parameters('siteName')]",
         "hostingPlanName": "[concat('dbcHosting-', resourceGroup().name)]",
+        "location": "[resourceGroup().location]",
         "netFrameworkVersion": "v6.0"
     },
     "resources": [
@@ -74,7 +68,7 @@
             "type": "Microsoft.Web/serverfarms",
             "apiVersion": "2020-12-01",
             "name": "[variables('hostingPlanName')]",
-            "location": "[parameters('location')]",
+            "location": "[variables('location')]",
             "sku": {
                 "name": "[parameters('sku')]",
                 "capacity": "[parameters('workerSize')]"
@@ -87,7 +81,7 @@
             "type": "Microsoft.Web/sites",
             "apiVersion": "2020-12-01",
             "name": "[variables('siteName')]",
-            "location": "[parameters('location')]",
+            "location": "[variables('location')]",
             "dependsOn": [
                 "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]"
             ],
@@ -103,7 +97,7 @@
                     "type": "sourcecontrols",
                     "apiVersion": "2020-12-01",
                     "name": "web",
-                    "location": "[parameters('location')]",
+                    "location": "[variables('location')]",
                     "dependsOn": [
                         "[resourceId('Microsoft.Web/sites', variables('siteName'))]",
                         "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]"

--- a/deploy/azuredeploy.json
+++ b/deploy/azuredeploy.json
@@ -9,6 +9,13 @@
         "description": "The AzureWebSites name of your Web Site (some random text will be added at the end for uniqueness)"
       }
     },
+    "hostingPlan": {
+      "type": "string",
+      "defaultValue": "DasBlogHosting",
+      "metadata": {
+        "description": "The name of the hosting plan to deploy to. If the plan doesn't exist, it will be created"
+      }
+    },
     "sku": {
       "type": "string",
       "allowedValues": [
@@ -58,8 +65,8 @@
     }
   },
   "variables": {
-    "siteName": "[toLower(concat(parameters('siteName'), uniqueString(resourceGroup().id)))]",
-    "hostingPlanName": "[concat('dbcHosting-', resourceGroup().name)]",
+    "siteName": "[toLower(concat(parameters('siteName'),'-', uniqueString(resourceGroup().id)))]",
+    "hostingPlanName": "[parameters('hostingPlan')]",
     "location": "[resourceGroup().location]",
     "netFrameworkVersion": "v6.0",
     "use32BitWorkerProcess": false


### PR DESCRIPTION
This is the initial PR to start the process of adding a DEPLOY TO AZURE button to the documentation (#492)

This is a straightforward addition of a "deploy" folder off of the root of the repository, containing an ARM template for deploying DasBlogCore to an Azure App Service. There will be two follow-up PRs: 
- One to the Wiki pages to add the DTA button and instructions on how to configure it.
- One to update the main project README with the DTA button and a link to the deployment instructions in the Wiki.

This ARM template will allow the user to deploy a single App Service using:
- Windows
- 64-bit Process
- Git-Deployment

The user has the ability to change the following settings when deploying the template:
- Name of the application/site
  - The name provided by the user will automatically have a suffix of 13 random characters added in order to ensure uniqueness of the subdomain/host. This is necessary because there is no way to check for uniqueness prior to deployment and the deployment doesn't not roll back the hosting plan if it fails due to a name collision.
- Name of the hosting plan
  - If an existing hosting plan name is used, the AppService will be added to the existing plan. If the plan does not exist, it will be created
- SKU (defaults to B1)
- Worker Size (defaults to 0/small)
- Repo URL
  - This is the URL of the git repository where the DasBlogCore project to be deployed is stored. It defaults to https://github.com/poppastring/dasblog-core.git to deploy from the root repository, but the user can point this to their own fork of the core project.