### PR TITLE
Refactor FindHeroImage to return URL and alt attributes

### DIFF
--- a/source/DasBlog.Tests/UnitTests/UI/StringExtensionTest.cs
+++ b/source/DasBlog.Tests/UnitTests/UI/StringExtensionTest.cs
@@ -11,31 +11,66 @@ namespace DasBlog.Tests.UnitTests.Misc
 		[Trait("StringExtension", "UnitTest")]
 		public void FindHeroImage_ReturnsHeroImage_WhenHeroImageExists()
 		{
-			string blogContent = "<img class=\"hero-image\" src=\"image.jpg\">";
-			string result = blogContent.FindHeroImage();
+			string blogContent = "<img src=\"incorrect.jpg\" /> <img class=\"hero-image\" src=\"image.jpg\" alt=\"hero alt\">";
+			var result = blogContent.FindHeroImage();
 
-			Assert.Equal("image.jpg", result);
+			Assert.Equal("image.jpg", result.url);
+			Assert.Equal("hero alt", result.alt);
+		}
+
+		[Fact]
+		[Trait("StringExtension", "UnitTest")]
+		public void FindHeroImage_ReturnsHeroImage_MoreThanOneClassHeroNotFirst()
+		{
+			string blogContent = "<img src=\"incorrect.jpg\" /> <img class=\"somestyle hero-image\" src=\"image.jpg\" alt=\"hero alt\">";
+			var result = blogContent.FindHeroImage();
+
+			Assert.Equal("image.jpg", result.url);
+			Assert.Equal("hero alt", result.alt);
+		}
+
+		[Fact]
+		[Trait("StringExtension", "UnitTest")]
+		public void FindHeroImage_ReturnsHeroImage_WhenClassIsNotFirst()
+		{
+			string blogContent = "<img src=\"incorrect.jpg\" /> <img src=\"image2.jpg\" alt=\"alt2\" class=\"hero-image\">";
+			var result = blogContent.FindHeroImage();
+
+			Assert.Equal("image2.jpg", result.url);
+			Assert.Equal("alt2", result.alt);
+		}
+
+		[Fact]
+		[Trait("StringExtension", "UnitTest")]
+		public void FindHeroImage_ReturnsHeroImage_WithoutAlt()
+		{
+			string blogContent = "<img src=\"incorrect.jpg\" /> <img class=\"hero-image\" src=\"image3.jpg\">";
+			var result = blogContent.FindHeroImage();
+
+			Assert.Equal("image3.jpg", result.url);
+			Assert.Equal(string.Empty, result.alt);
 		}
 
 		[Fact]
 		[Trait("StringExtension", "UnitTest")]
 		public void FindHeroImage_ReturnsFirstImage_WhenHeroImageDoesNotExist()
 		{
-			string blogContent = "<img src=\"image.jpg\">";
-			string result = blogContent.FindHeroImage();
+			string blogContent = "<img src=\"fallback.jpg\" /> <img src=\"image.jpg\" alt=\"first alt\">";
+			var result = blogContent.FindHeroImage();
 
-			Assert.Equal("image.jpg", result);
+			Assert.Equal("fallback.jpg", result.url);
+			Assert.Equal(string.Empty, result.alt); // alt is not returned for fallback
 		}
 
 		[Fact]
 		[Trait("StringExtension", "UnitTest")]
 		public void FindHeroImage_ReturnsNoImage_WhenNoImageExist()
 		{
-			string blogContent = "<p>This is some test...</p";
-			string result = blogContent.FindHeroImage();
+			string blogContent = "<p>This is some test...</p>";
+			var result = blogContent.FindHeroImage();
 
-			Assert.Empty(result);
+			Assert.Equal(string.Empty, result.url);
+			Assert.Equal(string.Empty, result.alt);
 		}
-
 	}
 }

--- a/source/DasBlog.Web.Core/Extensions/StringExtensions.cs
+++ b/source/DasBlog.Web.Core/Extensions/StringExtensions.cs
@@ -97,26 +97,36 @@ namespace DasBlog.Core.Extensions
 			return firstimage.Trim();
 		}
 
