### PR TITLE
CloudEvents support 

### DIFF
--- a/source/DasBlog.Services/ConfigFile/Interfaces/ISiteConfig.cs
+++ b/source/DasBlog.Services/ConfigFile/Interfaces/ISiteConfig.cs
@@ -130,7 +130,9 @@ namespace DasBlog.Services.ConfigFile.Interfaces
 
         bool EnableCrossposts { get; set; }
 
-        bool UseUserCulture { get; set; }
+		bool EnableCloudEvents { get; set; }
+
+		bool UseUserCulture { get; set; }
 
 		bool ShowItemSummaryInAggregatedViews { get; set; }
 
@@ -199,7 +201,13 @@ namespace DasBlog.Services.ConfigFile.Interfaces
         [XmlArray("CrosspostSites")]
         CrosspostSite[] CrosspostSiteArray { get; set; }
 
-        bool Pop3DeleteAllMessages { get; set; }
+		[XmlIgnore]
+		CloudEventsTargetCollection CloudEventsTargets { get; set; }
+
+		[XmlArray("CloudEventsTargets")]
+		CloudEventsTarget[] CloudEventsTargetArray { get; set; }
+
+		bool Pop3DeleteAllMessages { get; set; }
 
         bool Pop3LogIgnoredEmails { get; set; }
 

--- a/source/DasBlog.Services/ConfigFile/SiteConfig.cs
+++ b/source/DasBlog.Services/ConfigFile/SiteConfig.cs
@@ -126,8 +126,10 @@ namespace DasBlog.Services.ConfigFile
         public ContentFilterCollection ContentFilters { get; set; }
         public ContentFilter[] ContentFilterArray { get; set; }
         public CrosspostSiteCollection CrosspostSites { get; set; }
-        public CrosspostSite[] CrosspostSiteArray { get; set; }
-        public bool Pop3DeleteAllMessages { get; set; }
+		public CloudEventsTargetCollection CloudEventsTargets { get; set; }
+		public CrosspostSite[] CrosspostSiteArray { get; set; }
+		public CloudEventsTarget[] CloudEventsTargetArray { get; set; }
+		public bool Pop3DeleteAllMessages { get; set; }
         public bool Pop3LogIgnoredEmails { get; set; }
         public bool EnableReferralUrlBlackList { get; set; }
         public string ReferralUrlBlackList { get; set; }
@@ -224,6 +226,6 @@ namespace DasBlog.Services.ConfigFile
 		public string MastodonServerUrl { get; set; }
 
 		public string MastodonAccount { get; set; }
-
+		public bool EnableCloudEvents { get; set; }
 	}
 }

--- a/source/DasBlog.Services/IDasBlogSettings.cs
+++ b/source/DasBlog.Services/IDasBlogSettings.cs
@@ -49,5 +49,6 @@ namespace DasBlog.Services
 		SendMailInfo GetMailInfo(MailMessage emailmessage);
 		DateTime GetDisplayTime(DateTime datetime);
 		DateTime GetCreateTime(DateTime datetime);
+		string GetRssEntryUrl(string entryId);
 	}
 }

--- a/source/DasBlog.Services/Rss/Rss.cs
+++ b/source/DasBlog.Services/Rss/Rss.cs
@@ -125,7 +125,10 @@ namespace DasBlog.Services.Rss.Rss20
 		[XmlAttribute("xml:lang")]
         public string Language;
 
-        [XmlElement("author")]
+		[XmlAttribute("id")]
+		public string Id;
+
+		[XmlElement("author")]
 		public string Author { get; set; }
 
 		[XmlElement("title")]

--- a/source/DasBlog.Tests/UnitTests/DasBlogSettingTest.cs
+++ b/source/DasBlog.Tests/UnitTests/DasBlogSettingTest.cs
@@ -272,5 +272,10 @@ namespace DasBlog.Tests.UnitTests
 		{
 			throw new NotImplementedException();
 		}
+
+		public string GetRssEntryUrl(string entryId)
+		{
+			throw new NotImplementedException();
+		}
 	}
 }

