### PR TITLE
Add null/whitespace check for post title validation

### DIFF
--- a/source/DasBlog.Web.UI/Controllers/BlogPostController.cs
+++ b/source/DasBlog.Web.UI/Controllers/BlogPostController.cs
@@ -23,6 +23,7 @@ using Markdig;
 using DasBlog.Core.Extensions;
 using System.Text.RegularExpressions;
 using DasBlog.Services.Site;
+using Quartz.Util;
 
 namespace DasBlog.Web.Controllers
 {
@@ -668,6 +669,11 @@ namespace DasBlog.Web.Controllers
 
 		private void ValidatePostName(PostViewModel post)
 		{
+			if(post.Title.IsNullOrWhiteSpace())
+			{
+				return;
+			}
+
 			var dt = ValidatePostDate(post);
 			var entry = blogManager.GetBlogPost(post.Title.Replace(" ", string.Empty), dt);
 


### PR DESCRIPTION
Add null/whitespace check for post title validation

Prevent validation if post title is missing or empty by adding an early return in ValidatePostName. Import Quartz.Util to use IsNullOrWhiteSpace extension method. This avoids errors and unnecessary processing for invalid titles.