### PR TITLE
Change RecaptchaMinimumScore from input text to number to solve #706

### DIFF
--- a/source/DasBlog.Web.UI/Views/Admin/Settings.cshtml
+++ b/source/DasBlog.Web.UI/Views/Admin/Settings.cshtml
@@ -341,7 +341,7 @@
 
         @Html.LabelFor(m => @Model.SiteConfig.RecaptchaMinimumScore, null, new { @class = "col-form-label col-sm-2" })
         <div class="col-sm-2">
-            @Html.TextBoxFor(m => @Model.SiteConfig.RecaptchaMinimumScore, null, new { @class = "form-control sm-10" })
+            @Html.TextBoxFor(m => @Model.SiteConfig.RecaptchaMinimumScore, null, new { type = "number", step="0.1", @class = "form-control sm-10" })
         </div>
         @Html.ValidationMessageFor(m => m.SiteConfig.RecaptchaMinimumScore, null, new { @class = "text-danger" })
 


### PR DESCRIPTION
Using type="number" will ensure that the decimal symbol is always a dot, which will prevent that the validation will fail when the server is running on a non en-us configuration. The HTML input element type="number" also display a spinner, The default step size is 1, changed it to .1 to make the spinner useful.

Remark 1: the input element number also provides min/max settings to limit the user input. A custom HtmlHelperExtensions would be needed however to extract the range values from the model to set these values. Adding min/max manuallly in the .cshtml file is also possible but would duplicate the configuration SiteViewModel. Client validation will also ensure the range, so no functionality is lost.

Remark 2: an alternative would be change the page to use ASP.NET Tag Helpers (asp-for), which is used in some other pages of DasBlog, but this change would be much larger.