### PR TITLE
Limit form field selection to Comments section only

### DIFF
--- a/source/DasBlog.Web/Views/Shared/_Admin_Comments.cshtml
+++ b/source/DasBlog.Web/Views/Shared/_Admin_Comments.cshtml
@@ -111,8 +111,9 @@
             document.getElementById('recaptchaSiteKey'),
             document.getElementById('recaptchaSecretKey')
         ];
-        // All form fields except EnableComments
-        const allFormFields = Array.from(document.querySelectorAll('input, select, textarea'))
+        // All form fields in the Comments section except EnableComments
+        const commentsSection = document.getElementById('collapseComments');
+        const allFormFields = Array.from(commentsSection.querySelectorAll('input, select, textarea'))
             .filter(el => el !== enableCommentsCheckbox);
 
         function toggleRecaptchaFields() {


### PR DESCRIPTION
Limit form field selection to Comments section only

Updated logic to select and process only form fields within the "Comments" section, excluding unrelated fields elsewhere on the page. This ensures validation and manipulation apply solely to relevant comment settings.