### PR TITLE
Update dependencies and AutoMapper registration

### DIFF
--- a/source/DasBlog.CLI/DasBlog.CLI.csproj
+++ b/source/DasBlog.CLI/DasBlog.CLI.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Options" />
+    <PackageReference Include="System.Security.Cryptography.Xml" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
 

--- a/source/DasBlog.Web/AutomapperExtensions.cs
+++ b/source/DasBlog.Web/AutomapperExtensions.cs
@@ -103,7 +103,10 @@ namespace AutoMapper
                 services.AddTransient(type.AsType());
             }
 
-            services.AddSingleton<IConfigurationProvider>(sp => new MapperConfiguration(c => ConfigAction(sp, c)));
+            services.AddSingleton<IConfigurationProvider>(sp =>
+            {
+                return new MapperConfiguration(cfg => ConfigAction(sp, cfg), null);
+            });
             return services.AddScoped<IMapper>(sp => new Mapper(sp.GetRequiredService<IConfigurationProvider>(), sp.GetService));
         }
 

--- a/source/DasBlog.Web/DasBlog.Web.csproj
+++ b/source/DasBlog.Web/DasBlog.Web.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="NWebsec.AspNetCore.Middleware" />
     <PackageReference Include="reCAPTCHA.AspNetCore" />
     <PackageReference Include="Quartz.AspNetCore" />
+    <PackageReference Include="NuGet.Protocol" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>

--- a/source/Directory.Packages.props
+++ b/source/Directory.Packages.props
@@ -8,12 +8,14 @@
     <PackageVersion Include="reCAPTCHA.AspNetCore" Version="3.0.10" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
-    <PackageVersion Include="AutoMapper" Version="13.0.1" />
+    <PackageVersion Include="AutoMapper" Version="15.1.3" />
     <PackageVersion Include="ConsoleTables" Version="2.6.2" />
     <PackageVersion Include="Coravel" Version="6.0.0" />
     <PackageVersion Include="Kveer.XmlRPC" Version="1.3.1" />
     <PackageVersion Include="NodaTime" Version="3.2.0" />
-    <PackageVersion Include="MailKit" Version="4.8.0" />
+    <PackageVersion Include="MailKit" Version="4.16.0" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.6" />
+    <PackageVersion Include="NuGet.Protocol" Version="6.12.5" />
     <PackageVersion Include="Markdig" Version="0.38.0" />
     <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />


### PR DESCRIPTION
Update dependencies and AutoMapper registration

Upgraded AutoMapper to 15.1.3 and MailKit to 4.16.0. Added System.Security.Cryptography.Xml and NuGet.Protocol packages. Updated AutoMapper service registration for compatibility with the new version. Added new package references to DasBlog.CLI.csproj and DasBlog.Web.csproj.