### PR TITLE
Add theme switcher with persisted color mode support

### DIFF
--- a/source/DasBlog.Web/Themes/dasblog/_Layout.cshtml
+++ b/source/DasBlog.Web/Themes/dasblog/_Layout.cshtml
@@ -1,9 +1,23 @@
 ﻿<!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <base href="@Url.Content("~/")" />
+
+    @* Apply persisted color mode as early as possible to avoid a flash of incorrect theme *@
+    <script>
+        (function () {
+            try {
+                var stored = localStorage.getItem('dasblog-theme');
+                var theme = stored;
+                if (!theme || theme === 'auto') {
+                    theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+                }
+                document.documentElement.setAttribute('data-bs-theme', theme);
+            } catch (e) { /* ignore */ }
+        })();
+    </script>
 
     <partial name="_HtmlHeadPartial" />
     <partial name="_HtmlRSSPartial" />
@@ -47,6 +61,28 @@
                         <li><a class="dropdown-item" asp-area="" asp-controller="admin" asp-action="managecomments"><i class="fas fa-comments me-2"></i>Manage Comments</a></li>
                         <li><a class="dropdown-item" asp-area="" asp-controller="author" asp-action="index"><i class="fas fa-user me-2"></i>Author</a></li>
                         <li><a class="dropdown-item" asp-area="" asp-controller="activity" asp-action="index"><i class="fas fa-chart-line me-2"></i>Activity</a></li>
+                        <li><hr class="dropdown-divider"></li>
+                        <li>
+                            <h6 class="dropdown-header">Appearance</h6>
+                        </li>
+                        <li>
+                            <button type="button" class="dropdown-item dasblog-theme-option" data-bs-theme-value="light">
+                                <i class="fas fa-sun me-2"></i>Light
+                                <i class="fas fa-check ms-2 dasblog-theme-check d-none"></i>
+                            </button>
+                        </li>
+                        <li>
+                            <button type="button" class="dropdown-item dasblog-theme-option" data-bs-theme-value="dark">
+                                <i class="fas fa-moon me-2"></i>Dark
+                                <i class="fas fa-check ms-2 dasblog-theme-check d-none"></i>
+                            </button>
+                        </li>
+                        <li>
+                            <button type="button" class="dropdown-item dasblog-theme-option" data-bs-theme-value="auto">
+                                <i class="fas fa-circle-half-stroke me-2"></i>Auto
+                                <i class="fas fa-check ms-2 dasblog-theme-check d-none"></i>
+                            </button>
+                        </li>
                         <li><hr class="dropdown-divider"></li>
                         <li><a class="dropdown-item" asp-controller="account" asp-action="logout"><i class="fas fa-sign-out-alt me-2"></i>Log out</a></li>
                     </ul>

--- a/source/DasBlog.Web/wwwroot/js/site.js
+++ b/source/DasBlog.Web/wwwroot/js/site.js
@@ -119,3 +119,69 @@ function showLastUserError(showError) {
     }
     window.maintenanceForm.submit();
 }
+
+(function () {
+    var STORAGE_KEY = 'dasblog-theme';
+
+    function getStoredTheme() {
+        try { return localStorage.getItem(STORAGE_KEY); } catch (e) { return null; }
+    }
+
+    function setStoredTheme(theme) {
+        try { localStorage.setItem(STORAGE_KEY, theme); } catch (e) { /* ignore */ }
+    }
+
+    function resolveTheme(theme) {
+        if (!theme || theme === 'auto') {
+            return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        return theme;
+    }
+
+    function applyTheme(theme) {
+        document.documentElement.setAttribute('data-bs-theme', resolveTheme(theme));
+    }
+
+    function updateActiveIndicator(selected) {
+        var options = document.querySelectorAll('.dasblog-theme-option');
+        options.forEach(function (btn) {
+            var check = btn.querySelector('.dasblog-theme-check');
+            var isActive = btn.getAttribute('data-bs-theme-value') === selected;
+            btn.classList.toggle('active', isActive);
+            if (check) {
+                check.classList.toggle('d-none', !isActive);
+            }
+        });
+    }
+
+    function init() {
+        var current = getStoredTheme() || 'auto';
+        applyTheme(current);
+        updateActiveIndicator(current);
+
+        document.querySelectorAll('.dasblog-theme-option').forEach(function (btn) {
+            btn.addEventListener('click', function () {
+                var theme = btn.getAttribute('data-bs-theme-value');
+                setStoredTheme(theme);
+                applyTheme(theme);
+                updateActiveIndicator(theme);
+            });
+        });
+
+        var media = window.matchMedia('(prefers-color-scheme: dark)');
+        if (media.addEventListener) {
+            media.addEventListener('change', function () {
+                var stored = getStoredTheme();
+                if (!stored || stored === 'auto') {
+                    applyTheme('auto');
+                }
+            });
+        }
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();


### PR DESCRIPTION
Add theme switcher with persisted color mode support

Added a color theme switcher (light, dark, auto) to the user menu. Theme preference is stored in localStorage and applied early to prevent flash of incorrect theme. JavaScript updates the UI and responds to system color scheme changes.