### PR TITLE
First implementation of static pages as per #686.

### DIFF
--- a/source/DasBlog.Web.Repositories/BlogManager.cs
+++ b/source/DasBlog.Web.Repositories/BlogManager.cs
@@ -59,6 +59,11 @@ namespace DasBlog.Managers
 			}
 		}
 
+		public StaticPage GetStaticPage(string posttitle)
+		{
+			return dataService.GetStaticPage(posttitle);
+		}
+
 		public Entry GetBlogPostByGuid(Guid postid)
 		{
 			return dataService.GetEntry(postid.ToString());

--- a/source/DasBlog.Web.Repositories/Interfaces/IBlogManager.cs
+++ b/source/DasBlog.Web.Repositories/Interfaces/IBlogManager.cs
@@ -8,7 +8,7 @@ namespace DasBlog.Managers.Interfaces
     public interface IBlogManager
     {
         Entry GetBlogPost(string posttitle, DateTime? postDate);
-
+		StaticPage GetStaticPage(string posttitle);	
 		Entry GetBlogPostByGuid(Guid postid);
 
 		Entry GetEntryForEdit(string postid);

--- a/source/DasBlog.Web.UI/Controllers/BlogPostController.cs
+++ b/source/DasBlog.Web.UI/Controllers/BlogPostController.cs
@@ -41,6 +41,7 @@ namespace DasBlog.Web.Controllers
 		private readonly IExternalEmbeddingHandler embeddingHandler;
 		private readonly IRecaptchaService recaptcha;
 
+		
 		public BlogPostController(IBlogManager blogManager, IHttpContextAccessor httpContextAccessor, IDasBlogSettings dasBlogSettings,
 									IMapper mapper, ICategoryManager categoryManager, IFileSystemBinaryManager binaryManager, ILogger<BlogPostController> logger,
 									IBlogPostViewModelCreator modelViewCreator, IMemoryCache memoryCache, IExternalEmbeddingHandler embeddingHandler, IRecaptchaService recaptcha)
@@ -96,6 +97,14 @@ namespace DasBlog.Web.Controllers
 			}
 			else
 			{
+				// Post was not found. Let's see if it's a static page before we route user to home page.
+				var sp = blogManager.GetStaticPage(posttitle);
+				if(sp != null)	
+				{
+					var spvm = mapper.Map<StaticPageViewModel>(sp);
+					return View("LoadStaticPage", spvm);
+
+				}
 				return RedirectToAction("index", "home");
 			}
 		}

--- a/source/DasBlog.Web.UI/Mappers/ProfileSaticPages.cs
+++ b/source/DasBlog.Web.UI/Mappers/ProfileSaticPages.cs
@@ -1,0 +1,21 @@
+using AutoMapper;
+using DasBlog.Web.Models.BlogViewModels;
+using DasBlog.Core.Common;
+using DasBlog.Core.Extensions;
+using newtelligence.DasBlog.Runtime;
+using System.Collections.Generic;
+using System.Linq;
+using DasBlog.Services;
+using DasBlog.Core.Common.Comments;
+using DasBlog.Web.Models.AdminViewModels;
+
+namespace DasBlog.Web.Mappers
+{
+	public class ProfileStaticPage : Profile
+	{
+		public ProfileStaticPage()
+		{
+			CreateMap<StaticPage, StaticPageViewModel>();
+		}
+    }
+}

--- a/source/DasBlog.Web.UI/Models/BlogViewModels/StaticPageViewModel.cs
+++ b/source/DasBlog.Web.UI/Models/BlogViewModels/StaticPageViewModel.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Newtonsoft.Json;
+
+namespace DasBlog.Web.Models.BlogViewModels
+{
+	public class StaticPageViewModel
+	{
+		public string Name {get; set; }
+		
+		[DataType(DataType.MultilineText)]
+		public string Content { get; set; }
+
+	}
+}

--- a/source/DasBlog.Web.UI/Startup.cs
+++ b/source/DasBlog.Web.UI/Startup.cs
@@ -232,6 +232,7 @@ namespace DasBlog.Web
 					mapperConfig.AddProfile(new ProfileDasBlogUser(serviceProvider.GetService<ISiteSecurityManager>()));
 					mapperConfig.AddProfile(new ProfileSettings());
 					mapperConfig.AddProfile(new ProfileActivityPub());