-		public static string FindHeroImage(this string blogcontent)
-		{
-			var heroImage = string.Empty;
+        public static (string url, string alt) FindHeroImage(this string blogcontent)
+        {
+            string heroSrc = string.Empty;
+            string heroAlt = string.Empty;
 
-			var regex = new Regex("<img[^>]*class=\"hero-image\"[^>]*src=\"([^\"]+)\"[^>]*>", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            // Match <img> tag with class containing 'hero-image'
+            var imgTagRegex = new Regex("<img[^>]*class\\s*=\\s*\"[^\"]*hero-image[^\"]*\"[^>]*>", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+            var imgTagMatch = imgTagRegex.Match(blogcontent);
 
-			var match = regex.Match(blogcontent);
+            if (imgTagMatch.Success)
+            {
+                string imgTag = imgTagMatch.Value;
+                // Extract src and alt from the matched tag, regardless of order
+                var srcRegex = new Regex("src\\s*=\\s*\"([^\"]+)\"", RegexOptions.IgnoreCase);
+                var altRegex = new Regex("alt\\s*=\\s*\"([^\"]*)\"", RegexOptions.IgnoreCase);
+                var srcMatch = srcRegex.Match(imgTag);
+                var altMatch = altRegex.Match(imgTag);
+                if (srcMatch.Success)
+                    heroSrc = srcMatch.Groups[1].Value.Trim();
+                if (altMatch.Success)
+                    heroAlt = altMatch.Groups[1].Value.Trim();
+            }
 
-			if (match.Success)
-			{
-				heroImage = match.Groups[1].Value.Trim();
-			}
+            if (string.IsNullOrEmpty(heroSrc))
+            {
+                heroSrc = FindFirstImage(blogcontent);
+            }
 
-			if (string.IsNullOrEmpty(heroImage))
-			{
-				heroImage = FindFirstImage(blogcontent);
-			}
-
-			return heroImage;
-		}
+            return (heroSrc, heroAlt);
+        }
 
 		public static string FindFirstYouTubeVideo(this string blogcontent)
 		{

--- a/source/DasBlog.Web.UI/Mappers/ProfilePost.cs
+++ b/source/DasBlog.Web.UI/Mappers/ProfilePost.cs
@@ -33,7 +33,8 @@ namespace DasBlog.Web.Mappers
 				.ForMember(dest => dest.IsPublic, opt => opt.MapFrom(src => src.IsPublic))
 				.ForMember(dest => dest.Syndicated, opt => opt.MapFrom(src => src.Syndicated))
 				.ForMember(dest => dest.PermaLink, opt => opt.MapFrom(src => _dasBlogSettings.GeneratePostUrl(src)))
-				.ForMember(dest => dest.ImageUrl, opt => opt.MapFrom(src => src.Content.FindHeroImage()))
+				.ForMember(dest => dest.ImageUrl, opt => opt.MapFrom(src => src.Content.FindHeroImage().url))
+				.ForMember(dest => dest.ImageAlt, opt => opt.MapFrom(src => src.Content.FindHeroImage().alt))
 				.ForMember(dest => dest.VideoUrl, opt => opt.MapFrom(src => src.Content.FindFirstYouTubeVideo()))
 				.ForMember(dest => dest.CreatedDateTime, opt => opt.MapFrom(src => _dasBlogSettings.GetDisplayTime(src.CreatedUtc)))
 				.ForMember(dest => dest.ModifiedDateTime, opt => opt.MapFrom(src => _dasBlogSettings.GetDisplayTime(src.ModifiedUtc)));

--- a/source/DasBlog.Web.UI/Models/BlogViewModels/PostViewModel.cs
+++ b/source/DasBlog.Web.UI/Models/BlogViewModels/PostViewModel.cs
@@ -60,7 +60,8 @@ namespace DasBlog.Web.Models.BlogViewModels
 
 		public int Order { get; set; } = 0;
 
-
 		public List<string> ErrorMessages { get; set; }
+
+		public string ImageAlt { get; set; } = string.Empty;
 	}
 }


### PR DESCRIPTION
Refactor FindHeroImage to return URL and alt attributes

Refactored the `FindHeroImage` method in `StringExtensions.cs` to return a tuple `(string url, string alt)` instead of a single string, enabling extraction of both `src` and `alt` attributes from hero images. Updated regex logic to handle flexible attribute orders in `<img>` tags.

Enhanced unit tests in `StringExtensionTest.cs` to validate the new tuple-based implementation and added test cases for various scenarios, including missing `alt` attributes and fallback behavior.

Updated `ProfilePost.cs` to map `ImageUrl` and `ImageAlt` using the new tuple result. Added a new `ImageAlt` property in `PostViewModel.cs` to store the `alt` attribute of hero images.

These changes improve flexibility, robustness, and test coverage for handling hero images in blog content.