### PR TITLE
Fixed existing About page feature

### DIFF
--- a/source/DasBlog.Web.UI/Config/site.Development.config
+++ b/source/DasBlog.Web.UI/Config/site.Development.config
@@ -101,12 +101,11 @@
   <TitlePermalinkSpaceReplacement>-</TitlePermalinkSpaceReplacement>
   <UseAspxExtension>false</UseAspxExtension>
 
-  <EntryEditControl>Froala</EntryEditControl>
   <!-- TinyMce, NicEdit, TextArea or Froala -->
+  <EntryEditControl>Froala</EntryEditControl>
   <TinyMCEApiKey>no-api-key</TinyMCEApiKey>
+  
   <EnableBloggerApi>true</EnableBloggerApi>
-
-
 
   <EnableDailyReportEmail>false</EnableDailyReportEmail>
   <SendCommentsByEmail>false</SendCommentsByEmail>

--- a/source/DasBlog.Web.UI/Config/site.Development.config
+++ b/source/DasBlog.Web.UI/Config/site.Development.config
@@ -124,6 +124,8 @@
   <SecurityStyleSources>cloud.tinymce.com;cdn.tiny.cloud;cdn.jsdelivr.net;js.nicedit.com;www.google.com;platform.twitter.com;cdn.syndication.twimg.com;fonts.googleapis.com;maxcdn.bootstrapcdn.com</SecurityStyleSources>
   <SecurityScriptSources>cloud.tinymce.com;cdn.tiny.cloud;cdn.jsdelivr.net;js.nicedit.com;www.google.com;cse.google.com;cdn.syndication.twimg.com;platform.twitter.com;apis.google.com;www.google-analytics.com;www.googletagservices.com;adservice.google.com;securepubads.g.doubleclick.net;ajax.aspnetcdn.com;ssl.google-analytics.com</SecurityScriptSources>
 
+  <EnableAboutView>false</EnableAboutView>
+  
   <!-- Settings below this line are not currently in use -->
   <!-- _________________________________________________ -->
   <CommentsAllowHtml>true</CommentsAllowHtml>

--- a/source/DasBlog.Web.UI/Config/site.config
+++ b/source/DasBlog.Web.UI/Config/site.config
@@ -113,12 +113,11 @@
   <TitlePermalinkSpaceReplacement>-</TitlePermalinkSpaceReplacement>
   <UseAspxExtension>false</UseAspxExtension>
 
-  <EntryEditControl>TinyMce</EntryEditControl>
   <!-- TinyMce, NicEdit, TextArea or Froala -->
+  <EntryEditControl>TinyMce</EntryEditControl>
   <TinyMCEApiKey>no-api-key</TinyMCEApiKey>
+  
   <EnableBloggerApi>true</EnableBloggerApi>
-
-
 
   <EnableDailyReportEmail>false</EnableDailyReportEmail>
   <SendCommentsByEmail>false</SendCommentsByEmail>
@@ -137,6 +136,8 @@
   <SecurityStyleSources>cloud.tinymce.com;cdn.tiny.cloud;cdn.jsdelivr.net;js.nicedit.com;www.google.com;platform.twitter.com;cdn.syndication.twimg.com;fonts.googleapis.com;maxcdn.bootstrapcdn.com</SecurityStyleSources>
   <SecurityScriptSources>cloud.tinymce.com;cdn.tiny.cloud;cdn.jsdelivr.net;js.nicedit.com;www.google.com;cse.google.com;cdn.syndication.twimg.com;platform.twitter.com;apis.google.com;www.google-analytics.com;www.googletagservices.com;adservice.google.com;securepubads.g.doubleclick.net;ajax.aspnetcdn.com;ssl.google-analytics.com</SecurityScriptSources>
 
+  <EnableAboutView>false</EnableAboutView>
+  
   <!-- Settings below this line are not currently in use -->
   <!-- _________________________________________________ -->
   <CommentsAllowHtml>true</CommentsAllowHtml>

--- a/source/DasBlog.Web.UI/Controllers/HomeController.cs
+++ b/source/DasBlog.Web.UI/Controllers/HomeController.cs
@@ -107,6 +107,7 @@ namespace DasBlog.Web.Controllers
 			return AggregatePostView(lpvm);
 		}
 
+		[HttpGet("about")]
 		public IActionResult About()
 		{
 			if (dasBlogSettings.SiteConfiguration.EnableAboutView)


### PR DESCRIPTION
#### PR Classification
Fixed existing About page feature.

#### PR Summary
This pull request adds support for an optional "About" page, controlled via configuration. 
- HomeController.cs: Adds a new `/about` endpoint that renders the About page if enabled in configuration.
- site.config and site.Development.config: Introduce `<EnableAboutView>`.
