### PR TITLE
Fixing issues occuring when dasBlog uses a subdir

### DIFF
--- a/source/DasBlog.Services/ConfigFile/SiteConfig.cs
+++ b/source/DasBlog.Services/ConfigFile/SiteConfig.cs
@@ -51,6 +51,8 @@ namespace DasBlog.Services.ConfigFile
 	[XmlType("SiteConfig")]
 	public class SiteConfig : ISiteConfig
     {
+        private string _root;
+
         public SiteConfig() { }
 
         public string Title { get; set; }
@@ -58,7 +60,23 @@ namespace DasBlog.Services.ConfigFile
         public string Theme { get; set; }
         public string Description { get; set; }
         public string Contact { get; set; }
-        public string Root { get; set; }
+        public string Root {
+            get
+            {
+                return _root;
+            }
+            set 
+            {
+                if ( !string.IsNullOrEmpty(value) )
+                {
+                    _root = value + (value.EndsWith("/")?"":"/");
+                }
+                else
+                {
+                    _root = value;
+                }
+            }
+        }
 		public string AllowedHosts { get; set; }
 		public string Copyright { get; set; }
         public int RssDayCount { get; set; }

--- a/source/DasBlog.Web.UI/Controllers/BlogPostController.cs
+++ b/source/DasBlog.Web.UI/Controllers/BlogPostController.cs
@@ -135,6 +135,7 @@ namespace DasBlog.Web.Controllers
 				if (entry != null)
 				{
 					pvm = mapper.Map<PostViewModel>(entry);
+					pvm.PermaLink = dasBlogSettings.RelativeToRoot(pvm.PermaLink);
 					modelViewCreator.AddAllLanguages(pvm);
 					List<CategoryViewModel> allcategories = mapper.Map<List<CategoryViewModel>>(blogManager.GetCategories());
 
@@ -172,14 +173,14 @@ namespace DasBlog.Web.Controllers
 			ValidatePostName(post);
 			if (!ModelState.IsValid)
 			{
-				return LocalRedirect(string.Format("/post/{0}/edit", post.EntryId));
+				return LocalRedirect(string.Format("~/post/{0}/edit", post.EntryId));
 			}
 
 			if (!string.IsNullOrWhiteSpace(post.NewCategory))
 			{
 				ModelState.AddModelError(nameof(post.NewCategory),
 					$"Please click 'Add' to add the category, \"{post.NewCategory}\" or clear the text before continuing");
-				return LocalRedirect(string.Format("/post/{0}/edit", post.EntryId));
+				return LocalRedirect(string.Format("~/post/{0}/edit", post.EntryId));
 			}
 			try
 			{
@@ -196,7 +197,7 @@ namespace DasBlog.Web.Controllers
 				if (sts == NBR.EntrySaveState.Failed)
 				{
 					ModelState.AddModelError("", "Failed to edit blog post. Please check Logs for more details.");
-					return LocalRedirect(string.Format("/post/{0}/edit", post.EntryId));
+					return LocalRedirect(string.Format("~/post/{0}/edit", post.EntryId));
 				}
 
 			}
@@ -206,7 +207,7 @@ namespace DasBlog.Web.Controllers
 				ModelState.AddModelError("", "Failed to edit blog post. Please check Logs for more details.");
 			}
 
-			return LocalRedirect(string.Format("/post/{0}/edit", post.EntryId));
+			return LocalRedirect(string.Format("~/post/{0}/edit", post.EntryId));
 		}
 
 		[HttpGet("post/create")]
@@ -277,7 +278,7 @@ namespace DasBlog.Web.Controllers
 
 			BreakSiteCache();
 
-			return LocalRedirect(string.Format("/post/{0}/edit", entry.EntryId));
+			return LocalRedirect(string.Format("~/post/{0}/edit", entry.EntryId));
 		}
 
 		[HttpGet("post/{postid:guid}/delete")]

--- a/source/DasBlog.Web.UI/TagHelpers/RichEdit/TinyMceBuilder.cs
+++ b/source/DasBlog.Web.UI/TagHelpers/RichEdit/TinyMceBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using DasBlog.Services;
+using DasBlog.Web.Settings;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace DasBlog.Web.TagHelpers.RichEdit
@@ -7,15 +8,7 @@ namespace DasBlog.Web.TagHelpers.RichEdit
 	{
 		private readonly IDasBlogSettings dasBlogSettings;
 		private const string TINY_MCE_SERVICE_URL = "https://cdn.tiny.cloud/1/{0}/tinymce/5/tinymce.min.js";
-		private const string INIT_SCRIPT_TEMPLATE = @"
-		<script>
-		tinymce.init({{
-			selector: '#{0}'
-			,plugins: 'code'
-		}});
-		</script>
-		";
-
+		
 		public TinyMceBuilder(IDasBlogSettings dasBlogSettings)
 		{
 			this.dasBlogSettings = dasBlogSettings;
@@ -32,14 +25,24 @@ namespace DasBlog.Web.TagHelpers.RichEdit
 
 		}
 
-		public void ProcessScripts(RichEditScriptsTagHelper tagHeelper, TagHelperContext context, TagHelperOutput output)
+		public void ProcessScripts(RichEditScriptsTagHelper tagHelper, TagHelperContext context, TagHelperOutput output)
 		{
 			output.TagName = "script";
 			output.TagMode = TagMode.StartTagAndEndTag;
 			output.Attributes.SetAttribute("src", string.Format(TINY_MCE_SERVICE_URL, dasBlogSettings.SiteConfiguration.TinyMCEApiKey));
 			output.Attributes.SetAttribute("type", "text/javascript");
 			output.Attributes.SetAttribute("language", "javascript");
-			string htmlContent = string.Format(INIT_SCRIPT_TEMPLATE, tagHeelper.ControlId);
+			string initScriptTemplate = @"
+					<script>
+					tinymce.init({{
+						selector: '#{0}',
+						plugins: 'code',
+						relative_urls : false,
+						remove_script_host : true,
+						document_base_url : '" + dasBlogSettings.GetBaseUrl() + @"'
+					}});
+					</script>";
+		string htmlContent = string.Format(initScriptTemplate, tagHelper.ControlId);
 			output.PostElement.SetHtmlContent(htmlContent);
 		}
 	}


### PR DESCRIPTION
There are a few fixes here for #665 

* TinyMCEBuilder must use absolute URIs for embeddings like images because the resulting page content "moves around" in the site hierarchy and the links break.
* Permalinks must be absolute. The "navigate to permalink" link in the editor broke.
* Local redirects must be relative to the site root
* Site config needs to fix up a root that doesn't end in a slash. That's the most fundamental issue.