### PR TITLE
Simplify the site initialization process

### DIFF
--- a/source/DasBlog.Services/Site/SiteHttpContext.cs
+++ b/source/DasBlog.Services/Site/SiteHttpContext.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace DasBlog.Services.Site
+{
+	public class SiteHttpContext
+	{
+		private static IHttpContextAccessor m_httpContextAccessor;
+
+		public static HttpContext Current => m_httpContextAccessor.HttpContext;
+
+		public static string AppBaseUrl => $"{Current.Request.Scheme}://{Current.Request.Host}{Current.Request.PathBase}";
+
+		internal static void Configure(IHttpContextAccessor contextAccessor)
+		{
+			m_httpContextAccessor = contextAccessor;
+		}
+	}
+
+	public static class HttpContextExtensions
+	{
+		public static IApplicationBuilder UseHttpContext(this IApplicationBuilder app)
+		{
+			SiteHttpContext.Configure(app.ApplicationServices.GetRequiredService<IHttpContextAccessor>());
+			return app;
+		}
+	}
+}

--- a/source/DasBlog.Web.UI/Config/site.config
+++ b/source/DasBlog.Web.UI/Config/site.config
@@ -3,7 +3,7 @@
 
   <!-- REQUIRED: Your blog will not work properly until you configure these settings. -->
   <!-- Set the Root to the base URL of this blog, such as http://example.com/blog/ -->
-  <Root>https://localhost:5001/</Root>
+  <Root></Root>
 
   <!-- NotificationEMailAddress is the address used by the system to send you event (blog posts, comment posts) notifications.
        This address will NOT be published on the website. -->

--- a/source/DasBlog.Web.UI/Settings/DasBlogSettings.cs
+++ b/source/DasBlog.Web.UI/Settings/DasBlogSettings.cs
@@ -78,12 +78,26 @@ namespace DasBlog.Web.Settings
 
 		public string GetBaseUrl()
 		{
-			return new Uri(SiteConfiguration.Root).AbsoluteUri;
+			if (!string.IsNullOrWhiteSpace(SiteConfiguration.Root))
+			{
+				return new Uri(SiteConfiguration.Root).AbsoluteUri;
+			}
+			else
+			{
+				return "/";
+			}
 		}
 
 		public string RelativeToRoot(string relative)
 		{
-			return new Uri(new Uri(SiteConfiguration.Root), relative).AbsoluteUri;
+			if (!string.IsNullOrWhiteSpace(SiteConfiguration.Root))
+			{
+				return new Uri(new Uri(GetBaseUrl()), relative).AbsoluteUri;
+			}
+			else
+			{
+				return relative;
+			}
 		}
 
         public string GetPermaLinkUrl(string entryId)

--- a/source/DasBlog.Web.UI/Startup.cs
+++ b/source/DasBlog.Web.UI/Startup.cs
@@ -208,6 +208,7 @@ namespace DasBlog.Web
 				.AddSingleton<ISiteManager, SiteManager>()
 				.AddSingleton<IActivityPubManager, ActivityPubManager>()
 				.AddSingleton<IHttpContextAccessor, HttpContextAccessor>()
+				.AddSingleton<SiteHttpContext>()
 				.AddSingleton<IFileSystemBinaryManager, FileSystemBinaryManager>()
 				.AddSingleton<IUserDataRepo, UserDataRepo>()
 				.AddSingleton<ISiteSecurityConfig, SiteSecurityConfig>()
@@ -297,8 +298,12 @@ namespace DasBlog.Web
 			app.UseRouting();
 
 			//if you've configured it at /blog or /whatever, set that pathbase so ~ will generate correctly
-			var rootUri = new Uri(dasBlogSettings.SiteConfiguration.Root);
-			var path = rootUri.AbsolutePath;
+			var path = "/";
+			if (!string.IsNullOrWhiteSpace(dasBlogSettings.SiteConfiguration.Root))
+			{
+				var rootUri = new Uri(dasBlogSettings.SiteConfiguration.Root);
+				path = rootUri.AbsolutePath;
+			}
 
 			//Deal with path base and proxies that change the request path
 			if (path != "/")
