### PR TITLE
Use blog timezone for content lookahead window

### DIFF
--- a/source/DasBlog.Tests/UnitTests/Settings/DasBlogSettingsTests.cs
+++ b/source/DasBlog.Tests/UnitTests/Settings/DasBlogSettingsTests.cs
@@ -233,8 +233,22 @@ namespace DasBlog.Tests.UnitTests.Settings
         {
             var dasBlogSettings = dasBlogSettingsMock.CreateSettings();
             var lookahead = dasBlogSettings.GetContentLookAhead();
-            var expected = DateTime.UtcNow.AddDays(dasBlogSettings.SiteConfiguration.ContentLookaheadDays).Date;
+            var tz = dasBlogSettings.GetConfiguredTimeZone();
+            var localNow = SystemClock.Instance.GetCurrentInstant().InZone(tz).ToDateTimeUnspecified();
+            var expected = localNow.AddDays(dasBlogSettings.SiteConfiguration.ContentLookaheadDays).Date;
             Assert.Equal(expected, lookahead.Date);
+        }
+
+        [Fact]
+        public void GetContentLookAhead_UsesLocalTimeNotUtc()
+        {
+            var dasBlogSettings = dasBlogSettingsMock.CreateSettings();
+            var lookahead = dasBlogSettings.GetContentLookAhead();
+            var tz = dasBlogSettings.GetConfiguredTimeZone();
+            var localNow = SystemClock.Instance.GetCurrentInstant().InZone(tz).ToDateTimeUnspecified();
+
+            // Lookahead should be relative to blog-local time, not UTC
+            Assert.True(Math.Abs((lookahead - localNow.AddDays(dasBlogSettings.SiteConfiguration.ContentLookaheadDays)).TotalMinutes) < 1);
         }
 
         [Fact]

--- a/source/DasBlog.Web/Settings/DasBlogSettings.cs
+++ b/source/DasBlog.Web/Settings/DasBlogSettings.cs
@@ -175,7 +175,9 @@ namespace DasBlog.Web.Settings
 
 		public DateTime GetContentLookAhead()
 		{
-			return DateTime.UtcNow.AddDays(SiteConfiguration.ContentLookaheadDays);
+			var tz = timeZoneProvider.GetConfiguredTimeZone();
+			var localNow = SystemClock.Instance.GetCurrentInstant().InZone(tz).ToDateTimeUnspecified();
+			return localNow.AddDays(SiteConfiguration.ContentLookaheadDays);
 		}
 
 		public string FilterHtml(string input)


### PR DESCRIPTION
Use blog timezone for content lookahead window

GetContentLookAhead was anchored to DateTime.UtcNow, which shifts the
lookahead window relative to the blog owner's local time. For example,
at 8 PM EST (which is already the next day in UTC), the window starts
a day ahead of what the blog owner expects.

Now uses SystemClock.Instance.GetCurrentInstant().InZone(tz) to anchor
the lookahead to the blog's configured timezone.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>