--- a/source/DasBlog.Tests/UnitTests/SiteConfigTest.cs
+++ b/source/DasBlog.Tests/UnitTests/SiteConfigTest.cs
@@ -171,5 +171,8 @@ namespace DasBlog.Tests.UnitTests
 		public string MastodonServerUrl { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 		public string MastodonAccount { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
         public bool AllowMarkdownInComments { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-       }
+		public bool EnableCloudEvents { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+		public CloudEventsTargetCollection CloudEventsTargets { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+		public CloudEventsTarget[] CloudEventsTargetArray { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+	}
 }

--- a/source/DasBlog.Web.Repositories/BlogManager.cs
+++ b/source/DasBlog.Web.Repositories/BlogManager.cs
@@ -199,19 +199,27 @@ namespace DasBlog.Managers
 
 		private void RaisePostCreatedCloudEvent(Entry entry)
 		{
+			var cloudEvent = CreateCloudEvent(entry);
+			cloudEvent.Type = "dasblog.post.created";
+			RaiseCloudEvent(cloudEvent);
+		}
+
+		private CloudEvent CreateCloudEvent(Entry entry)
+		{
 			var ext = CloudEventAttribute.CreateExtension("tags", CloudEventAttributeType.String);
 			var cloudEvent = new CloudEvent(CloudEventsSpecVersion.V1_0, new[] { ext })
 			{
-				Type = "dasblog.post.created",
 				Source = new Uri(dasBlogSettings.GetBaseUrl()),
-				Subject = entry.Link,
+				Subject = MakePermaLinkFromCompressedTitle(entry).ToString(),
 				Data = MapEntryToCloudEventData(entry),
 				Id = Guid.NewGuid().ToString(),
 				Time = DateTime.UtcNow,
 			};
-			cloudEvent.SetAttributeFromString("tags", entry.Categories);
-			RaiseCloudEvent(cloudEvent);
-
+			if (!string.IsNullOrEmpty(entry.Categories))
+			{
+				cloudEvent.SetAttributeFromString("tags", entry.Categories);
+			}
+			return cloudEvent;
 		}
 
 		private void RaiseCloudEvent(CloudEvent cloudEvent)
@@ -284,17 +292,8 @@ namespace DasBlog.Managers
 
 		private void RaisePostUpdatedCloudEvent(Entry entry)
 		{
-			var ext = CloudEventAttribute.CreateExtension("tags", CloudEventAttributeType.String);
-			var cloudEvent = new CloudEvent(CloudEventsSpecVersion.V1_0, new[] { ext })
-			{
-				Type = "dasblog.post.updated",
-				Source = new Uri(dasBlogSettings.GetBaseUrl()),
-				Subject = entry.Link,
-				Data = MapEntryToCloudEventData(entry),
-				Id = Guid.NewGuid().ToString(),
-				Time = DateTime.UtcNow,
-			};
-			cloudEvent.SetAttributeFromString("tags", entry.Categories);
+			var cloudEvent = CreateCloudEvent(entry);
+			cloudEvent.Type = "dasblog.post.updated";
 			RaiseCloudEvent(cloudEvent);
 		}
 
@@ -308,17 +307,8 @@ namespace DasBlog.Managers
 
 		private void RaisePostDeletedCloudEvent(Entry entry)
 		{
-			var ext = CloudEventAttribute.CreateExtension("tags", CloudEventAttributeType.String);
-			var cloudEvent = new CloudEvent(CloudEventsSpecVersion.V1_0, new[] { ext })
-			{
-				Type = "dasblog.post.deleted",
-				Source = new Uri(dasBlogSettings.GetBaseUrl()),
-				Subject = MakePermaLinkFromCompressedTitle(entry).ToString(),
-				Id = Guid.NewGuid().ToString(),
-				Time = DateTime.UtcNow,
-				Data = MapEntryToCloudEventData(entry)
-			};
-			cloudEvent.SetAttributeFromString("tags", entry.Categories);
+			var cloudEvent = CreateCloudEvent(entry);
+			cloudEvent.Type = "dasblog.post.deleted";
 			RaiseCloudEvent(cloudEvent);
 		}
 

--- a/source/DasBlog.Web.Repositories/BlogManager.cs
+++ b/source/DasBlog.Web.Repositories/BlogManager.cs
@@ -265,7 +265,7 @@ namespace DasBlog.Managers
 			data.ModifiedUtc = entry.ModifiedUtc;
 			data.Tags = entry.Categories;
 			data.Description = entry.Description;
-			data.PermaLink = entry.Link;
+			data.PermaLink = MakePermaLinkFromCompressedTitle(entry).ToString();
 			data.DetailsLink = dasBlogSettings.GetRssEntryUrl(entry.EntryId);
 			data.IsPublic = entry.IsPublic;
 			data.Author = entry.Author;
@@ -313,7 +313,7 @@ namespace DasBlog.Managers
 			{
 				Type = "dasblog.post.deleted",
 				Source = new Uri(dasBlogSettings.GetBaseUrl()),
-				Subject = entry.Link,
+				Subject = MakePermaLinkFromCompressedTitle(entry).ToString(),
 				Id = Guid.NewGuid().ToString(),
 				Time = DateTime.UtcNow,
 				Data = MapEntryToCloudEventData(entry)

--- a/source/DasBlog.Web.Repositories/DasBlog.Managers.csproj
+++ b/source/DasBlog.Web.Repositories/DasBlog.Managers.csproj
@@ -10,8 +10,10 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="CloudNative.CloudEvents" Version="2.5.1" />
+    <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.5.1" />
     <PackageReference Include="NodaTime" Version="3.0.9" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/source/DasBlog.Web.Repositories/EntryCloudEventData.cs
+++ b/source/DasBlog.Web.Repositories/EntryCloudEventData.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Text.Json.Serialization;
+
+namespace DasBlog.Managers
+{
+	internal class EntryCloudEventData
+	{
+		[JsonPropertyName("id")]
+		public string Id { get; internal set; }
+		[JsonPropertyName("title")]
+		public string Title { get; internal set; }
+		[JsonPropertyName("createdUtc")]
+		public DateTime CreatedUtc { get; internal set; }
+		[JsonPropertyName("modifiedUtc")]
+		public DateTime ModifiedUtc { get; internal set; }
+		[JsonPropertyName("tags")]
+		public string Tags { get; internal set; }
+		[JsonPropertyName("description")]
+		public string Description { get; internal set; }
+		[JsonPropertyName("permaLink")]
+		public string PermaLink { get; internal set; }
+		[JsonPropertyName("contentLink")]
+		public string DetailsLink { get; internal set; }
+		[JsonPropertyName("isPublic")]
+		public bool IsPublic { get; internal set; }
+		[JsonPropertyName("author")]
+		public string Author { get; internal set; }
+		[JsonPropertyName("longitude")]
+		public double? Longitude { get; internal set; }
+		[JsonPropertyName("latitude")]
+		public double? Latitude { get; internal set; }
+		
+	}
+}

--- a/source/DasBlog.Web.Repositories/Interfaces/ISubscriptionManager.cs
+++ b/source/DasBlog.Web.Repositories/Interfaces/ISubscriptionManager.cs
@@ -10,5 +10,6 @@ namespace DasBlog.Managers.Interfaces
         RssRoot GetAtom();
         RssRoot GetAtomCategory(string categoryName);
         RsdRoot GetRsd();
-    }
+		RssItem GetRssItem(string entryId);
+	}
 }

--- a/source/DasBlog.Web.UI/Config/IISUrlRewrite.Development.config
+++ b/source/DasBlog.Web.UI/Config/IISUrlRewrite.Development.config
@@ -57,7 +57,7 @@
       <conditions>
         <add input="{QUERY_STRING}" pattern="&amp;?guid=(.*)" />
       </conditions>
-      <action type="Redirect" url="feed/rss/comments/{C:1}" redirectType="Permanent" />
+      <action type="Redirect" url="feed/rss/{C:1}/comments/" redirectType="Permanent" />
     </rule>
     
   </rules>

--- a/source/DasBlog.Web.UI/Config/site.Development.config
+++ b/source/DasBlog.Web.UI/Config/site.Development.config
@@ -3,7 +3,7 @@
 
   <!-- REQUIRED: Your blog will not work properly until you configure these settings. -->
   <!-- Set the Root to the base URL of this blog, such as http://example.com/blog/ -->
-  <Root>https://localhost:5001/</Root>
+  <Root>http://localhost:5001/</Root>
 
   <!-- NotificationEMailAddress is the address used by the system to send you event (blog posts, comment posts) notifications.
        This address will NOT be published on the website. -->
@@ -139,6 +139,7 @@
   <EnableBlogrollDescription>false</EnableBlogrollDescription>
   <EnableUrlRewriting>false</EnableUrlRewriting>
   <EnableCrossposts>false</EnableCrossposts>
+  <EnableCloudEvents>false</EnableCloudEvents>
   <UseUserCulture>true</UseUserCulture>
   <ExtensionlessUrls>false</ExtensionlessUrls>
   <EnableAggregatorBugging>false</EnableAggregatorBugging>
@@ -159,6 +160,18 @@
   <CrosspostSites>
     <CrosspostSite profileName="LongHornBlogs" hostName="www.longhornblogs.com" port="80" endpoint="" username="" password="" apitype="metaweblog" />
   </CrosspostSites>
+  <CloudEventsTargets>
+    <CloudEventsTarget>
+      <ProfileName>eventGrid</ProfileName>
+      <Uri>https://{myns}.westeurope-1.eventgrid.azure.net/api/events</Uri>
+      <Headers>
+        <Header>
+          <Name>aeg-sas-key</Name>
+          <Value>xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx</Value>
+        </Header>
+      </Headers> 
+    </CloudEventsTarget>
+  </CloudEventsTargets>
   <Pop3DeleteAllMessages>true</Pop3DeleteAllMessages>
   <Pop3LogIgnoredEmails>true</Pop3LogIgnoredEmails>
   <EnableReferralUrlBlackList>false</EnableReferralUrlBlackList>

--- a/source/DasBlog.Web.UI/Config/site.config
+++ b/source/DasBlog.Web.UI/Config/site.config
@@ -138,6 +138,7 @@
   <EnableBlogrollDescription>false</EnableBlogrollDescription>
   <EnableUrlRewriting>false</EnableUrlRewriting>
   <EnableCrossposts>false</EnableCrossposts>
+  <EnableCloudEvents>false</EnableCloudEvents>
   <UseUserCulture>true</UseUserCulture>
   <ExtensionlessUrls>false</ExtensionlessUrls>
   <EnableAggregatorBugging>false</EnableAggregatorBugging>
@@ -158,6 +159,20 @@
   <CrosspostSites>
     <CrosspostSite profileName="LongHornBlogs" hostName="www.longhornblogs.com" port="80" endpoint="" username="" password="" apitype="metaweblog" />
   </CrosspostSites>
+  <CloudEventsTargets>
+    <CloudEventsTargets>
+      <CloudEventsTarget>
+        <ProfileName>eventGrid</ProfileName>
+        <Uri>https://{myns}.westeurope-1.eventgrid.azure.net/api/events</Uri>
+        <Headers>
+          <Header>
+            <Name>aeg-sas-key</Name>
+            <Value>xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx</Value>
+          </Header>
+        </Headers>
+      </CloudEventsTarget>
+    </CloudEventsTargets>
+  </CloudEventsTargets>
   <Pop3DeleteAllMessages>true</Pop3DeleteAllMessages>
   <Pop3LogIgnoredEmails>true</Pop3LogIgnoredEmails>
   <EnableReferralUrlBlackList>false</EnableReferralUrlBlackList>

--- a/source/DasBlog.Web.UI/Config/site.config
+++ b/source/DasBlog.Web.UI/Config/site.config
@@ -160,7 +160,6 @@
     <CrosspostSite profileName="LongHornBlogs" hostName="www.longhornblogs.com" port="80" endpoint="" username="" password="" apitype="metaweblog" />
   </CrosspostSites>
   <CloudEventsTargets>
-    <CloudEventsTargets>
       <CloudEventsTarget>
         <ProfileName>eventGrid</ProfileName>
         <Uri>https://{myns}.westeurope-1.eventgrid.azure.net/api/events</Uri>
@@ -171,7 +170,6 @@
           </Header>
         </Headers>
       </CloudEventsTarget>
-    </CloudEventsTargets>
   </CloudEventsTargets>
   <Pop3DeleteAllMessages>true</Pop3DeleteAllMessages>
   <Pop3LogIgnoredEmails>true</Pop3LogIgnoredEmails>

--- a/source/DasBlog.Web.UI/Controllers/FeedController.cs
+++ b/source/DasBlog.Web.UI/Controllers/FeedController.cs
@@ -45,7 +45,20 @@ namespace DasBlog.Web.Controllers
         }
 
 		[Produces("text/xml")]
