### PR TITLE
Fixed for WebFinger account validation

### DIFF
--- a/source/DasBlog.Web.Repositories/ActivityPubManager.cs
+++ b/source/DasBlog.Web.Repositories/ActivityPubManager.cs
@@ -97,22 +97,10 @@ namespace DasBlog.Managers
 			{
 				mastodonAccount = mastodonAccount.Remove(0, 1);
 			}
-
-			var address = new MailAddress(resource);
-			if (string.Compare(address.User, mastodonAccount, StringComparison.InvariantCultureIgnoreCase) != 0)
-			{
-				return null;
-			}
 		
 			if (!mastodonUrl.Contains("://"))
 			{
 				mastodonUrl = "https://" + mastodonUrl;
-			}
-
-			var host = new Uri(mastodonUrl);
-			if (string.Compare(address.Host, host.Host, StringComparison.InvariantCultureIgnoreCase) != 0)
-			{
-				return null;
 			}
 
 			var mastotonSiteUri = new Uri(mastodonUrl);


### PR DESCRIPTION
Removed validation so that the blog can support its own Web finger and redirecting to another federated server