### PR TITLE
Blank site.config Root, remove blogUrl template parameter, fix URLs

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -6,7 +6,7 @@ A: DasBlog Core  is an open source blogging engine based heavily on the  work pr
 
 
 #### Q: Does this replace the original DasBlog?
-A: We think so. The original DasBlog relies on Web Forms and will not be supported on .NET Core platform going forward.
+A: We think so. The original DasBlog relies on Web Forms and will not be supported going forward.
 
 
 #### Q: Does it work on a Mac?  On Linux?

--- a/README.md
+++ b/README.md
@@ -47,15 +47,15 @@ Navigate to `http://localhost:5000` and log in with the default credentials. **C
 * **CDN support** for serving media from a content delivery network
 * **CLI tools** for [configuration and management](https://github.com/poppastring/dasblog-core/wiki/CLI-Reference)
 
-## Deployment
+## Install
 
 | Option | Description |
 |--------|-------------|
-| [**.NET template**](https://github.com/poppastring/dasblog-core/wiki/1.-Deployment#deploy-with-net-template-nuget) | `dotnet new dasblog` — fastest way to get running |
-| [**Deploy to Azure Button**](https://github.com/poppastring/dasblog-core/wiki/1.-Deployment#deploy-to-azure-button) | One-click Azure deployment |
+| [**.NET template**](https://github.com/poppastring/dasblog-core/wiki/1.-Install#net-template) | `dotnet new dasblog` — fastest way to get running |
+| [**Deploy to Azure Button**](https://github.com/poppastring/dasblog-core/wiki/1.-Install#azure--deploy-button) | One-click Azure deployment |
 | [**Azure App Services**](https://github.com/poppastring/dasblog-core/wiki/Azure-App-Services) | Step-by-step for Linux, Windows, or sub-folder |
-| [**Self-hosted**](https://github.com/poppastring/dasblog-core/wiki/1.-Deployment#deploy-to-your-own-web-host) | Any host that supports .NET 10 |
-| [**Local**](https://github.com/poppastring/dasblog-core/wiki/1.-Deployment#deploy-to-your-local-machine) | Run on your own machine |
+| [**Cloud hosting**](https://github.com/poppastring/dasblog-core/wiki/1.-Install#cloud-hosting) | Any host that supports .NET 10 |
+| [**Local**](https://github.com/poppastring/dasblog-core/wiki/1.-Install#local-install) | Run on your own machine |
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ cd myblog
 .\DasBlog.Web.exe
 ```
 
-Navigate to `https://localhost:5001` and log in with the default credentials. **Change them immediately** at `/admin/authors`.
+Navigate to `http://localhost:5000` and log in with the default credentials. **Change them immediately** at `/admin/authors`.
 
 ## Features
 

--- a/source/.template.config/template.json
+++ b/source/.template.config/template.json
@@ -36,13 +36,6 @@
       "replaces": "My DasBlog!",
       "description": "The title of your blog"
     },
-    "blogUrl": {
-      "type": "parameter",
-      "datatype": "string",
-      "defaultValue": "",
-      "replaces": "https://localhost:5001/",
-      "description": "The root URL of your blog"
-    },
     "adminEmail": {
       "type": "parameter",
       "datatype": "string",

--- a/source/DasBlog.Tests/UnitTests/Config/site.config
+++ b/source/DasBlog.Tests/UnitTests/Config/site.config
@@ -3,7 +3,7 @@
 
   <!-- REQUIRED: Your blog will not work properly until you configure these settings. -->
   <!-- Set the Root to the base URL of this blog, such as http://example com/joeuser/blog/ -->
-  <Root>https://localhost:5001/</Root>
+  <Root></Root>
 
   <!-- NotificationEMailAddress is the address used by the system to send you event (blog posts, comment posts) notifications.
        This address will NOT be published on the website. -->

--- a/source/DasBlog.Web/Config/site.config
+++ b/source/DasBlog.Web/Config/site.config
@@ -3,7 +3,7 @@
 
   <!-- REQUIRED: Your blog will not work properly until you configure these settings. -->
   <!-- Set the Root to the base URL of this blog, such as http://example.com/blog/ -->
-  <Root>https://localhost:5001/</Root>
+  <Root></Root>
 
   <!-- NotificationEMailAddress is the address used by the system to send you event (blog posts, comment posts) notifications.
        This address will NOT be published on the website. -->

--- a/source/NUGET_README.md
+++ b/source/NUGET_README.md
@@ -16,7 +16,7 @@ cd myblog
 .\DasBlog.Web.exe
 ```
 
-Navigate to `https://localhost:5001` and log in with the default credentials:
+Navigate to `http://localhost:5000` and log in with the default credentials:
 
 - **Email:** myemail@myemail.com
 - **Password:** admin
@@ -28,13 +28,12 @@ Navigate to `https://localhost:5001` and log in with the default credentials:
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--blogTitle` | Your blog title | My DasBlog! |
-| `--blogUrl` | Root URL of your blog | *(empty)* |
 | `--adminEmail` | Admin email address | myemail@myemail.com |
 
 Example:
 
 ```bash
-dotnet new dasblog -n myblog --blogTitle "My Blog" --blogUrl "https://myblog.example.com"
+dotnet new dasblog -n myblog --blogTitle "My Blog"
 ```
 
 ## Next steps


### PR DESCRIPTION
- site.config: blank Root (DasBlog auto-detects URL)
- template.json: remove blogUrl symbol (users set URL via CLI or admin UX)
- README/NUGET_README: fix to http://localhost:5000, remove --blogUrl references
- FAQ: fix stale .NET Core wording
- Tests: blank Root in test site.config to match production