### PR TITLE
Support for Simple Markdown in Comments

### DIFF
--- a/source/DasBlog.Services/ConfigFile/Interfaces/ISiteConfig.cs
+++ b/source/DasBlog.Services/ConfigFile/Interfaces/ISiteConfig.cs
@@ -106,6 +106,8 @@ namespace DasBlog.Services.ConfigFile.Interfaces
 
         bool EnableComments { get; set; }
 
+        bool AllowMarkdownInComments {get; set;}
+
         bool EnableCommentApi { get; set; }
 
         bool EnableConfigEditService { get; set; }

--- a/source/DasBlog.Services/ConfigFile/SiteConfig.cs
+++ b/source/DasBlog.Services/ConfigFile/SiteConfig.cs
@@ -83,6 +83,7 @@ namespace DasBlog.Services.ConfigFile
         public string TinyMCEApiKey { get; set; }
         public bool EnableBloggerApi { get; set; }
         public bool EnableComments { get; set; }
+        public bool AllowMarkdownInComments {get; set;}
         public bool EnableCommentApi { get; set; }
         public bool EnableConfigEditService { get; set; }
         public bool EnableEditService { get; set; }

--- a/source/DasBlog.Tests/UnitTests/Config/site.config
+++ b/source/DasBlog.Tests/UnitTests/Config/site.config
@@ -62,6 +62,7 @@
   <DaysCommentsAllowed>360</DaysCommentsAllowed>
   <EnableCommentDays>true</EnableCommentDays>
   <EnableComments>true</EnableComments>
+  <AllowMarkdownInComments>true</AllowMarkdownInComments>
   <CommentsRequireApproval>false</CommentsRequireApproval>
   <CheesySpamQ>2+5=?</CheesySpamQ>
   <CheesySpamA>7</CheesySpamA>
@@ -83,6 +84,7 @@
     <tag name="ul" attributes="" allowed="true" />
     <tag name="ol" attributes="" allowed="true" />
     <tag name="li" attributes="" allowed="true" />
+    <tag name="p" attributes="" allowed="true" />
   </validCommentTags>
 
   <ChannelImageUrl>images/zenicon.jpg</ChannelImageUrl>

