### PR TITLE
Reduce padding in container and article styles

### DIFF
--- a/source/DasBlog.Web/Themes/kindofblue/custom.css
+++ b/source/DasBlog.Web/Themes/kindofblue/custom.css
@@ -72,7 +72,7 @@ a:hover {
 /* Container */
 .kob-container {
     max-width: 880px;
-    padding-top: 2rem;
+    padding-top: 1rem;
     padding-bottom: 2rem;
 }
 
@@ -182,7 +182,7 @@ a:hover {
 
 /* Article (full post) */
 .kob-article {
-    padding: 2rem 0;
+    padding: 0.5rem 0 3rem;
 }
 
 .kob-article-header {


### PR DESCRIPTION
Reduce padding in container and article styles

Adjusted .kob-container top padding from 2rem to 1rem for a more compact layout. Updated .kob-article padding to 0.5rem top, 0 right/left, and 3rem bottom to refine spacing.