-		[HttpGet("feed/rss/{category}"), HttpHead("feed/rss/{category}")]
+		[HttpGet("feed/rss/{id}"), HttpHead("feed/rss/{id}")]
+		public IActionResult RssItem(string id)
+		{
+			if (!memoryCache.TryGetValue(CACHEKEY_RSS+id, out RssItem rssItem))
+			{
+				rssItem = subscriptionManager.GetRssItem(id);
+
+				memoryCache.Set(CACHEKEY_RSS+id, rssItem, SiteCacheSettings());
+			}
+			return Ok(rssItem);
+		}
+
+		[Produces("text/xml")]
+		[HttpGet("feed/tags/{category}/rss"), HttpHead("feed/tags/{category}/rss")]
         public IActionResult RssByCategory(string category)
         {
 			if (!memoryCache.TryGetValue(CACHEKEY_RSS + "_" + category, out RssRoot rss))
@@ -120,7 +133,7 @@ namespace DasBlog.Web.Controllers
 			return Ok();
 		}
 
-		[HttpGet("feed/rss/comments/{entryid}"), HttpHead("feed/rss/comments/{entryid}")]
+		[HttpGet("feed/rss/{entryid}/comments"), HttpHead("feed/rss/{entryid}/comments")]
 		public ActionResult RssComments(string entryid)
 		{
 			return Ok();

--- a/source/DasBlog.Web.UI/Settings/DasBlogSettings.cs
+++ b/source/DasBlog.Web.UI/Settings/DasBlogSettings.cs
@@ -101,7 +101,7 @@ namespace DasBlog.Web.Settings
 
         public string GetEntryCommentsRssUrl(string entryId)
         {
-            return RelativeToRoot(RssUrl + "/comments/" + entryId);
+            return RelativeToRoot(RssUrl + $"/{entryId}/comments/");
         }
 
 		public string GetCategoryViewUrl(string category)
@@ -116,7 +116,12 @@ namespace DasBlog.Web.Settings
 
 		public string GetRssCategoryUrl(string category)
 		{
-			return string.Empty;
+			return RelativeToRoot($"feed/tags/{category}/rss");
+		}
+
+		public string GetRssEntryUrl(string entryId)
+		{
+			return RelativeToRoot($"feed/rss/{entryId}");
 		}
 
 		public User GetUser(string userName)
@@ -307,5 +312,7 @@ namespace DasBlog.Web.Settings
 
 			return datetime;
 		}
