### PR TITLE
Adding CDN support for binary content. Configurable from site.config.

### DIFF
--- a/source/DasBlog.Services/ConfigFile/Interfaces/ISiteConfig.cs
+++ b/source/DasBlog.Services/ConfigFile/Interfaces/ISiteConfig.cs
@@ -61,9 +61,11 @@ namespace DasBlog.Services.ConfigFile.Interfaces
 
         string Root { get; set; }
 
-        string Copyright { get; set; }
+        string CdnRoot { get; set; }
 
-        int RssDayCount { get; set; }
+        string Copyright { get; set; }
+		
+		int RssDayCount { get; set; }
 
         int RssMainEntryCount { get; set; }
 

--- a/source/DasBlog.Services/ConfigFile/Interfaces/ISiteConfig.cs
+++ b/source/DasBlog.Services/ConfigFile/Interfaces/ISiteConfig.cs
@@ -61,9 +61,10 @@ namespace DasBlog.Services.ConfigFile.Interfaces
 
         string Root { get; set; }
 
-        string CdnRoot { get; set; }
+        string CdnFrom { get; set; }
+        string CdnTo { get; set; }
 
-        string Copyright { get; set; }
+		string Copyright { get; set; }
 		
 		int RssDayCount { get; set; }
 

--- a/source/DasBlog.Services/ConfigFile/SiteConfig.cs
+++ b/source/DasBlog.Services/ConfigFile/SiteConfig.cs
@@ -52,7 +52,8 @@ namespace DasBlog.Services.ConfigFile
 	public class SiteConfig : ISiteConfig
     {
         private string _root;
-        private string _cdnRoot;
+        private string _cdnFrom;
+        private string _cdnTo;
 
 		public SiteConfig() { }
 
@@ -79,21 +80,40 @@ namespace DasBlog.Services.ConfigFile
             }
         }
 
-		public string CdnRoot
+		public string CdnFrom
 		{
 			get
 			{
-				return _cdnRoot;
+				return _cdnFrom;
 			}
 			set
 			{
 				if (!string.IsNullOrEmpty(value))
 				{
-					_cdnRoot = value + (value.EndsWith("/") ? "" : "/");
+					_cdnFrom = value + (value.EndsWith("/") ? "" : "/");
 				}
 				else
 				{
-					_cdnRoot = value;
+					_cdnFrom = value;
+				}
+			}
+		}
+
+		public string CdnTo
+		{
+			get
+			{
+				return _cdnTo;
+			}
+			set
+			{
+				if (!string.IsNullOrEmpty(value))
+				{
+					_cdnTo= value + (value.EndsWith("/") ? "" : "/");
+				}
+				else
+				{
+					_cdnTo = value;
 				}
 			}
 		}

--- a/source/DasBlog.Services/ConfigFile/SiteConfig.cs
+++ b/source/DasBlog.Services/ConfigFile/SiteConfig.cs
@@ -52,8 +52,9 @@ namespace DasBlog.Services.ConfigFile
 	public class SiteConfig : ISiteConfig
     {
         private string _root;
+        private string _cdnRoot;
 
-        public SiteConfig() { }
+		public SiteConfig() { }
 
         public string Title { get; set; }
         public string Subtitle { get; set; }
@@ -77,6 +78,26 @@ namespace DasBlog.Services.ConfigFile
                 }
             }
         }
+
+		public string CdnRoot
+		{
+			get
+			{
+				return _cdnRoot;
+			}
+			set
+			{
+				if (!string.IsNullOrEmpty(value))
+				{
+					_cdnRoot = value + (value.EndsWith("/") ? "" : "/");
+				}
+				else
+				{
+					_cdnRoot = value;
+				}
+			}
+		}
+
 		public string AllowedHosts { get; set; }
 		public string Copyright { get; set; }
         public int RssDayCount { get; set; }

--- a/source/DasBlog.Services/ConfigFile/SiteConfig.cs
+++ b/source/DasBlog.Services/ConfigFile/SiteConfig.cs
@@ -79,44 +79,8 @@ namespace DasBlog.Services.ConfigFile
                 }
             }
         }
