### PR TITLE
Twitter Card Model Fix

### DIFF
--- a/source/DasBlog.Web.UI/Models/AdminViewModels/TwitterCardViewModel.cs
+++ b/source/DasBlog.Web.UI/Models/AdminViewModels/TwitterCardViewModel.cs
@@ -14,7 +14,7 @@ namespace DasBlog.Web.Models.AdminViewModels
 		public List<TwitterCardViewModel> Init()
 		{
 			return new List<TwitterCardViewModel>() {
-				new TwitterCardViewModel { Id = "summarywithlargeimage", Name = "Summary card with a large image" },
+				new TwitterCardViewModel { Id = "summary_large_image", Name = "Summary card with a large image" },
 				new TwitterCardViewModel { Id = "summary", Name = "Summary card" }
 			};
 		}


### PR DESCRIPTION
The name of the Twitter card with a large image is "summary_large_image". 

(Btw, it might make sense to allow for the card model to be picked per post)