### PR TITLE
Improvement for time zone handling

### DIFF
--- a/source/DasBlog.Managers/XmlRpcManager.cs
+++ b/source/DasBlog.Managers/XmlRpcManager.cs
@@ -477,8 +477,6 @@ namespace DasBlog.Managers
 			newPost.IsPublic = publish;
 			newPost.Syndicated = publish;
 
-			newPost.CreatedUtc = newPost.ModifiedUtc = dasBlogSettings.GetCreateTime(newPost.CreatedUtc);
-
 			dataService.SaveEntry(newPost);
 
 			return newPost.EntryId;
@@ -616,8 +614,7 @@ namespace DasBlog.Managers
 
 			var trackbackList = FillEntryFromMetaWeblogPost(newPost, post);
 
-			newPost.CreatedUtc = newPost.ModifiedUtc = dasBlogSettings.GetCreateTime(newPost.CreatedUtc);
-
+			newPost.ModifiedUtc = newPost.CreatedUtc;
 			newPost.IsPublic = publish;
 			newPost.Syndicated = publish;
 
@@ -652,7 +649,7 @@ namespace DasBlog.Managers
 			// so we have to check for that
 			if (post.dateCreated != DateTime.MinValue)
 			{
-				entry.CreatedUtc = post.dateCreated.ToUniversalTime();
+				entry.CreatedUtc = dasBlogSettings.GetCreateTime(post.dateCreated);
 			}
 
 			//Patched to avoid html entities in title

--- a/source/DasBlog.Tests/UnitTests/Runtime/EntryTimezoneFilterTests.cs
+++ b/source/DasBlog.Tests/UnitTests/Runtime/EntryTimezoneFilterTests.cs
@@ -1,0 +1,107 @@
+using System;
+using Xunit;
+using newtelligence.DasBlog.Runtime;
+using NodaTime;
+
+namespace DasBlog.Tests.UnitTests.Runtime
+{
+	public class EntryTimezoneFilterTests
+	{
+		private readonly DateTimeZone utcPlus5 = DateTimeZone.ForOffset(Offset.FromHours(5));
+
+		[Fact]
+		public void OccursBetween_ConvertsUtcToLocalBeforeComparing()
+		{
+			// Entry created at 22:00 UTC = 03:00 next day in UTC+5
+			var entry = new Entry { CreatedUtc = new DateTime(2024, 1, 15, 22, 0, 0, DateTimeKind.Utc) };
+			var startLocal = new DateTime(2024, 1, 16, 0, 0, 0);
+			var endLocal = new DateTime(2024, 1, 16, 23, 59, 59);
+
+			// In UTC+5, 22:00 UTC = 03:00 Jan 16 local, so it should be within Jan 16 local range
+			Assert.True(Entry.OccursBetween(entry, utcPlus5, startLocal, endLocal));
+		}
+
+		[Fact]
+		public void OccursBetween_ExcludesEntryOutsideLocalRange()
+		{
+			// Entry created at 10:00 UTC = 15:00 in UTC+5
+			var entry = new Entry { CreatedUtc = new DateTime(2024, 1, 15, 10, 0, 0, DateTimeKind.Utc) };
+			var startLocal = new DateTime(2024, 1, 16, 0, 0, 0);
+			var endLocal = new DateTime(2024, 1, 16, 23, 59, 59);
+
+			// In UTC+5, 10:00 UTC Jan 15 = 15:00 Jan 15 local, outside Jan 16 range
+			Assert.False(Entry.OccursBetween(entry, utcPlus5, startLocal, endLocal));
+		}
+
+		[Fact]
+		public void OccursBefore_ConvertsUtcToLocal()
+		{
+			// Entry created at 20:00 UTC Jan 15 = 01:00 Jan 16 in UTC+5
+			var entry = new Entry { CreatedUtc = new DateTime(2024, 1, 15, 20, 0, 0, DateTimeKind.Utc) };
+
+			// In UTC+5, this is Jan 16 01:00, which is NOT before midnight Jan 16
+			Assert.False(Entry.OccursBefore(entry, utcPlus5, new DateTime(2024, 1, 16, 0, 0, 0)));
+
+			// But it IS before Jan 16 02:00
+			Assert.True(Entry.OccursBefore(entry, utcPlus5, new DateTime(2024, 1, 16, 2, 0, 0)));
+		}
+
+		[Fact]
+		public void OccursInMonth_UsesTimezone()
+		{
+			// Entry created at 23:30 UTC Dec 31 = 04:30 Jan 1 in UTC+5
+			var entry = new Entry { CreatedUtc = new DateTime(2023, 12, 31, 23, 30, 0, DateTimeKind.Utc) };
+
+			// In UTC+5, this is January 1 — should be in January
+			Assert.True(Entry.OccursInMonth(entry, utcPlus5, new DateTime(2024, 1, 1)));
+
+			// Should NOT be in December (local time is Jan 1)
+			Assert.False(Entry.OccursInMonth(entry, utcPlus5, new DateTime(2023, 12, 1)));
+		}
+	}
+
+	public class DayEntryTimezoneFilterTests
+	{
+		private readonly DateTimeZone utcPlus5 = DateTimeZone.ForOffset(Offset.FromHours(5));
+
+		[Fact]
+		public void OccursBetween_ConvertsUtcDateToLocal()
+		{
+			// Day entry for Jan 15 UTC midnight = Jan 15 05:00 in UTC+5
+			var dayEntry = new DayEntry();
+			dayEntry.DateUtc = new DateTime(2024, 1, 15, 0, 0, 0, DateTimeKind.Utc);
+
+			var startLocal = new DateTime(2024, 1, 15, 0, 0, 0);
+			var endLocal = new DateTime(2024, 1, 15, 23, 59, 59);
+
+			// In UTC+5, midnight UTC = 05:00 local, which is within Jan 15 local range
+			Assert.True(DayEntry.OccursBetween(dayEntry, utcPlus5, startLocal, endLocal));
+		}
+
+		[Fact]
+		public void OccursBetween_ExcludesDayOutsideLocalRange()
+		{
+			var utcMinus5 = DateTimeZone.ForOffset(Offset.FromHours(-5));
+			// Day entry for Jan 16 UTC midnight = Jan 15 19:00 in UTC-5
+			var dayEntry = new DayEntry();
+			dayEntry.DateUtc = new DateTime(2024, 1, 16, 0, 0, 0, DateTimeKind.Utc);
+
+			var startLocal = new DateTime(2024, 1, 16, 0, 0, 0);
+			var endLocal = new DateTime(2024, 1, 16, 23, 59, 59);
+
+			// In UTC-5, midnight Jan 16 UTC = 19:00 Jan 15 local, outside Jan 16 range
+			Assert.False(DayEntry.OccursBetween(dayEntry, utcMinus5, startLocal, endLocal));
+		}
+
+		[Fact]
+		public void OccursInMonth_UsesTimezone()
+		{
+			// Day entry for Dec 31 UTC = Dec 31 05:00 in UTC+5
+			var dayEntry = new DayEntry();
+			dayEntry.DateUtc = new DateTime(2023, 12, 31, 0, 0, 0, DateTimeKind.Utc);
+
+			// In UTC+5, Dec 31 midnight UTC = Dec 31 05:00 local — still December
+			Assert.True(DayEntry.OccursInMonth(dayEntry, utcPlus5, new DateTime(2023, 12, 1)));
+		}
+	}
+}

