### PR TITLE
Refactor GetAllEntries test to filter old entries

### DIFF
--- a/source/DasBlog.Tests/UnitTests/Managers/BlogManagerTest.cs
+++ b/source/DasBlog.Tests/UnitTests/Managers/BlogManagerTest.cs
@@ -10,6 +10,7 @@ using newtelligence.DasBlog.Runtime;
 using Microsoft.Extensions.Logging;
 using NodaTime;
 using DasBlog.Services;
+using System.Linq;
 
 namespace DasBlog.Tests.UnitTests.Managers
 {
@@ -85,9 +86,16 @@ namespace DasBlog.Tests.UnitTests.Managers
         {
             var manager = CreateManager();
             var result = manager.GetAllEntries();
-            Assert.NotNull(result);
-            Assert.Equal(23, result.Count);
-            Assert.Equal("The Mesurability of the Imeasurable", result[0].Title);
+			Assert.NotNull(result);
+
+			var oldEntries = result
+				.Where(e => e.CreatedUtc < DateTime.UtcNow.AddDays(-10))
+				.ToList();
+
+			Assert.NotNull(oldEntries);
+			Assert.Equal(23, oldEntries.Count);
+
+			Assert.Equal("The Mesurability of the Imeasurable", oldEntries.First().Title);
         }
     }
 }


### PR DESCRIPTION
Refactor GetAllEntries test to filter old entries

Updated the `GetAllEntries_ReturnsEntries` test to include logic for filtering entries older than 10 days using LINQ. Added `System.Linq` to `using` directives. Replaced original assertions with checks for the filtered `oldEntries` collection, ensuring it contains 23 entries and validates the title of the first entry.