### PR TITLE
Add Mastodon share tag helper and update share options

### DIFF
--- a/source/DasBlog.Tests/UnitTests/UI/TagHelperTest.cs
+++ b/source/DasBlog.Tests/UnitTests/UI/TagHelperTest.cs
@@ -117,6 +117,41 @@ namespace DasBlog.Tests.UnitTests.UI
 
 		[Fact]
 		[Trait("Category", "UnitTest")]
+		public async Task PostToMastodonTagHelper_GeneratedTagHelper_BlogPostRendersAsAnchorTag()
+		{
+			var postTitle = "Hello Mastodon";
+			var postLink = "hello-mastodon";
+			var dasBlogSettingsMock = new DasBlogSettingsMock();
+			var dasBlogSettings = dasBlogSettingsMock.CreateSettings();
+
+			var sut = new PostToMastodonTagHelper(dasBlogSettings) { Post = new PostViewModel { Title = postTitle, PermaLink = postLink, EntryId = "6E5D34A8-2C7B-4F1E-9A88-3D5F2E8C9B11" } };
+
+			var context = new TagHelperContext(new TagHelperAttributeList(), new Dictionary<object, object>(), Guid.NewGuid().ToString("N"));
+			var output = new TagHelperOutput("editpost", new TagHelperAttributeList(), (useCachedResult, htmlEncoder) =>
+			{
+				var tagHelperContent = new DefaultTagHelperContent();
+				tagHelperContent.SetContent(string.Empty);
+				return Task.FromResult<TagHelperContent>(tagHelperContent);
+			});
+
+			await sut.ProcessAsync(context, output);
+
+			Assert.Same("a", output.TagName);
+
+			var href = output.Attributes.FirstOrDefault(a => a.Name == "href")?.Value.ToString();
+			Assert.NotNull(href);
+			Assert.StartsWith("https://mastodonshare.com/", href);
+
+			var urlencodedBaseUrl = UrlEncoder.Default.Encode(dasBlogSettings.GetBaseUrl());
+			Assert.Contains($"={urlencodedBaseUrl}{postLink}", href);
+			Assert.Contains(UrlEncoder.Default.Encode(postTitle), href);
+
+			var cssClass = output.Attributes.FirstOrDefault(a => a.Name == "class")?.Value.ToString();
+			Assert.Equal("dasblog-a-share-mastodon", cssClass);
+		}
+
+		[Fact]
+		[Trait("Category", "UnitTest")]
 		public void CommentContentTagHelper_WhenCommentIsNull_ShouldNotThrow()
 		{
 			var dasBlogSettingsMock = new DasBlogSettingsMock();

--- a/source/DasBlog.Web/TagHelpers/Post/PostToMastodonTagHelper.cs
+++ b/source/DasBlog.Web/TagHelpers/Post/PostToMastodonTagHelper.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using DasBlog.Services;
+using DasBlog.Web.Models.BlogViewModels;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace DasBlog.Web.TagHelpers.Post
+{
+	public class PostToMastodonTagHelper : TagHelper
+	{
+		private const string MASTODON_SHARE_URL = "https://mastodonshare.com/?text={0}&url={1}";
+		private readonly IUrlResolver urlResolver;
+		public PostViewModel Post { get; set; }
+
+		public PostToMastodonTagHelper(IUrlResolver urlResolver)
+		{
+			this.urlResolver = urlResolver;
+		}
+
+		public override async Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+		{
+			output.TagName = "a";
+			output.TagMode = TagMode.StartTagAndEndTag;
+			output.Attributes.SetAttribute("class", "dasblog-a-share-mastodon");
+			output.Attributes.SetAttribute("href", string.Format(MASTODON_SHARE_URL,
+								UrlEncoder.Default.Encode(Post.Title),
+								UrlEncoder.Default.Encode(urlResolver.RelativeToRoot(Post.PermaLink))
+								));
+
+			var content = await output.GetChildContentAsync();
+			output.Content.SetHtmlContent(content.GetContent());
+		}
+	}
+}

--- a/source/DasBlog.Web/Themes/darkly/_BlogItem.cshtml
+++ b/source/DasBlog.Web/Themes/darkly/_BlogItem.cshtml
@@ -22,7 +22,7 @@
             Categories: <post-categories-list post="@Model" >, </post-categories-list>
         </div>
         <div class="col-md-12 mb-2">
-            Share on <post-to-twitter post="@Model">Twitter</post-to-twitter>, <post-to-reddit post="@Model">Reddit</post-to-reddit>, <post-to-facebook post="@Model">Facebook</post-to-facebook> or <post-to-linked-in post="@Model">LinkedIn</post-to-linked-in>, <post-to-blue-sky post="@Model">BlueSky</post-to-blue-sky>
+            Share on <post-to-twitter post="@Model">Twitter</post-to-twitter>, <post-to-reddit post="@Model">Reddit</post-to-reddit>, <post-to-facebook post="@Model">Facebook</post-to-facebook>, <post-to-linked-in post="@Model">LinkedIn</post-to-linked-in>, <post-to-blue-sky post="@Model">BlueSky</post-to-blue-sky> or <post-to-mastodon post="@Model">Mastodon</post-to-mastodon>
         </div>
         <div dasblog-authorized class="col-md-12 mb-2">
             <post-edit-link post="@Model" />

--- a/source/DasBlog.Web/Themes/dasblog/_BlogItem.cshtml
+++ b/source/DasBlog.Web/Themes/dasblog/_BlogItem.cshtml
@@ -21,7 +21,7 @@
             Categories: <post-categories-list post="@Model" >, </post-categories-list>
         </div>
         <div class="col-md-12 mb-2">
-            Share on <post-to-twitter post="@Model">Twitter</post-to-twitter>, <post-to-reddit post="@Model">Reddit</post-to-reddit>, <post-to-facebook post="@Model">Facebook</post-to-facebook> or <post-to-linked-in post="@Model">LinkedIn</post-to-linked-in>, <post-to-blue-sky post="@Model">BlueSky</post-to-blue-sky>
+            Share on <post-to-twitter post="@Model">Twitter</post-to-twitter>, <post-to-reddit post="@Model">Reddit</post-to-reddit>, <post-to-facebook post="@Model">Facebook</post-to-facebook>, <post-to-linked-in post="@Model">LinkedIn</post-to-linked-in>, <post-to-blue-sky post="@Model">BlueSky</post-to-blue-sky> or <post-to-mastodon post="@Model">Mastodon</post-to-mastodon>
         </div>
         <div dasblog-authorized class="col-md-12 mb-2">
             <post-edit-link post="@Model" />

--- a/source/DasBlog.Web/Themes/flamingo/_BlogItem.cshtml
+++ b/source/DasBlog.Web/Themes/flamingo/_BlogItem.cshtml
@@ -31,6 +31,8 @@
             <post-to-linked-in post="@Model">LinkedIn</post-to-linked-in>
             <span class="flm-separator">&middot;</span>
             <post-to-blue-sky post="@Model">BlueSky</post-to-blue-sky>
+            <span class="flm-separator">&middot;</span>
+            <post-to-mastodon post="@Model">Mastodon</post-to-mastodon>
         </div>
         <div dasblog-authorized class="mb-3">
             <post-edit-link post="@Model" />

--- a/source/DasBlog.Web/Themes/kindofblue/_BlogItem.cshtml
+++ b/source/DasBlog.Web/Themes/kindofblue/_BlogItem.cshtml
@@ -25,7 +25,8 @@
             <post-to-reddit post="@Model">Reddit</post-to-reddit> &middot;
             <post-to-facebook post="@Model">Facebook</post-to-facebook> &middot;
             <post-to-linked-in post="@Model">LinkedIn</post-to-linked-in> &middot;
-            <post-to-blue-sky post="@Model">BlueSky</post-to-blue-sky>
+            <post-to-blue-sky post="@Model">BlueSky</post-to-blue-sky> &middot;
+            <post-to-mastodon post="@Model">Mastodon</post-to-mastodon>
         </div>
         <div dasblog-authorized class="mb-3">
             <post-edit-link post="@Model" />

--- a/source/DasBlog.Web/Themes/median/_BlogItem.cshtml
+++ b/source/DasBlog.Web/Themes/median/_BlogItem.cshtml
@@ -26,7 +26,7 @@
                 <post-created-date post="@Model" />
             </div>
             <div class="col-md-12 mb-2">
-            Share on <post-to-twitter post="@Model">Twitter</post-to-twitter>, <post-to-reddit post="@Model">Reddit</post-to-reddit>, <post-to-facebook post="@Model">Facebook</post-to-facebook> or <post-to-linked-in post="@Model">LinkedIn</post-to-linked-in>, <post-to-blue-sky post="@Model">BlueSky</post-to-blue-sky>
+            Share on <post-to-twitter post="@Model">Twitter</post-to-twitter>, <post-to-reddit post="@Model">Reddit</post-to-reddit>, <post-to-facebook post="@Model">Facebook</post-to-facebook>, <post-to-linked-in post="@Model">LinkedIn</post-to-linked-in>, <post-to-blue-sky post="@Model">BlueSky</post-to-blue-sky> or <post-to-mastodon post="@Model">Mastodon</post-to-mastodon>
             </div>
             <div dasblog-authorized class="col-md-12 mb-2">
                 <post-edit-link post="@Model" />


### PR DESCRIPTION
Add Mastodon share tag helper and update share options

Introduced PostToMastodonTagHelper for Mastodon sharing with proper URL/title encoding. Updated _BlogItem.cshtml to include Mastodon in share links. Added unit test to verify Mastodon tag helper rendering.