### PR TITLE
Add invariant double model binder and update Recaptcha field

### DIFF
--- a/source/DasBlog.Web/DasBlogServiceCollectionExtensions.cs
+++ b/source/DasBlog.Web/DasBlogServiceCollectionExtensions.cs
@@ -14,6 +14,7 @@ using DasBlog.Services.Site;
 using DasBlog.Services.Users;
 using DasBlog.Web.Identity;
 using DasBlog.Web.Mappers;
+using DasBlog.Web.ModelBinding;
 using DasBlog.Web.Services;
 using DasBlog.Web.Services.Interfaces;
 using DasBlog.Web.Settings;
@@ -232,7 +233,10 @@ namespace DasBlog.Web
 					mapperConfig.AddProfile(new ProfileActivityPub());
 					mapperConfig.AddProfile(new ProfileStaticPage());
 				}, Array.Empty<Assembly>())
-				.AddMvc()
+				.AddMvc(options =>
+				{
+					options.ModelBinderProviders.Insert(0, new InvariantDoubleModelBinderProvider());
+				})
 				.AddXmlSerializerFormatters();
 
 			services

--- a/source/DasBlog.Web/ModelBinding/InvariantDoubleModelBinder.cs
+++ b/source/DasBlog.Web/ModelBinding/InvariantDoubleModelBinder.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
+using System;
+using System.Globalization;
+using System.Threading.Tasks;
+
+namespace DasBlog.Web.ModelBinding
+{
+	public class InvariantDoubleModelBinder : IModelBinder
+	{
+		public Task BindModelAsync(ModelBindingContext bindingContext)
+		{
+			ArgumentNullException.ThrowIfNull(bindingContext);
+
+			var modelName = bindingContext.ModelName;
+			var valueProviderResult = bindingContext.ValueProvider.GetValue(modelName);
+
+			if (valueProviderResult == ValueProviderResult.None)
+			{
+				return Task.CompletedTask;
+			}
+
+			bindingContext.ModelState.SetModelValue(modelName, valueProviderResult);
+
+			var value = valueProviderResult.FirstValue;
+
+			if (string.IsNullOrWhiteSpace(value))
+			{
+				return Task.CompletedTask;
+			}
+
+			if (double.TryParse(value, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture, out var result))
+			{
+				bindingContext.Result = ModelBindingResult.Success(result);
+			}
+			else
+			{
+				bindingContext.ModelState.TryAddModelError(modelName, $"The value '{value}' is not a valid number.");
+			}
+
+			return Task.CompletedTask;
+		}
+	}
+}

--- a/source/DasBlog.Web/ModelBinding/InvariantDoubleModelBinderProvider.cs
+++ b/source/DasBlog.Web/ModelBinding/InvariantDoubleModelBinderProvider.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
+using System;
+
+namespace DasBlog.Web.ModelBinding
+{
+	public class InvariantDoubleModelBinderProvider : IModelBinderProvider
+	{
+		public IModelBinder? GetBinder(ModelBinderProviderContext context)
+		{
+			ArgumentNullException.ThrowIfNull(context);
+
+			if (context.Metadata.ModelType == typeof(double) || context.Metadata.ModelType == typeof(double?))
+			{
+				return new InvariantDoubleModelBinder();
+			}
+
+			return null;
+		}
+	}
+}

--- a/source/DasBlog.Web/Views/Shared/_Admin_Comments.cshtml
+++ b/source/DasBlog.Web/Views/Shared/_Admin_Comments.cshtml
@@ -65,7 +65,7 @@
 <div class="row gy-2 gx-3 align-items-md-start">
     <div class="col-sm-4">
         <div class="form-floating">
-            @Html.TextBoxFor(m => @Model.SiteConfig.RecaptchaMinimumScore, null, new { type = "number", step = "0.1", @class = "form-control", id = "recaptchaMinimumScore" })
+            @Html.TextBox("SiteConfig.RecaptchaMinimumScore", Model.SiteConfig.RecaptchaMinimumScore.ToString(System.Globalization.CultureInfo.InvariantCulture), new { type = "number", step = "0.1", @class = "form-control", id = "recaptchaMinimumScore" })
             @Html.LabelFor(m => @Model.SiteConfig.RecaptchaMinimumScore, null, new { @class = "form-label", @for = "recaptchaMinimumScore" })
         </div>
         @Html.ValidationMessageFor(m => m.SiteConfig.RecaptchaMinimumScore, null, new { @class = "text-danger" })


### PR DESCRIPTION
Add invariant double model binder and update Recaptcha field

Introduced InvariantDoubleModelBinder and provider to enforce invariant culture parsing for double values. Registered the provider in MVC configuration for double and nullable double types. Updated _Admin_Comments.cshtml to use invariant culture formatting for RecaptchaMinimumScore input.