+					mapperConfig.AddProfile(new ProfileStaticPage());
 				})
 				.AddMvc()
 				.AddXmlSerializerFormatters();

--- a/source/DasBlog.Web.UI/Views/BlogPost/LoadStaticPage.cshtml
+++ b/source/DasBlog.Web.UI/Views/BlogPost/LoadStaticPage.cshtml
@@ -1,0 +1,4 @@
+@model DasBlog.Web.Models.BlogViewModels.StaticPageViewModel
+@using DasBlog.Core.Common
+@Html.Raw(Model.Content)
+

--- a/source/newtelligence.DasBlog.Runtime/BlogDataService.cs
+++ b/source/newtelligence.DasBlog.Runtime/BlogDataService.cs
@@ -1421,5 +1421,21 @@ namespace newtelligence.DasBlog.Runtime
 
             return data.lastCommentUpdate;
         }
+
+        public StaticPage GetStaticPage( string pagename )
+        {
+            StaticPage page = new StaticPage();
+            page.Name = pagename;
+            string staticPathLocation = this.contentBaseDirectory + "\\static\\" + pagename + ".html";
+            if (File.Exists(staticPathLocation))
+            {
+                page.Content = File.ReadAllText(staticPathLocation);
+            }
+            else
+            {
+                return null;
+            }
+            return page;
+        }
     }
 }

--- a/source/newtelligence.DasBlog.Runtime/IBlogDataService.cs
+++ b/source/newtelligence.DasBlog.Runtime/IBlogDataService.cs
@@ -233,5 +233,7 @@ namespace newtelligence.DasBlog.Runtime
 		/// </summary>
 		/// <returns></returns>
 		DateTime GetLastCommentUpdate();
+
+		StaticPage GetStaticPage( string pagename );
 	}
 }

--- a/source/newtelligence.DasBlog.Runtime/StaticPage.cs
+++ b/source/newtelligence.DasBlog.Runtime/StaticPage.cs
@@ -1,0 +1,45 @@
+using NodaTime;
+using System;
+using System.Collections;
+using System.Globalization;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Xml;
+using System.Xml.Serialization;
+using System.Collections.Generic;
+
+namespace newtelligence.DasBlog.Runtime
+{
+	[Serializable]
+	[XmlRoot(Namespace=Data.NamespaceURI)]
+	[XmlType(Namespace=Data.NamespaceURI)]
+	public class StaticPage 
+	{
+        string _content;
+        string _name;
+
+        public string Name
+        {
+            get
+            {
+                return _name;
+            }
+            set
+            {
+                _name = value;
+            }
+        }
+        public string Content
+        {
+            get
+            {
+                return _content;
+            }
+            set
+            {
+                _content = value;
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Simple Implementation (v1):

This is the basic implementation as discussed in #686.

Once the merge is done testing is really simple. 

1. In your content folder, create a folder called "static" inside your content folder (wherever that is configured). e.g.
![image](https://github.com/poppastring/dasblog-core/assets/24845706/19cdf124-9e2f-4072-b71e-a25e06f164db)

2. Inside the static folder keep a ".html" file with simple HTML:
![image](https://github.com/poppastring/dasblog-core/assets/24845706/1e1302b0-3693-4016-b114-a9e02d984f84)

3. It can hold any static HTML:
![image](https://github.com/poppastring/dasblog-core/assets/24845706/c260f509-d56b-4f65-a6f4-a6e3098a8a2e)

4. Save the File, run the blog, and now replace ".html" either with ".aspx" or nothing (depending on your blog's routing scheme):
![image](https://github.com/poppastring/dasblog-core/assets/24845706/e6c1441b-5689-4ce6-85d6-44e0ff55162b)


5.  Of course if you are using aspx based URL scheme (older migrations of historic blogs with URLs retained) you can also retain the URL of your static page and use ".aspx" in the end:
![image](https://github.com/poppastring/dasblog-core/assets/24845706/401d5ac4-b007-4e83-bdbc-74acbf309413)

# Next Steps:

Once this PR is approved I will be working on:
1. Test Cases.
2. Caching (this would be better than reading from the file) - in the long run, we should do file-dependency caching so that files are not read till changes are made.
3. Maybe even a front end for creating and managing these pages? (if there is a real demand/need for that).
4. For now I've not removed the about-us implementation that already exists. I can remove it if we all agree that this feature makes that one redundant.

Please do let me know if any added changes are required. Happy to make those.