-
-		public string CdnFrom
-		{
-			get
-			{
-				return _cdnFrom;
-			}
-			set
-			{
-				if (!string.IsNullOrEmpty(value))
-				{
-					_cdnFrom = value + (value.EndsWith("/") ? "" : "/");
-				}
-				else
-				{
-					_cdnFrom = value;
-				}
-			}
-		}
-
-		public string CdnTo
-		{
-			get
-			{
-				return _cdnTo;
-			}
-			set
-			{
-				if (!string.IsNullOrEmpty(value))
-				{
-					_cdnTo= value + (value.EndsWith("/") ? "" : "/");
-				}
-				else
-				{
-					_cdnTo = value;
-				}
-			}
-		}
+		public string CdnFrom { get; set; }
+		public string CdnTo { get; set; }
 
 		public string AllowedHosts { get; set; }
 		public string Copyright { get; set; }

--- a/source/DasBlog.Tests/UnitTests/SiteConfigTest.cs
+++ b/source/DasBlog.Tests/UnitTests/SiteConfigTest.cs
@@ -3,8 +3,6 @@ using DasBlog.Core.Configuration;
 using DasBlog.Services.ConfigFile.Interfaces;
 using newtelligence.DasBlog.Runtime;
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Xml;
 
 namespace DasBlog.Tests.UnitTests
@@ -17,10 +15,10 @@ namespace DasBlog.Tests.UnitTests
 		public string Description { get => "Description"; set => throw new NotImplementedException(); }
 		public string Contact { get => "Contact"; set => throw new NotImplementedException(); }
 		public string Root { get => "http://www.poppastring.com/"; set => throw new NotImplementedException(); }
+		public string CdnRoot { get => ""; set => throw new NotImplementedException(); }
 		public string Copyright { get => "CopyRight"; set => throw new NotImplementedException(); }
 		public int RssDayCount { get => 100; set => throw new NotImplementedException(); }
 		public bool ShowCommentCount { get => true; set => throw new NotImplementedException(); }
-
 		public int RssMainEntryCount { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 		public int RssEntryCount { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 		public bool EnableRssItemFooters { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }

--- a/source/DasBlog.Tests/UnitTests/SiteConfigTest.cs
+++ b/source/DasBlog.Tests/UnitTests/SiteConfigTest.cs
@@ -15,7 +15,8 @@ namespace DasBlog.Tests.UnitTests
 		public string Description { get => "Description"; set => throw new NotImplementedException(); }
 		public string Contact { get => "Contact"; set => throw new NotImplementedException(); }
 		public string Root { get => "http://www.poppastring.com/"; set => throw new NotImplementedException(); }
-		public string CdnRoot { get => ""; set => throw new NotImplementedException(); }
+		public string CdnFrom{ get => ""; set => throw new NotImplementedException(); }
+		public string CdnTo{ get => ""; set => throw new NotImplementedException(); }
 		public string Copyright { get => "CopyRight"; set => throw new NotImplementedException(); }
 		public int RssDayCount { get => 100; set => throw new NotImplementedException(); }
 		public bool ShowCommentCount { get => true; set => throw new NotImplementedException(); }

--- a/source/DasBlog.Web.Repositories/FileSystemBinaryManager.cs
+++ b/source/DasBlog.Web.Repositories/FileSystemBinaryManager.cs
@@ -1,7 +1,6 @@
 ﻿using DasBlog.Managers.Interfaces;
 using DasBlog.Services;
 using DasBlog.Services.ConfigFile;
-using DasBlog.Services.ConfigFile.Interfaces;
 using DasBlog.Services.FileManagement;
 using DasBlog.Services.FileManagement.Interfaces;
 using Microsoft.Extensions.Options;
@@ -33,7 +32,9 @@ namespace DasBlog.Managers
 
 			var loggingDataService = LoggingDataServiceFactory.GetService(Path.Combine(dasBlogSettings.WebRootDirectory, dasBlogSettings.SiteConfiguration.LogDir));
 
-			this.binaryDataService = BinaryDataServiceFactory.GetService(options.BinaryFolder, physBinaryPathUrl, loggingDataService);
+			var cdnManager = CdnManagerFactory.GetService(dasBlogSettings.SiteConfiguration.Root, dasBlogSettings.SiteConfiguration.CdnRoot);
+
+			binaryDataService = BinaryDataServiceFactory.GetService(options.BinaryFolder, physBinaryPathUrl, loggingDataService, cdnManager);
 		}
 
 		public string SaveFile(Stream inputFile, string fileName)

--- a/source/DasBlog.Web.Repositories/FileSystemBinaryManager.cs
+++ b/source/DasBlog.Web.Repositories/FileSystemBinaryManager.cs
@@ -32,7 +32,7 @@ namespace DasBlog.Managers
 
 			var loggingDataService = LoggingDataServiceFactory.GetService(Path.Combine(dasBlogSettings.WebRootDirectory, dasBlogSettings.SiteConfiguration.LogDir));
 
-			var cdnManager = CdnManagerFactory.GetService(dasBlogSettings.SiteConfiguration.Root, dasBlogSettings.SiteConfiguration.CdnRoot);
+			var cdnManager = CdnManagerFactory.GetService(dasBlogSettings.SiteConfiguration.CdnFrom, dasBlogSettings.SiteConfiguration.CdnTo);
 
 			binaryDataService = BinaryDataServiceFactory.GetService(options.BinaryFolder, physBinaryPathUrl, loggingDataService, cdnManager);
 		}