--- a/source/DasBlog.Tests/UnitTests/Settings/DasBlogSettingsTests.cs
+++ b/source/DasBlog.Tests/UnitTests/Settings/DasBlogSettingsTests.cs
@@ -194,6 +194,16 @@ namespace DasBlog.Tests.UnitTests.Settings
 			Assert.Equal(now.AddHours(-2), create);
 		}
 
+		[Fact]
+		public void GetCreateTime_IsInverseOfGetDisplayTime()
+		{
+			var dasBlogSettings = dasBlogSettingsMock.CreateSettings();
+			var utcTime = new DateTime(2024, 7, 15, 14, 30, 0, DateTimeKind.Utc);
+			var displayTime = dasBlogSettings.GetDisplayTime(utcTime);
+			var roundTripped = dasBlogSettings.GetCreateTime(displayTime);
+			Assert.Equal(utcTime, roundTripped);
+		}
+
         [Fact]
         public void GetCategoryViewUrlName_ReturnsEmptyString()
         {

--- a/source/DasBlog.Web/Services/BlogPostViewModelCreator.cs
+++ b/source/DasBlog.Web/Services/BlogPostViewModelCreator.cs
@@ -28,8 +28,9 @@ namespace DasBlog.Web.Services
 		{
 			PostViewModel post = new PostViewModel();
 			var tz = timeZoneProvider.GetConfiguredTimeZone();
-			var offset = tz.GetUtcOffset(new Instant());
-			post.CreatedDateTime = DateTime.UtcNow.Add(new TimeSpan(0,0,0,offset.Seconds));
+			var utcNow = DateTime.UtcNow;
+			var instant = Instant.FromDateTimeUtc(DateTime.SpecifyKind(utcNow, DateTimeKind.Utc));
+			post.CreatedDateTime = instant.InZone(tz).ToDateTimeUnspecified();
 			post.IsPublic = true;
 			post.Syndicated = true;
 			post.AllowComments = true;

--- a/source/DasBlog.Web/Settings/DasBlogSettings.cs
+++ b/source/DasBlog.Web/Settings/DasBlogSettings.cs
@@ -307,8 +307,8 @@ namespace DasBlog.Web.Settings
 		public DateTime GetCreateTime(DateTime datetime)
 		{
 			var tz = timeZoneProvider.GetConfiguredTimeZone();
-			var offset = tz.GetUtcOffset(Instant.FromDateTimeUtc(DateTime.UtcNow));
-			return datetime.Add(-offset.ToTimeSpan());
+			var local = LocalDateTime.FromDateTime(datetime);
+			return local.InZoneLeniently(tz).ToDateTimeUtc();
 		}
 	}
 }

