### PR TITLE
Publish NuGet artifacts and update template packaging

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -136,6 +136,13 @@ steps:
     nuGetFeedType: external
     publishFeedCredentials: 'NuGetOrg'
 
+- task: PublishPipelineArtifact@1
+  displayName: Publish NuGet artifact
+  condition: and(succeeded(), eq(variables['imageName'], 'windows-latest'), eq(variables.isTag, true))
+  inputs:
+    targetPath: '$(Build.ArtifactStagingDirectory)/nupkg'
+    artifactName: nuget
+
 - task: GitHubRelease@1
   displayName: Create GitHub Release
   condition: and(succeeded(), eq(variables['imageName'], 'windows-latest'), eq(variables.isTag, true))

--- a/source/.template.config/template.json
+++ b/source/.template.config/template.json
@@ -13,6 +13,8 @@
   "preferNameDirectory": true,
   "sources": [
     {
+      "source": "template-staging/",
+      "target": "./",
       "modifiers": [
         {
           "exclude": [
@@ -20,9 +22,7 @@
             "**/obj/**",
             "**/logs/**",
             "**/.vs/**",
-            "**/.git/**",
-            "**/TestResults/**",
-            "**/DasBlog.Template.csproj"
+            "**/.git/**"
           ]
         }
       ]
@@ -52,18 +52,6 @@
     }
   },
   "primaryOutputs": [
-    { "path": "DasBlog.Web/DasBlog.Web.csproj" }
-  ],
-  "postActions": [
-    {
-      "description": "Restore NuGet packages",
-      "manualInstructions": [
-        {
-          "text": "Run 'dotnet restore'"
-        }
-      ],
-      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
-      "continueOnError": true
-    }
+    { "path": "DasBlog.Web.exe" }
   ]
 }

--- a/source/DasBlog.Template.csproj
+++ b/source/DasBlog.Template.csproj
@@ -21,6 +21,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Content Include="template-staging\**" />
+    <Content Include=".template.config\**" />
     <Compile Remove="**" />
     <None Include="..\images\dasblog-square-icon.jpg" Pack="true" PackagePath="" />
     <None Include="NUGET_README.md" Pack="true" PackagePath="" />


### PR DESCRIPTION
Publish NuGet artifacts and update template packaging

Added PublishPipelineArtifact to CI for NuGet artifacts. Updated template.json to use "template-staging/" as a source, revised exclude list, changed primary output to DasBlog.Web.exe, and removed restore postAction. Included .template.config in DasBlog.Template.csproj content.