--- a/source/DasBlog.Tests/UnitTests/SiteConfigTest.cs
+++ b/source/DasBlog.Tests/UnitTests/SiteConfigTest.cs
@@ -170,5 +170,6 @@ namespace DasBlog.Tests.UnitTests
 		public string DefaultSources { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 		public string MastodonServerUrl { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 		public string MastodonAccount { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-	}
+        public bool AllowMarkdownInComments { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+       }
 }

--- a/source/DasBlog.Web.UI/Config/site.Development.config
+++ b/source/DasBlog.Web.UI/Config/site.Development.config
@@ -65,6 +65,8 @@
   <DaysCommentsAllowed>360</DaysCommentsAllowed>
   <EnableCommentDays>true</EnableCommentDays>
   <EnableComments>true</EnableComments>
+  <AllowMarkdownInComments>true</AllowMarkdownInComments>
+
   <CommentsRequireApproval>false</CommentsRequireApproval>
   <CheesySpamQ>2+5=?</CheesySpamQ>
   <CheesySpamA>7</CheesySpamA>
@@ -87,6 +89,7 @@
     <tag name="ul" attributes="" allowed="true" />
     <tag name="ol" attributes="" allowed="true" />
     <tag name="li" attributes="" allowed="true" />
+    <tag name="p" attributes="" allowed="true" /> 
   </validCommentTags>
 
   <ChannelImageUrl>images/zenicon.jpg</ChannelImageUrl>

--- a/source/DasBlog.Web.UI/Config/site.Development.config
+++ b/source/DasBlog.Web.UI/Config/site.Development.config
@@ -65,7 +65,7 @@
   <DaysCommentsAllowed>360</DaysCommentsAllowed>
   <EnableCommentDays>true</EnableCommentDays>
   <EnableComments>true</EnableComments>
-  <AllowMarkdownInComments>true</AllowMarkdownInComments>
+  <AllowMarkdownInComments>false</AllowMarkdownInComments>
 
   <CommentsRequireApproval>false</CommentsRequireApproval>
   <CheesySpamQ>2+5=?</CheesySpamQ>

--- a/source/DasBlog.Web.UI/Config/site.config
+++ b/source/DasBlog.Web.UI/Config/site.config
@@ -65,6 +65,7 @@
   <DaysCommentsAllowed>360</DaysCommentsAllowed>
   <EnableCommentDays>true</EnableCommentDays>
   <EnableComments>true</EnableComments>
+  <AllowMarkdownInComments>true</AllowMarkdownInComments>
   <CommentsRequireApproval>false</CommentsRequireApproval>
   <CheesySpamQ>2+5=?</CheesySpamQ>
   <CheesySpamA>7</CheesySpamA>
@@ -87,6 +88,7 @@
     <tag name="ul" attributes="" allowed="true" />
     <tag name="ol" attributes="" allowed="true" />
     <tag name="li" attributes="" allowed="true" />
+    <tag name="p" attributes="" allowed="true" />
   </validCommentTags>
 
   <ChannelImageUrl>images/zenicon.jpg</ChannelImageUrl>

--- a/source/DasBlog.Web.UI/Config/site.config
+++ b/source/DasBlog.Web.UI/Config/site.config
@@ -65,7 +65,7 @@
   <DaysCommentsAllowed>360</DaysCommentsAllowed>
   <EnableCommentDays>true</EnableCommentDays>
   <EnableComments>true</EnableComments>
-  <AllowMarkdownInComments>true</AllowMarkdownInComments>
+  <AllowMarkdownInComments>false</AllowMarkdownInComments>
   <CommentsRequireApproval>false</CommentsRequireApproval>
   <CheesySpamQ>2+5=?</CheesySpamQ>
   <CheesySpamA>7</CheesySpamA>

--- a/source/DasBlog.Web.UI/Controllers/BlogPostController.cs
+++ b/source/DasBlog.Web.UI/Controllers/BlogPostController.cs
@@ -411,7 +411,8 @@ namespace DasBlog.Web.Controllers
 
             if(dasBlogSettings.SiteConfiguration.AllowMarkdownInComments)
             {
-                addcomment.Content = Markdown.ToHtml(addcomment.Content);
+                var pipeline = new MarkdownPipelineBuilder().UseReferralLinks("nofollow").Build();
+                addcomment.Content = Markdown.ToHtml(addcomment.Content, pipeline);
             }
 
 			// Optional in case of Captcha. Commenting the settings in the config file 

--- a/source/DasBlog.Web.UI/Controllers/BlogPostController.cs
+++ b/source/DasBlog.Web.UI/Controllers/BlogPostController.cs
@@ -19,6 +19,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using reCAPTCHA.AspNetCore;
+using Markdig;
 
 namespace DasBlog.Web.Controllers
 {
@@ -35,7 +36,6 @@ namespace DasBlog.Web.Controllers
 		private readonly IBlogPostViewModelCreator modelViewCreator;
 		private readonly IMemoryCache memoryCache;
 		private readonly IRecaptchaService recaptcha;
-
 
 		public BlogPostController(IBlogManager blogManager, IHttpContextAccessor httpContextAccessor, IDasBlogSettings dasBlogSettings,
 									IMapper mapper, ICategoryManager categoryManager, IFileSystemBinaryManager binaryManager, ILogger<BlogPostController> logger,
@@ -408,6 +408,11 @@ namespace DasBlog.Web.Controllers
 			{
 				errors.Add("Comments are disabled on the site.");
 			}
+
+            if(dasBlogSettings.SiteConfiguration.AllowMarkdownInComments)
+            {
+                addcomment.Content = Markdown.ToHtml(addcomment.Content);
+            }
 
 			// Optional in case of Captcha. Commenting the settings in the config file 
 			// Will disable this check. People will typically disable this when using captcha.

--- a/source/DasBlog.Web.UI/DasBlog.Web.csproj
+++ b/source/DasBlog.Web.UI/DasBlog.Web.csproj
@@ -23,6 +23,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="10.1.1" />
     <PackageReference Include="Coravel" Version="4.1.2" />
+    <PackageReference Include="Markdig" Version="0.30.4" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.19.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.0" />    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.Extensions" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.0" />

--- a/source/DasBlog.Web.UI/Models/AdminViewModels/SiteViewModel.cs
+++ b/source/DasBlog.Web.UI/Models/AdminViewModels/SiteViewModel.cs
@@ -123,6 +123,10 @@ namespace DasBlog.Web.Models.AdminViewModels
 		[Description("Allow comments on your blog posts")]
 		public bool EnableComments { get; set; }
 
+        [DisplayName("Allow Markdown In Comments")]
+        [Description("Allow the use of Markdown In Comments")]
+        public bool AllowMarkdownInComments { get; set; }
+
 		[DisplayName("Enable comment days limitation")]
 		[Description("Once enabled comments are allowed as defined by 'Days Comments Allowed'")]
 		public bool EnableCommentDays { get; set; }

--- a/source/DasBlog.Web.UI/Models/AdminViewModels/SiteViewModel.cs
+++ b/source/DasBlog.Web.UI/Models/AdminViewModels/SiteViewModel.cs
@@ -123,7 +123,7 @@ namespace DasBlog.Web.Models.AdminViewModels
 		[Description("Allow comments on your blog posts")]
 		public bool EnableComments { get; set; }
 
-        [DisplayName("Allow Markdown In Comments")]
+        [DisplayName("Allow Markdown in comments")]
         [Description("Allow the use of Markdown In Comments")]
         public bool AllowMarkdownInComments { get; set; }
 

--- a/source/DasBlog.Web.UI/Views/Admin/Settings.cshtml
+++ b/source/DasBlog.Web.UI/Views/Admin/Settings.cshtml
@@ -249,6 +249,15 @@
 
     <div class="form-check row mb-3">
         <div class="col-sm-10 offset-sm-2">
+            <div class="col-sm-10">
+                @Html.CheckBoxFor(m => @Model.SiteConfig.AllowMarkdownInComments, new { @class = "form-check-input form-check-input" })
+            </div>
+            @Html.LabelFor(m => @Model.SiteConfig.AllowMarkdownInComments, null, new { @class = "col-check-label col-sm-2" })
+        </div>
+    </div>
+
+    <div class="form-check row mb-3">
+        <div class="col-sm-10 offset-sm-2">
             <div class="col-sm-2">
                 @Html.CheckBoxFor(m => @Model.SiteConfig.EnableCommentDays, new { @class = "form-check-input form-check-input" })
             </div>


### PR DESCRIPTION
As per our discussion in #659 this PR should allow users to post comments using simple Markdown.

As we discussed there are some points **worth noting**:
1. All restrictions of what is allowed and not allowed remain as is. (Other than **one exception** where I had to allow P by default because markdowns generate a lot of P tags in each line break. We now have p allowed by default in site.config).
2. Everything else in terms of which tags are allowed and not allowed remains the same.
3. There is now a new setting in site.config where admins can control if they want to allow comments in markdown: 
![image](https://user-images.githubusercontent.com/24845706/207050905-81ca2200-0e41-424d-98b5-8978084a21d4.png)
4. Once turned on this will start honoring markdown. 
5. If someone wants to test they can try enabling this setting and then post a comment - ```Hello **there**!``` and the double asterisk will be converted to strong or bold.

Once you disable this setting markdown will not be converted to HTML. 

@poppastring - Please feel free to let me know if any other changes are required and I'll be happy to make them and redo the whole PR.