--- a/source/newtelligence.DasBlog.Runtime/DayEntry.cs
+++ b/source/newtelligence.DasBlog.Runtime/DayEntry.cs
@@ -283,10 +283,10 @@ namespace newtelligence.DasBlog.Runtime
 		public static bool OccursBetween(DayEntry dayEntry, DateTimeZone timeZone, 
 			DateTime startDateTime, DateTime endDateTime)
 		{
-			//return ((timeZone.ToLocalTime(dayEntry.DateUtc) >= startDateTime)
-			//	&& (timeZone.ToLocalTime(dayEntry.DateUtc) <= endDateTime) );
-			return ((dayEntry.DateUtc >= startDateTime)
-				&& (dayEntry.DateUtc <= endDateTime) );
+			var instant = Instant.FromDateTimeUtc(DateTime.SpecifyKind(dayEntry.DateUtc, DateTimeKind.Utc));
+			var localDate = instant.InZone(timeZone).ToDateTimeUnspecified();
+			return ((localDate >= startDateTime)
+				&& (localDate <= endDateTime) );
 		}
 
 		/// <summary>
@@ -303,9 +303,6 @@ namespace newtelligence.DasBlog.Runtime
 			endOfMonth = endOfMonth.AddMonths(1);
 			endOfMonth = endOfMonth.AddSeconds(-1);
 
-			var localTime = LocalDateTime.FromDateTime(endOfMonth);
-			var offset = timeZone.GetUtcOffset(localTime.InZoneStrictly(timeZone).ToInstant());
-			endOfMonth = endOfMonth.Add(offset.ToTimeSpan());
 			return (OccursBetween(dayEntry, timeZone, startOfMonth, endOfMonth));
 		}
 	}

--- a/source/newtelligence.DasBlog.Runtime/Entry.cs
+++ b/source/newtelligence.DasBlog.Runtime/Entry.cs
@@ -497,7 +497,8 @@ namespace newtelligence.DasBlog.Runtime
 		/// </returns>
 		public static bool OccursBefore(Entry entry, DateTimeZone timeZone, DateTime dateTime)
 		{
-			var entryCreated = timeZone.AtStrictly(LocalDateTime.FromDateTime(entry.CreatedUtc)).LocalDateTime;
+			var instant = Instant.FromDateTimeUtc(DateTime.SpecifyKind(entry.CreatedUtc, DateTimeKind.Utc));
+			var entryCreated = instant.InZone(timeZone).LocalDateTime;
 			var date = LocalDateTime.FromDateTime(dateTime);
 
 			return (entryCreated <= date);
@@ -506,7 +507,8 @@ namespace newtelligence.DasBlog.Runtime
 		public static bool OccursBetween(Entry entry, DateTimeZone timeZone, 
 												DateTime startDateTime, DateTime endDateTime)
 		{
-			var entryCreated = timeZone.AtStrictly(LocalDateTime.FromDateTime(entry.CreatedUtc)).LocalDateTime;
+			var instant = Instant.FromDateTimeUtc(DateTime.SpecifyKind(entry.CreatedUtc, DateTimeKind.Utc));
+			var entryCreated = instant.InZone(timeZone).LocalDateTime;
 			var strartDate = LocalDateTime.FromDateTime(startDateTime);
 			var endDate = LocalDateTime.FromDateTime(endDateTime);
 


### PR DESCRIPTION
#### PR Classification
Bug fix and improvement for time zone handling in blog post creation and filtering.

#### PR Summary
This PR standardizes time zone conversions using NodaTime for blog post creation and filtering logic, ensuring consistent behavior across time zones. It also adds unit tests to verify correct time zone handling.
- Entry.cs and DayEntry.cs: Refactored filtering methods to convert UTC to local time using NodaTime before comparisons.
- DasBlogSettings.cs: Updated `GetCreateTime` to use NodaTime for local-to-UTC conversion.
- BlogPostViewModelCreator.cs: Set post creation date using NodaTime in the configured time zone.
- EntryTimezoneFilterTests.cs: Added unit tests for entry and day entry time zone filtering.
- DasBlogSettingsTests.cs: Added a test to verify `GetCreateTime` and `GetDisplayTime` are inverses.
