### PR TITLE
Refactor edit link helpers for DI and root-relative URLs

### DIFF
--- a/source/DasBlog.Tests/UnitTests/UI/TagHelperTest.cs
+++ b/source/DasBlog.Tests/UnitTests/UI/TagHelperTest.cs
@@ -49,7 +49,7 @@ namespace DasBlog.Tests.UnitTests.UI
 
 		public static TheoryData<TagHelper, string, string> DasBlogPostLinkTagHelperData = new TheoryData<TagHelper, string, string>
 		{
-			{new PostEditLinkTagHelper() {BlogPostId = "theBlogPost"}, "theBlogPost", "Edit this post"},
+			{new PostEditLinkTagHelper(dasBlogSettings) {BlogPostId = "theBlogPost"}, "theBlogPost", "Edit this post"},
 			{new PostCommentLinkTagHelper(dasBlogSettings.SiteConfiguration, dasBlogSettings) { Post = new PostViewModel { PermaLink = "some-blog-post", EntryId = "0B74C9D3-4D2C-4754-B607-F3847183221C" }}, "/some-blog-post/comments", "Comment on this post [0]" },
 			{new PostCommentLinkTagHelper(dasBlogSettings.SiteConfiguration, dasBlogSettings) { Post = new PostViewModel { PermaLink = "some-blog-post", EntryId = "0B74C9D3-4D2C-4754-B607-F3847183221C" }, LinkText = "Custom text ({0})"}, "/some-blog-post/comments", "Custom text (0)" },
 			{new PostCommentLinkTagHelper(dasBlogSettings.SiteConfiguration, dasBlogSettings) { Post = new PostViewModel { PermaLink = "some-blog-post", EntryId = "0B74C9D3-4D2C-4754-B607-F3847183221C" }, LinkText = "Link text only "}, "/some-blog-post/comments", "Link text only" }

--- a/source/DasBlog.Web/TagHelpers/EditPostTagHelper.cs
+++ b/source/DasBlog.Web/TagHelpers/EditPostTagHelper.cs
@@ -1,4 +1,5 @@
-﻿using DasBlog.Web.TagHelpers.Post;
+﻿using DasBlog.Services;
+using DasBlog.Web.TagHelpers.Post;
 using System;
 
 namespace DasBlog.Web.TagHelpers
@@ -6,5 +7,8 @@ namespace DasBlog.Web.TagHelpers
 	[Obsolete]
 	public class EditPostTagHelper : PostEditLinkTagHelper
 	{
+		public EditPostTagHelper(IUrlResolver urlResolver) : base(urlResolver)
+		{
+		}
 	}
 }

--- a/source/DasBlog.Web/TagHelpers/Post/PostEditLinkTagHelper.cs
+++ b/source/DasBlog.Web/TagHelpers/Post/PostEditLinkTagHelper.cs
@@ -1,4 +1,5 @@
-﻿using DasBlog.Web.Models.BlogViewModels;
+﻿using DasBlog.Services;
+using DasBlog.Web.Models.BlogViewModels;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using System.Threading.Tasks;
 
@@ -10,6 +11,13 @@ namespace DasBlog.Web.TagHelpers.Post
 		public string BlogPostId { get; set; }
 		public string EditLinkText { get; set; } = "Edit this post";
 
+		private readonly IUrlResolver urlResolver;
+
+		public PostEditLinkTagHelper(IUrlResolver urlResolver)
+		{
+			this.urlResolver = urlResolver;
+		}
+
 		public override void Process(TagHelperContext context, TagHelperOutput output)
 		{
 			if (Post != null)
@@ -19,7 +27,7 @@ namespace DasBlog.Web.TagHelpers.Post
 
 			output.TagName = "a";
 			output.TagMode = TagMode.StartTagAndEndTag;
-			output.Attributes.SetAttribute("href", "/admin/post/" + BlogPostId + "/edit");
+			output.Attributes.SetAttribute("href", urlResolver.RelativeToRoot("admin/post/" + BlogPostId + "/edit"));
 			if (!string.IsNullOrEmpty(EditLinkText))
 			{
 				output.Content.SetHtmlContent("Edit this post");

--- a/source/DasBlog.Web/Views/BlogPost/CreatePost.cshtml
+++ b/source/DasBlog.Web/Views/BlogPost/CreatePost.cshtml
@@ -18,7 +18,7 @@
 <!-- Success Alert using reusable partial -->
 <partial name="_SuccessAlertPartial" view-data="ViewData" />
 
-<form action="/admin/post/create" method="post" enctype="multipart/form-data" id="CreatePostForm">
+<form action="@Url.Content("~/admin/post/create")" method="post" enctype="multipart/form-data" id="CreatePostForm">
     @Html.AntiForgeryToken()
 
     <partial name="BlogPostFields" model="Model" />

--- a/source/DasBlog.Web/Views/BlogPost/EditPost.cshtml
+++ b/source/DasBlog.Web/Views/BlogPost/EditPost.cshtml
@@ -19,7 +19,7 @@
 <!-- Success Alert using reusable partial -->
 <partial name="_SuccessAlertPartial" view-data="ViewData" />
 
-<form action="/admin/post/edit" method="post" enctype="multipart/form-data" id="EditPostForm">
+<form action="@Url.Content("~/admin/post/edit")" method="post" enctype="multipart/form-data" id="EditPostForm">
     @Html.AntiForgeryToken()
 
     <div class="row gy-2 gx-3 align-items-md-start mb-2">


### PR DESCRIPTION
Refactor edit link helpers for DI and root-relative URLs

Refactored PostEditLinkTagHelper and EditPostTagHelper to use constructor injection for IUrlResolver, ensuring dependency injection and generating root-relative URLs. Updated test data and form actions in CreatePost.cshtml and EditPost.cshtml to use root-relative paths for improved hosting compatibility.