### PR TITLE
Remove EnableAboutView and About page functionality

### DIFF
--- a/source/DasBlog.Services/ConfigFile/Interfaces/ISiteConfig.cs
+++ b/source/DasBlog.Services/ConfigFile/Interfaces/ISiteConfig.cs
@@ -101,7 +101,6 @@ namespace DasBlog.Services.ConfigFile.Interfaces
         bool SendPingbacksByEmail { get; set; }
 
         bool SendPostsByEmail { get; set; }
-        bool EnableAboutView { get; set; }
 
         string TinyMCEApiKey { get; set; }
         

--- a/source/DasBlog.Services/ConfigFile/SiteConfig.cs
+++ b/source/DasBlog.Services/ConfigFile/SiteConfig.cs
@@ -100,7 +100,6 @@ namespace DasBlog.Services.ConfigFile
         public bool SendTrackbacksByEmail { get; set; }
         public bool SendPingbacksByEmail { get; set; }
         public bool SendPostsByEmail { get; set; }
-        public bool EnableAboutView { get; set; }
         public string TinyMCEApiKey { get; set; }
         public bool EnableBloggerApi { get; set; }
         public bool EnableComments { get; set; }

--- a/source/DasBlog.Tests/UnitTests/SiteConfigTest.cs
+++ b/source/DasBlog.Tests/UnitTests/SiteConfigTest.cs
@@ -37,7 +37,6 @@ namespace DasBlog.Tests.UnitTests
 		public bool SendTrackbacksByEmail { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 		public bool SendPingbacksByEmail { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 		public bool SendPostsByEmail { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-		public bool EnableAboutView { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 		public bool EnableBloggerApi { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 		public string TinyMCEApiKey { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 		public bool EnableComments { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }

--- a/source/DasBlog.Web/Config/site.Development.config
+++ b/source/DasBlog.Web/Config/site.Development.config
@@ -123,8 +123,6 @@
   <DefaultSources>data:;https:;wss:</DefaultSources>
   <SecurityStyleSources>cloud.tinymce.com;cdn.tiny.cloud;cdn.jsdelivr.net;js.nicedit.com;www.google.com;platform.twitter.com;cdn.syndication.twimg.com;fonts.googleapis.com;maxcdn.bootstrapcdn.com</SecurityStyleSources>
   <SecurityScriptSources>cloud.tinymce.com;cdn.tiny.cloud;cdn.jsdelivr.net;js.nicedit.com;www.google.com;cse.google.com;cdn.syndication.twimg.com;platform.twitter.com;apis.google.com;www.google-analytics.com;www.googletagservices.com;adservice.google.com;securepubads.g.doubleclick.net;ajax.aspnetcdn.com;ssl.google-analytics.com</SecurityScriptSources>
-
-  <EnableAboutView>false</EnableAboutView>
   
   <!-- Settings below this line are not currently in use -->
   <!-- _________________________________________________ -->

--- a/source/DasBlog.Web/Config/site.config
+++ b/source/DasBlog.Web/Config/site.config
@@ -134,8 +134,6 @@
   <DefaultSources>data:;https:</DefaultSources>
   <SecurityStyleSources>cloud.tinymce.com;cdn.tiny.cloud;cdn.jsdelivr.net;js.nicedit.com;www.google.com;platform.twitter.com;cdn.syndication.twimg.com;fonts.googleapis.com;maxcdn.bootstrapcdn.com</SecurityStyleSources>
   <SecurityScriptSources>cloud.tinymce.com;cdn.tiny.cloud;cdn.jsdelivr.net;js.nicedit.com;www.google.com;cse.google.com;cdn.syndication.twimg.com;platform.twitter.com;apis.google.com;www.google-analytics.com;www.googletagservices.com;adservice.google.com;securepubads.g.doubleclick.net;ajax.aspnetcdn.com;ssl.google-analytics.com</SecurityScriptSources>
-
-  <EnableAboutView>false</EnableAboutView>
   
   <!-- Settings below this line are not currently in use -->
   <!-- _________________________________________________ -->

--- a/source/DasBlog.Web/Controllers/HomeController.cs
+++ b/source/DasBlog.Web/Controllers/HomeController.cs
@@ -101,17 +101,6 @@ namespace DasBlog.Web.Controllers
 			return AggregatePostView(lpvm);
 		}
 
-		[HttpGet("about")]
-		public IActionResult About()
-		{
-			if (dasBlogSettings.SiteConfiguration.EnableAboutView)
-			{
-				DefaultPage("About");
-				return View();
-			}
-			return NoContent();
-		}
-
 		public IActionResult Error()
 		{
 			try

--- a/source/DasBlog.Web/Mappers/ProfilePost.cs
+++ b/source/DasBlog.Web/Mappers/ProfilePost.cs
@@ -111,6 +111,8 @@ namespace DasBlog.Web.Mappers
 			CreateMap<ValidCommentTagsViewModel, ValidCommentTags>()
 				.ForMember(dest => dest.Tag, opt => opt.MapFrom(src => src.Tag));
 
+			CreateMap<StaticPage, StaticPageViewModel>();
+
 		}
 
 		private IList<CategoryViewModel> ConvertCategory(string category)

--- a/source/DasBlog.Web/Models/AdminViewModels/SiteViewModel.cs
+++ b/source/DasBlog.Web/Models/AdminViewModels/SiteViewModel.cs
@@ -85,10 +85,6 @@ namespace DasBlog.Web.Models.AdminViewModels
 		[Description("This allows you to design a summary view for each blog post on the home page")]
 		public bool ShowItemSummaryInAggregatedViews { get; set; }
 
-		[DisplayName("Enable the About page ")]
-		[Description("This enables the Home/About view and allows you to customize this in the site theme.")]
-		public bool EnableAboutView { get; set; }
-
 		[DisplayName("RSS day count")]
 		[Description("Maximum number of days to appear in your RSS feed")]
 		[Required(AllowEmptyStrings = false, ErrorMessage = "Enter a value for RSS Day Count")]

--- a/source/DasBlog.Web/Views/Home/About.cshtml
+++ b/source/DasBlog.Web/Views/Home/About.cshtml
@@ -1,4 +1,0 @@
-﻿<h2>@ViewData["PageTitle"]</h2>
-<h3><site-sub-title/></h3>
-
-<p><site-description/></p>

--- a/source/DasBlog.Web/Views/Shared/_Admin_General.cshtml
+++ b/source/DasBlog.Web/Views/Shared/_Admin_General.cshtml
@@ -70,8 +70,3 @@
     </div>
     @Html.ValidationMessageFor(m => m.SiteConfig.Theme, null, new { @class = "text-danger" })
 </div>
-
-<div class="col-md-4 form-check-inline">
-    <input name="EnableAboutView" checked="@Model.SiteConfig.EnableAboutView" type="checkbox" class="form-check-input me-1" disabled readonly />
-    <label asp-for="SiteConfig.EnableAboutView" class="form-check-label me-3"></label>
-</div>


### PR DESCRIPTION
Remove EnableAboutView and About page functionality

Removed all code, config, and UI related to EnableAboutView and the About page, including properties, settings, controller action, view, and admin UI. Also added AutoMapper mapping for StaticPage to StaticPageViewModel.