@@ -432,6 +437,8 @@ namespace DasBlog.Web
 				endpoints.MapControllerRoute(
 					name: "default", "~/{controller=Home}/{action=Index}/{id?}");
 			});
+
+			app.UseHttpContext();
 		}
 
 		/// <summary>

--- a/source/DasBlog.Web.UI/TagHelpers/Post/PostToFacebookTagHelper.cs
+++ b/source/DasBlog.Web.UI/TagHelpers/Post/PostToFacebookTagHelper.cs
@@ -24,7 +24,7 @@ namespace DasBlog.Web.TagHelpers
 			output.TagMode = TagMode.StartTagAndEndTag;
 			output.Attributes.SetAttribute("class", "dasblog-a-share-facebook");
 			output.Attributes.SetAttribute("href", string.Format(FACEBOOK_SHARE_URL, 
-				UrlEncoder.Default.Encode(new Uri(new Uri(dasBlogSettings.GetBaseUrl()), Post.PermaLink).AbsoluteUri)));
+				UrlEncoder.Default.Encode(dasBlogSettings.RelativeToRoot(Post.PermaLink))));
 
 			var content = await output.GetChildContentAsync();
 

--- a/source/DasBlog.Web.UI/TagHelpers/Post/PostToLinkedInTagHelper.cs
+++ b/source/DasBlog.Web.UI/TagHelpers/Post/PostToLinkedInTagHelper.cs
@@ -24,7 +24,7 @@ public class PostToLinkedInTagHelper : TagHelper
 		output.TagMode = TagMode.StartTagAndEndTag;
 		output.Attributes.SetAttribute("class", "dasblog-a-share-linkedin");
 		output.Attributes.SetAttribute("href", string.Format(LINKEDIN_SHARE_URL, 
-			UrlEncoder.Default.Encode(new Uri(new Uri(dasBlogSettings.GetBaseUrl()), Post.PermaLink).AbsoluteUri)));
+			UrlEncoder.Default.Encode(dasBlogSettings.RelativeToRoot(Post.PermaLink))));
 
 		var content = await output.GetChildContentAsync();
 

--- a/source/DasBlog.Web.UI/TagHelpers/Post/PostToRedditTagHelper.cs
+++ b/source/DasBlog.Web.UI/TagHelpers/Post/PostToRedditTagHelper.cs
@@ -24,7 +24,7 @@ namespace DasBlog.Web.TagHelpers.Post
 			output.TagMode = TagMode.StartTagAndEndTag;
 			output.Attributes.SetAttribute("class", "dasblog-a-share-reddit");
 			output.Attributes.SetAttribute("href", string.Format(REDDIT_SHARE_URL,
-								UrlEncoder.Default.Encode(new Uri(new Uri(dasBlogSettings.GetBaseUrl()), Post.PermaLink).AbsoluteUri),
+								UrlEncoder.Default.Encode(dasBlogSettings.RelativeToRoot(Post.PermaLink)),
 								UrlEncoder.Default.Encode(Post.Title)
 								));
 

--- a/source/DasBlog.Web.UI/TagHelpers/Post/PostToTwitterTagHelper.cs
+++ b/source/DasBlog.Web.UI/TagHelpers/Post/PostToTwitterTagHelper.cs
@@ -29,7 +29,7 @@ namespace DasBlog.Web.TagHelpers
 			output.Attributes.SetAttribute("class", "dasblog-a-share-twitter");
 
 			output.Attributes.SetAttribute("href", string.Format(TWITTER_SHARE_URL, 
-								UrlEncoder.Default.Encode(new Uri(new Uri(dasBlogSettings.GetBaseUrl()), Post.PermaLink).AbsoluteUri),
+								UrlEncoder.Default.Encode(dasBlogSettings.RelativeToRoot(Post.PermaLink)),
 								UrlEncoder.Default.Encode(Post.Title),
 								UrlEncoder.Default.Encode(author.TrimStart('@')), 
 								RetrieveFormattedCategories(Post.Categories)));


### PR DESCRIPTION
The assumption is that upon first deployment the site will start up without a root URL defined.
dasblog will allow you to login and change the root url through the web page and update the root URL.
Some functions will still not work so this should still be the first thing you do.