--- a/source/DasBlog.Web.UI/Config/site.config
+++ b/source/DasBlog.Web.UI/Config/site.config
@@ -29,6 +29,10 @@
 
   <!-- END OF SUGGESTED SETTINGS -->
 
+  <!-- OPTIONAL: IF you use a CDN service your files are still stored locally on the blog site, and the CDN url below will replace your <Root> when referncing your binary content. -->
+  <!-- Set the base URL of the cdn servcie http://cdn.example.com/blog/ -->
+  <CdnRoot></CdnRoot>
+
   <MastodonServerUrl />
   <MastodonAccount />
   

--- a/source/DasBlog.Web.UI/Config/site.config
+++ b/source/DasBlog.Web.UI/Config/site.config
@@ -29,15 +29,6 @@
 
   <!-- END OF SUGGESTED SETTINGS -->
 
-  <!-- OPTIONAL: Content Delivery Network (CDN)
-                 The two CDN settings below (CdnFrom/CdnTo) is a search and replace pattern.
-                 Note: This setting will not work from localhost when posting a new blog post.
-  -->
-  <!-- The part of your <Root> or binary hosting path you want to replace (ex. http://example.com/content/binary/): -->
-  <CdnFrom></CdnFrom>
-  <!-- The URL of the cdn servcie you are replacing to (ex. http://cdn.example.com/content/binary/): -->
-  <CdnTo></CdnTo>
-
   <MastodonServerUrl />
   <MastodonAccount />
   
@@ -64,6 +55,16 @@
   <ContentDir>content</ContentDir>
   <LogDir>logs</LogDir>
   <BinariesDir>content/binary</BinariesDir>
+
+  <!-- OPTIONAL: Content Delivery Network (CDN)
+                 The two CDN settings below (CdnFrom/CdnTo) is a search and replace pattern.
+                 * Default binaries storage is <Root>/<BinariesDir>.
+                 * Note: This setting will not work from localhost when posting a new blog post.
+  -->
+  <!-- The part of your <Root>/<BinariesDir> hosting path you want to replace (ex. http://example.com/content/binary/): -->
+  <CdnFrom></CdnFrom>
+  <!-- The URL of the cdn servcie you are replacing to (ex. http://cdn.example.com/content/binary/): -->
+  <CdnTo></CdnTo>
 
   <EnableTitlePermaLink>true</EnableTitlePermaLink>
   <EnableTitlePermaLinkUnique>false</EnableTitlePermaLinkUnique>

--- a/source/DasBlog.Web.UI/Config/site.config
+++ b/source/DasBlog.Web.UI/Config/site.config
@@ -29,9 +29,14 @@
 
   <!-- END OF SUGGESTED SETTINGS -->
 
-  <!-- OPTIONAL: IF you use a CDN service your files are still stored locally on the blog site, and the CDN url below will replace your <Root> when referncing your binary content. -->
-  <!-- Set the base URL of the cdn servcie http://cdn.example.com/blog/ -->
-  <CdnRoot></CdnRoot>
+  <!-- OPTIONAL: Content Delivery Network (CDN)
+                 The two CDN settings below (CdnFrom/CdnTo) is a search and replace pattern.
+                 Note: This setting will not work from localhost when posting a new blog post.
+  -->
+  <!-- The part of your <Root> or binary hosting path you want to replace (ex. http://example.com/content/binary/): -->
+  <CdnFrom></CdnFrom>
+  <!-- The URL of the cdn servcie you are replacing to (ex. http://cdn.example.com/content/binary/): -->
+  <CdnTo></CdnTo>
 
   <MastodonServerUrl />
   <MastodonAccount />

--- a/source/DasBlog.Web.UI/Models/AdminViewModels/SiteViewModel.cs
+++ b/source/DasBlog.Web.UI/Models/AdminViewModels/SiteViewModel.cs
@@ -240,8 +240,15 @@ namespace DasBlog.Web.Models.AdminViewModels
 
 		[DisplayName("Time zone index")]
 		[Description("")]
-
 		public int DisplayTimeZoneIndex { get; set; }
+
+		[DisplayName("CDN from")]
+		[Description("The part of your Root URL to replace with the CDN URL. (optional)")]
+		public string CdnFrom { get; set; }
+
+		[DisplayName("CDN to")]
+		[Description("The CDN URL that will replace 'CDN from'. (optional)")]
+		public string CdnTo { get; set; }
 
 		[DisplayName("Comments require approval")]
 		[Description("")]

--- a/source/DasBlog.Web.UI/Views/Admin/Settings.cshtml
+++ b/source/DasBlog.Web.UI/Views/Admin/Settings.cshtml
@@ -694,6 +694,22 @@
         @Html.ValidationMessageFor(m => m.SiteConfig.DisplayTimeZoneIndex, null, new { @class = "text-danger" })
 
     </div>
+    
+    <div class="form-group row mb-3">
+
+        @Html.LabelFor(m => @Model.SiteConfig.CdnFrom, null, new { @class = "col-form-label col-sm-2" })
+        <div class="col-sm-5">
+                @Html.TextBoxFor(m => @Model.SiteConfig.CdnFrom, null, new { @class = "form-control sm-10" })
+        </div>
+        @Html.ValidationMessageFor(m => m.SiteConfig.CdnFrom, null, new { @class = "text-danger" })
+
+        @Html.LabelFor(m => @Model.SiteConfig.CdnTo, null, new { @class = "col-form-label col-sm-2" })
+        <div class="col-sm-5">
+            @Html.TextBoxFor(m => @Model.SiteConfig.CdnTo, null, new { @class = "form-control sm-10" })
+        </div>
+        @Html.ValidationMessageFor(m => m.SiteConfig.CdnTo, null, new { @class = "text-danger" })
+    
+    </div>
 
     <h3>Security</h3>
 

--- a/source/newtelligence.DasBlog.Runtime/CdnManager.cs
+++ b/source/newtelligence.DasBlog.Runtime/CdnManager.cs
@@ -4,39 +4,32 @@ namespace newtelligence.DasBlog.Runtime
 {
 	public static class CdnManagerFactory
 	{
-		public static ICdnManager GetService(string rootUri, string cdnUri)
+		public static ICdnManager GetService(string cdnFrom, string cdnTo)
 		{
-			return new CdnManager(rootUri, cdnUri);
+			return new CdnManager(cdnFrom, cdnTo);
 		}
 	}
 
 	internal sealed class CdnManager : ICdnManager
 	{
-		private readonly string rootUri;
-		private readonly string cdnUri;
+		private readonly string cdnFrom;
+		private readonly string cdnTo;
 
 		/// <summary>
 		/// Setting up the cdn manager to return cdn uris when that is configured.
 		/// </summary>
-		/// <param name="rootUri">The root of the </param>
-		/// <param name="cdnUri"></param>
-		public CdnManager(string rootUri, string cdnUri)
+		/// <param name="cdnFrom">The binary hosting path to be replaced.</param>
+		/// <param name="cdnTo">The cdn binary hosting path to change to.</param>
+		public CdnManager(string cdnFrom, string cdnTo)
 		{
-			this.rootUri = 
-				string.IsNullOrWhiteSpace(rootUri) || !Uri.TryCreate(rootUri, UriKind.Absolute, out _) ?
-				null :
-				rootUri;
-			this.cdnUri = 
-				string.IsNullOrWhiteSpace(cdnUri) || !Uri.TryCreate(cdnUri, UriKind.Absolute, out _) ? 
-				null : 
-				cdnUri;
-			if (this.rootUri == null) this.cdnUri = null;
+			this.cdnFrom = string.IsNullOrWhiteSpace(cdnFrom) ? null : cdnFrom;
+			this.cdnTo = string.IsNullOrWhiteSpace(cdnTo) || this.cdnFrom == null ? null : cdnTo;
 		}
 
 		public string ApplyCdnUri(string uri)
 		{
 			// If the cdnUri is null then we can just return the uri.
-			return cdnUri == null ? uri : uri.Replace(rootUri, cdnUri);
+			return cdnTo == null ? uri : uri.Replace(cdnFrom, cdnTo);
 		}
 	}
 }

--- a/source/newtelligence.DasBlog.Runtime/CdnManager.cs
+++ b/source/newtelligence.DasBlog.Runtime/CdnManager.cs
@@ -1,0 +1,42 @@
+﻿using System;
+
+namespace newtelligence.DasBlog.Runtime
+{
+	public static class CdnManagerFactory
+	{
+		public static ICdnManager GetService(string rootUri, string cdnUri)
+		{
+			return new CdnManager(rootUri, cdnUri);
+		}
+	}
+
+	internal sealed class CdnManager : ICdnManager
+	{
+		private readonly string rootUri;
+		private readonly string cdnUri;
+
+		/// <summary>
+		/// Setting up the cdn manager to return cdn uris when that is configured.
+		/// </summary>
+		/// <param name="rootUri">The root of the </param>
+		/// <param name="cdnUri"></param>
+		public CdnManager(string rootUri, string cdnUri)
+		{
+			this.rootUri = 
+				string.IsNullOrWhiteSpace(rootUri) || !Uri.TryCreate(rootUri, UriKind.Absolute, out _) ?
+				null :
+				rootUri;
+			this.cdnUri = 
+				string.IsNullOrWhiteSpace(cdnUri) || !Uri.TryCreate(cdnUri, UriKind.Absolute, out _) ? 
+				null : 
+				cdnUri;
+			if (this.rootUri == null) this.cdnUri = null;
+		}
+
+		public string ApplyCdnUri(string uri)
+		{
+			// If the cdnUri is null then we can just return the uri.
+			return cdnUri == null ? uri : uri.Replace(rootUri, cdnUri);
+		}
+	}
+}

--- a/source/newtelligence.DasBlog.Runtime/ICdnManager.cs
+++ b/source/newtelligence.DasBlog.Runtime/ICdnManager.cs
@@ -1,0 +1,16 @@
+﻿namespace newtelligence.DasBlog.Runtime
+{
+	/// <summary>
+	/// When the site is configured with a "CdnRoot" setting,
+	/// this manager is used to create content URIs for the CDN location.
+	/// </summary>
+	public interface ICdnManager
+	{
+		/// <summary>
+		/// Manages URI creation for resources when CDN is configured.
+		/// </summary>
+		/// <param name="uri">The URI of a file hosted locally.</param>
+		/// <returns>The URI of a file when it is hosted in CDN.</returns>
+		string ApplyCdnUri(string uri);
+	}
+}


### PR DESCRIPTION
This approach adds code to dasblog-core along exactly the same vein as the present code base.

However it feels slightly overworked, as the actual business logic change, other than one more site.config setting, ultimately is one line of code.

The alternate approach would be to inline the code change in the constructor of the FileSystemBinaryManager and set the CDN domain in the binaryRoot field. Happy to do either.

As I see it this extends an easy CDN option for those that wish to host their blog with a CDN. I will also add this in detail to the wiki documentation.