### PR TITLE
Cryptographic method cleanup

### DIFF
--- a/source/DasBlog.Web.Core/Common/Utils.cs
+++ b/source/DasBlog.Web.Core/Common/Utils.cs
@@ -14,7 +14,7 @@ namespace DasBlog.Core.Common
 
 			data = Encoding.Default.GetBytes(email.ToLowerInvariant());
 
-			using (MD5 md5 = new MD5CryptoServiceProvider())
+			using (MD5 md5 = MD5.Create())
 			{
 				enc = md5.TransformFinalBlock(data, 0, data.Length);
 				foreach (byte b in md5.Hash)

--- a/source/DasBlog.Web.Repositories/SiteSecurityManager.cs
+++ b/source/DasBlog.Web.Repositories/SiteSecurityManager.cs
@@ -1,5 +1,4 @@
-﻿
-using DasBlog.Core.Security;
+﻿using DasBlog.Core.Security;
 using DasBlog.Managers.Interfaces;
 using DasBlog.Services;
 using System;
@@ -20,7 +19,7 @@ namespace DasBlog.Managers
 
 		public string HashPassword(string password)
 		{
-			var hashAlgorithm = SHA512Managed.Create();
+			var hashAlgorithm = SHA512.Create();
 			return HashPassword(password, hashAlgorithm);
 		}
 
@@ -42,10 +41,10 @@ namespace DasBlog.Managers
 		{
 			string hashprovidedpassword = string.Empty;
 
-			HashAlgorithm hashAlgorithm = SHA512Managed.Create();
+			HashAlgorithm hashAlgorithm = SHA512.Create();
 			if (this.IsMd5Hash(hashedPassword))
 			{
-				hashAlgorithm = MD5CryptoServiceProvider.Create();
+				hashAlgorithm = MD5.Create();
 			}
 
 			hashprovidedpassword = HashPassword(providedPassword, hashAlgorithm);


### PR DESCRIPTION
#### PR Classification
Code cleanup and modernization of cryptographic method usage.

#### PR Summary
This pull request updates cryptographic method instantiations to use modern factory methods and removes redundant code.
- `Utils.cs`: Replaced `MD5CryptoServiceProvider` with `MD5.Create()` in `GetGravatarHash`.
- `SiteSecurityManager.cs`: Removed duplicate `using` directive and replaced `SHA512Managed.Create()` with `SHA512.Create()` and `MD5CryptoServiceProvider.Create()` with `MD5.Create()` in relevant methods.

Closes #724 #723 