### PR TITLE
Improve category dropdown by separating display and value

### DIFF
--- a/source/DasBlog.Web.UI/Models/AdminViewModels/CategoryListViewModel.cs
+++ b/source/DasBlog.Web.UI/Models/AdminViewModels/CategoryListViewModel.cs
@@ -6,13 +6,15 @@ namespace DasBlog.Web.Models.AdminViewModels
 {
 	public class CategoryListViewModel
 	{
+		public string Name { get; set; }
+
 		public string Category { get; set; }
 
 		public List<CategoryListViewModel> Init(List<string> categories)
 		{
-			var allposts = categories.Select(p => new CategoryListViewModel { Category = p}).ToList();
+			var allposts = categories.Select(p => new CategoryListViewModel { Name = p, Category = p}).ToList();
 
-			allposts.Insert(0, new CategoryListViewModel { Category = "--Disable Home Category--"});
+			allposts.Insert(0, new CategoryListViewModel { Name = "--Disable Home Category--", Category = "" });
 
 			return allposts;
 		}

--- a/source/DasBlog.Web.UI/Views/Shared/_Admin_FrontPage.cshtml
+++ b/source/DasBlog.Web.UI/Views/Shared/_Admin_FrontPage.cshtml
@@ -41,7 +41,7 @@
     <div class="col-sm-4">
         <div class="form-floating">            
             @Html.DropDownListFor(n => n.SiteConfig.FrontPageCategory,
-                        new SelectList(new DasBlog.Web.Models.AdminViewModels.CategoryListViewModel().Init(blogManager.GetCategories().Select(p => p.Name).ToList()), "Category", "Category"),
+                        new SelectList(new DasBlog.Web.Models.AdminViewModels.CategoryListViewModel().Init(blogManager.GetCategories().Select(p => p.Name).ToList()), "Category", "Name"),
                         new { @class = "form-select", id = "frontPageCategory" })
 
             @Html.LabelFor(m => @Model.SiteConfig.FrontPageCategory, null, new { @class = "form-label", @for = "frontPageCategory" })


### PR DESCRIPTION
Improve category dropdown by separating display and value

Updated CategoryListViewModel to include a Name property for display purposes, and adjusted the Init method to set both Name and Category. Modified the admin front page dropdown to use Name as the display text and Category as the value, and set the "Disable Home Category" option to have an empty value. This enhances clarity and flexibility in the category selection UI.