+
+		
 	}
 }

--- a/source/newtelligence.DasBlog.Runtime/CloudEventsTarget.cs
+++ b/source/newtelligence.DasBlog.Runtime/CloudEventsTarget.cs
@@ -1,0 +1,143 @@
+﻿#region Copyright (c) 2003, newtelligence AG. All rights reserved.
+/*
+// Copyright (c) 2003, newtelligence AG. (http://www.newtelligence.com)
+// Original BlogX Source Code: Copyright (c) 2003, Chris Anderson (http://simplegeek.com)
+// All rights reserved.
+//  
+// Redistribution and use in source and binary forms, with or without modification, are permitted 
+// provided that the following conditions are met: 
+//  
+// (1) Redistributions of source code must retain the above copyright notice, this list of 
+// conditions and the following disclaimer. 
+// (2) Redistributions in binary form must reproduce the above copyright notice, this list of 
+// conditions and the following disclaimer in the documentation and/or other materials 
+// provided with the distribution. 
+// (3) Neither the name of the newtelligence AG nor the names of its contributors may be used 
+// to endorse or promote products derived from this software without specific prior 
+// written permission.
+//      
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS 
+// OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY 
+// AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR 
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER 
+// IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT 
+// OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+// -------------------------------------------------------------------------
+//
+// Original BlogX source code (c) 2003 by Chris Anderson (http://simplegeek.com)
+// 
+// newtelligence is a registered trademark of newtelligence Aktiengesellschaft.
+// 
+// For portions of this software, the some additional copyright notices may apply 
+// which can either be found in the license.txt file included in the source distribution
+// or following this notice. 
+//
+*/
+#endregion
+
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Xml;
+using System.Xml.Serialization;
+
+
+namespace newtelligence.DasBlog.Runtime
+{
+
+	public class CloudEventsTargetHeader
+	{
+		public string Name { get; set; }
+		public string Value { get; set; }
+	}
+
+	[Serializable]
+    public class CloudEventsTarget
+    {
+        string profileName;
+        string uri;
+		CloudEventsTargetHeader[] headers;
+		CloudEventsTargetHeader[] queryArgs;
+
+		public CloudEventsTarget()
+        {
+        }
+
+        public CloudEventsTarget(string profileName, string uri, CloudEventsTargetHeader[] headers, CloudEventsTargetHeader[] queryArgs)
+        {
+            this.profileName = profileName;
+            this.uri = uri;
+			this.headers = headers;
+			this.queryArgs = queryArgs;
+		}
+
+        [XmlElement("ProfileName")]
+        public string ProfileName { get { return profileName; } set { profileName = value; } }
+        [XmlElement("Uri")]
+        public string Uri { get { return uri; } set { uri = value; } }
+		[XmlArray("QueryArgs")]
+		public CloudEventsTargetHeader[] QueryArgs { get { return queryArgs; } set { queryArgs = value; } }
+		[XmlArray("Headers")]
+		public CloudEventsTargetHeader[] Headers { get { return headers; } set { headers = value; } }
+
+		[XmlAnyElement]
+        public XmlElement[] anyElements;
+        [XmlAnyAttribute]
+        public XmlAttribute[] anyAttributes;
+    }
+
+    /// <summary>
+    /// A collection of elements of type CloudEventsSite
+    /// </summary>
+    [Serializable]
+    public class CloudEventsTargetCollection: Collection<CloudEventsTarget>
+    {
+        /// <summary>
+        /// Initializes a new empty instance of the CloudEventsSiteCollection class.
+        /// </summary>
+        public CloudEventsTargetCollection()
+            :base()
+        {
+            // empty
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the CloudEventsSiteCollection class, containing elements
+        /// copied from an array.
+        /// </summary>
+        /// <param name="items">
+        /// The array whose elements are to be added to the new CloudEventsSiteCollection.
+        /// </param>
+        public CloudEventsTargetCollection(IList<CloudEventsTarget> items)
+            :base()
+        {
+            if (items == null) {
+                throw new ArgumentNullException("items");
+            }
+
+            this.AddRange(items);
+        }
+
+        /// <summary>
+        /// Adds the elements of an array to the end of this CloudEventsSiteCollection.
+        /// </summary>
+        /// <param name="items">
+        /// The array whose elements are to be added to the end of this CloudEventsSiteCollection.
+        /// </param>
+        public virtual void AddRange(IEnumerable<CloudEventsTarget> items)
+        {
+            if (items == null)
+            {
+                throw new ArgumentNullException("items");
+            }
+
+            foreach (CloudEventsTarget item in items)
+            {
+                this.Add(item);
+            }
+        }
+    }
+}

--- a/source/newtelligence.DasBlog.Runtime/newtelligence.DasBlog.Runtime.csproj
+++ b/source/newtelligence.DasBlog.Runtime/newtelligence.DasBlog.Runtime.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="NodaTime" Version="3.0.9" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />


### PR DESCRIPTION
#do-not-merge

This PR adds CloudEvents support addressing #671. 

I had to move the cheese a bit in the RSS feed area, though, because I need an endpoint for an event consumer to fetch the full content from. I'm assuming that we can't route the entire text of all posts through the eventing channel. 

Base feed still at ./feed/rss
* (new) `./feed/rss/{id}` newly returns an RSS item with inlined content (as when the AlwaysIncludeContentInRSS option is turned on). I also fixed an issue with XHTML encoding since XHTML doesn't like HTML entities undecoded. 
* (changed) `./feed/rss/{id}/comments` switched from `./feed/rss/comments/{id}` 
* (changed) `./feed/rss/tags/{categoryid}/rss` switched from `./feed/rss/{categoryid}`  

In config, you enable the CloudEvents support with 

``` xml
 <EnableCloudEvents>false</EnableCloudEvents>
 ```
 
 and you need to add one or more HTTPS target endpoints to deliver those events to. That is currently done synchronously, inline with posting the item, but should be very fast with an event broker.

The targets are configured with a `<CloudEventsTargets>` element that can hold one or more targets. The `Uri` holds the target Uri, the `Headers` collection holds name/value pairs for HTTP headers to add to the request. Here, I show an Event Grid  SAS key header. 

``` xml
<CloudEventsTargets>
      <CloudEventsTarget>
        <ProfileName>eventGrid</ProfileName>
        <Uri>https://{myns}.westeurope-1.eventgrid.azure.net/api/events</Uri>
        <Headers>
          <Header>
            <Name>aeg-sas-key</Name>
            <Value>xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx</Value>
          </Header>
        </Headers>
      </CloudEventsTarget>
  </CloudEventsTargets>
```
