### PR TITLE
Prefill admin info in comment reply form

### DIFF
--- a/source/DasBlog.Web.UI/Controllers/AdminController.cs
+++ b/source/DasBlog.Web.UI/Controllers/AdminController.cs
@@ -30,10 +30,11 @@ namespace DasBlog.Web.Controllers
 		private readonly IHostApplicationLifetime appLifetime;
 		private readonly ILogger<AdminController> logger;
 		private readonly IMemoryCache memoryCache;
+		private readonly ISiteSecurityManager siteSecurityManager;
 		private readonly List<PostViewModel> posts = [];	
 
 		public AdminController(IDasBlogSettings dasBlogSettings, IFileSystemBinaryManager fileSystemBinaryManager, IMapper mapper,
-								IBlogManager blogManager, IHostApplicationLifetime appLifetime, ILogger<AdminController> logger, IMemoryCache memoryCache) : base(dasBlogSettings)
+								IBlogManager blogManager, IHostApplicationLifetime appLifetime, ILogger<AdminController> logger, IMemoryCache memoryCache, ISiteSecurityManager siteSecurityManager) : base(dasBlogSettings)
 		{
 			this.dasBlogSettings = dasBlogSettings;
 			this.fileSystemBinaryManager = fileSystemBinaryManager;
@@ -42,6 +43,7 @@ namespace DasBlog.Web.Controllers
 			this.appLifetime = appLifetime;
 			this.logger = logger;
 			this.memoryCache = memoryCache;
+			this.siteSecurityManager = siteSecurityManager;
 			this.posts = blogManager.GetAllEntries()
 								.Select(entry => mapper.Map<PostViewModel>(entry)).ToList();
 		}
@@ -125,6 +127,13 @@ namespace DasBlog.Web.Controllers
 				cmt.Title = blogManager.GetBlogPostByGuid(new Guid(cmt.BlogPostId))?.Title;
 			}
 
+			var currentUser = siteSecurityManager.GetUserByDisplayName(User.Identity?.Name);
+
+			// Pass user information to the view
+			ViewData["CurrentUserDisplayName"] = currentUser?.DisplayName;
+			ViewData["CurrentUserEmail"] = currentUser?.EmailAddress;
+			ViewData["CurrentUserHomePage"] = dasBlogSettings.SiteConfiguration.Root;
+
 			ViewData[Constants.CommentPageNumber] = 0;
 			ViewData[Constants.CommentPostCount] = 5;
 			return View(comments.OrderByDescending(d => d.Date).ToList());
@@ -150,6 +159,13 @@ namespace DasBlog.Web.Controllers
 			{
 				cmt.Title = blogManager.GetBlogPostByGuid(new Guid(cmt.BlogPostId))?.Title;
 			}
+
+			var currentUser = siteSecurityManager.GetUserByDisplayName(User.Identity?.Name);
+
+			// Pass user information to the view
+			ViewData["CurrentUserDisplayName"] = currentUser?.DisplayName;
+			ViewData["CurrentUserEmail"] = currentUser?.EmailAddress;
+			ViewData["CurrentUserHomePage"] = dasBlogSettings.SiteConfiguration.Root;
 
 			ViewData[Constants.CommentShowPageControl] = true;
 			ViewData[Constants.CommentPostCount] = 5;

--- a/source/DasBlog.Web.UI/Views/Admin/ManageComments.cshtml
+++ b/source/DasBlog.Web.UI/Views/Admin/ManageComments.cshtml
@@ -87,15 +87,15 @@
                     <input type="hidden" id="replyTargetEntryId" name="TargetEntryId" />
                     <div class="mb-3">
                         <label for="replyName" class="form-label">Name</label>
-                        <input type="text" class="form-control" id="replyName" name="Name" value="@dasBlogSettings.SiteConfiguration.Copyright" readonly />
+                        <input type="text" class="form-control" id="replyName" name="Name" value="@ViewData["CurrentUserDisplayName"]" readonly />
                     </div>
                     <div class="mb-3">
                         <label for="replyEmail" class="form-label">Email</label>
-                        <input type="email" class="form-control" id="replyEmail" name="Email" value="@dasBlogSettings.SiteConfiguration.Contact" readonly />
+                        <input type="email" class="form-control" id="replyEmail" name="Email" value="@ViewData["CurrentUserEmail"]" readonly />
                     </div>
                     <div class="mb-3">
                         <label for="replyHomePage" class="form-label">Homepage</label>
-                        <input type="url" class="form-control" id="replyHomePage" name="HomePage" value="@dasBlogSettings.SiteConfiguration.Root" readonly />
+                        <input type="url" class="form-control" id="replyHomePage" name="HomePage" value="@ViewData["CurrentUserHomePage"]" readonly />
                     </div>
                     <div class="mb-3">
                         <label for="replyContent" class="form-label">Comment <span class="text-danger">*</span></label>


### PR DESCRIPTION
Prefill admin info in comment reply form

AdminController now uses ISiteSecurityManager to fetch the current user's display name and email, passing them to the ManageComments view. The reply form in ManageComments.cshtml now pre-fills Name, Email, and Homepage fields with the admin's info, improving accuracy and personalization for comment replies.