### PR TITLE
Adds explicit hero image support

### DIFF
--- a/source/DasBlog.Core/Common/Constants.cs
+++ b/source/DasBlog.Core/Common/Constants.cs
@@ -6,6 +6,7 @@
 		public const string BlogPostCancelAction = "Cancel";
 		public const string BlogPostAddCategoryAction = "Add";
 		public const string BlogPostEditAction = "Edit";
+		public const string BlogPostClearHeroImageAction = "ClearHeroImage";
 		public const string UsersCreateMode = "Create";
 		public const string UsersEditMode = "Edit";
 		public const string UsersDeleteMode = "Delete";

--- a/source/DasBlog.Tests/UnitTests/Mappers/ProfilePostHeroImageTests.cs
+++ b/source/DasBlog.Tests/UnitTests/Mappers/ProfilePostHeroImageTests.cs
@@ -1,0 +1,109 @@
+﻿using AutoMapper;
+using DasBlog.Services;
+using DasBlog.Web.Mappers;
+using DasBlog.Web.Models.BlogViewModels;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using newtelligence.DasBlog.Runtime;
+using System.Collections.Generic;
+using Xunit;
+
+namespace DasBlog.Tests.UnitTests.Mappers
+{
+	public class ProfilePostHeroImageTests
+	{
+		private static IMapper CreateMapper()
+		{
+			var settings = new Mock<IDasBlogSettings>();
+			settings.Setup(s => s.GeneratePostUrl(It.IsAny<Entry>())).Returns("https://example.com/post");
+			settings.Setup(s => s.GetDisplayTime(It.IsAny<System.DateTime>()))
+				.Returns<System.DateTime>(dt => dt);
+			settings.Setup(s => s.CompressTitle(It.IsAny<string>()))
+				.Returns<string>(c => c);
+
+			var config = new MapperConfiguration(cfg => cfg.AddProfile(new ProfilePost(settings.Object)), NullLoggerFactory.Instance);
+			return config.CreateMapper();
+		}
+
+		[Fact]
+		[Trait("Category", "UnitTest")]
+		public void Entry_To_PostViewModel_PopulatesHeroImageFromEntry()
+		{
+			var mapper = CreateMapper();
+			var entry = new Entry
+			{
+				Title = "T",
+				Content = "<p>hi</p>",
+				ImageUrl = "https://cdn.example.com/hero.jpg",
+				ImageAlt = "Hero alt"
+			};
+
+			var vm = mapper.Map<PostViewModel>(entry);
+
+			Assert.Equal("https://cdn.example.com/hero.jpg", vm.HeroImageUrl);
+			Assert.Equal("Hero alt", vm.HeroImageAlt);
+			// Resolved display image should also use the explicit hero value.
+			Assert.Equal("https://cdn.example.com/hero.jpg", vm.ImageUrl);
+			Assert.Equal("Hero alt", vm.ImageAlt);
+		}
+
+		[Fact]
+		[Trait("Category", "UnitTest")]
+		public void Entry_To_PostViewModel_EmptyHeroFieldsAreEmptyStrings()
+		{
+			var mapper = CreateMapper();
+			var entry = new Entry
+			{
+				Title = "T",
+				Content = "<p>no images</p>",
+				ImageUrl = null,
+				ImageAlt = null
+			};
+
+			var vm = mapper.Map<PostViewModel>(entry);
+
+			Assert.Equal(string.Empty, vm.HeroImageUrl);
+			Assert.Equal(string.Empty, vm.HeroImageAlt);
+		}
+
+		[Fact]
+		[Trait("Category", "UnitTest")]
+		public void PostViewModel_To_Entry_WritesHeroFieldsTrimmed()
+		{
+			var mapper = CreateMapper();
+			var vm = new PostViewModel
+			{
+				Title = "T",
+				Content = "<p>hi</p>",
+				HeroImageUrl = "  https://cdn.example.com/hero.jpg  ",
+				HeroImageAlt = "  Hero alt  ",
+				AllCategories = new List<CategoryViewModel>()
+			};
+
+			var entry = mapper.Map<Entry>(vm);
+
+			Assert.Equal("https://cdn.example.com/hero.jpg", entry.ImageUrl);
+			Assert.Equal("Hero alt", entry.ImageAlt);
+		}
+
+		[Fact]
+		[Trait("Category", "UnitTest")]
+		public void PostViewModel_To_Entry_EmptyHeroFieldsBecomeNull()
+		{
+			var mapper = CreateMapper();
+			var vm = new PostViewModel
+			{
+				Title = "T",
+				Content = "<p>hi</p>",
+				HeroImageUrl = "   ",
+				HeroImageAlt = string.Empty,
+				AllCategories = new List<CategoryViewModel>()
+			};
+
+			var entry = mapper.Map<Entry>(vm);
+
+			Assert.Null(entry.ImageUrl);
+			Assert.Null(entry.ImageAlt);
+		}
+	}
+}

--- a/source/DasBlog.Tests/UnitTests/Services/BlogDataServiceTest.cs
+++ b/source/DasBlog.Tests/UnitTests/Services/BlogDataServiceTest.cs
@@ -77,6 +77,45 @@ namespace DasBlog.Tests.UnitTests.Services
 		[Theory]
 		[MemberData(nameof(DasBlogDataService))]
 		[Trait("Category", "UnitTest")]
+		public void BlogDataService_HeroImageRoundTrip_Successful(IBlogDataService blogdataservice)
+		{
+			var entry = TestEntry.CreateEntry("Test Hero Image Entry", 5, 2);
+			entry.ImageUrl = "https://cdn.example.com/hero.jpg";
+			entry.ImageAlt = "Hero alt text";
+			blogdataservice.SaveEntry(entry, null);
+
+			var saved = blogdataservice.GetEntry(entry.EntryId);
+			Assert.NotNull(saved);
+			Assert.Equal("https://cdn.example.com/hero.jpg", saved.ImageUrl);
+			Assert.Equal("Hero alt text", saved.ImageAlt);
+
+			// Update the hero image fields and verify the change is persisted.
+			var forEdit = blogdataservice.GetEntryForEdit(entry.EntryId);
+			forEdit.ImageUrl = "https://cdn.example.com/hero2.jpg";
+			forEdit.ImageAlt = "Updated alt";
+			var state = blogdataservice.SaveEntry(forEdit, null);
+			Assert.True(state == EntrySaveState.Updated);
+
+			var updated = blogdataservice.GetEntry(entry.EntryId);
+			Assert.Equal("https://cdn.example.com/hero2.jpg", updated.ImageUrl);
+			Assert.Equal("Updated alt", updated.ImageAlt);
+
+			// Clearing hero image fields should also round-trip.
+			var forClear = blogdataservice.GetEntryForEdit(entry.EntryId);
+			forClear.ImageUrl = string.Empty;
+			forClear.ImageAlt = string.Empty;
+			blogdataservice.SaveEntry(forClear, null);
+
+			var cleared = blogdataservice.GetEntry(entry.EntryId);
+			Assert.True(string.IsNullOrEmpty(cleared.ImageUrl));
+			Assert.True(string.IsNullOrEmpty(cleared.ImageAlt));
+
+			blogdataservice.DeleteEntry(entry.EntryId);
+		}
+
+		[Theory]
+		[MemberData(nameof(DasBlogDataService))]
+		[Trait("Category", "UnitTest")]
 		public void BlogDataService_GetPublicEntriesForDayMaxValue_Successful(IBlogDataService blogdataservice)
 		{
 			var entries = blogdataservice.GetEntriesForDay(DateTime.MaxValue.AddDays(-2), DateTimeZone.Utc, string.Empty, int.MaxValue, int.MaxValue, string.Empty);

--- a/source/DasBlog.Tests/UnitTests/Settings/DasBlogSettingsTests.cs
+++ b/source/DasBlog.Tests/UnitTests/Settings/DasBlogSettingsTests.cs
@@ -40,6 +40,36 @@ namespace DasBlog.Tests.UnitTests.Settings
             Assert.Equal("https://example.com/feed/rss", result);
         }
 
+        [Theory]
+        [InlineData("https://cdn.example.com/images/hero.jpg")]
+        [InlineData("http://cdn.example.com/images/hero.jpg")]
+        [InlineData("HTTPS://CDN.EXAMPLE.COM/images/hero.jpg")]
+        public void RelativeToRoot_ReturnsAbsoluteUrlUnchanged(string absoluteUrl)
+        {
+            var dasBlogSettings = dasBlogSettingsMock.CreateSettings();
+            var result = dasBlogSettings.RelativeToRoot(absoluteUrl);
+            Assert.Equal(absoluteUrl, result);
+        }
+
+        [Fact]
+        public void RelativeToRoot_ReturnsProtocolRelativeUrlUnchanged()
+        {
+            var dasBlogSettings = dasBlogSettingsMock.CreateSettings();
+            var result = dasBlogSettings.RelativeToRoot("//cdn.example.com/images/hero.jpg");
+            Assert.Equal("//cdn.example.com/images/hero.jpg", result);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void RelativeToRoot_ReturnsInputUnchanged_WhenNullOrWhitespace(string input)
+        {
+            var dasBlogSettings = dasBlogSettingsMock.CreateSettings();
+            var result = dasBlogSettings.RelativeToRoot(input);
+            Assert.Equal(input, result);
+        }
+
         [Fact]
         public void GetPermaLinkUrl_ReturnsCorrectUrl()
         {

--- a/source/DasBlog.Web/Controllers/BlogPostController.cs
+++ b/source/DasBlog.Web/Controllers/BlogPostController.cs
@@ -194,6 +194,12 @@ namespace DasBlog.Web.Controllers
 				return HandleNewCategory(post);
 			}
 
+			if (submit == Constants.BlogPostClearHeroImageAction)
+			{
+				post.HeroImageUrl = string.Empty;
+				post.HeroImageAlt = string.Empty;
+			}
+
 			ValidatePostName(post);
 			if (!ModelState.IsValid)
 			{
@@ -256,6 +262,12 @@ namespace DasBlog.Web.Controllers
 			if (submit == Constants.BlogPostAddCategoryAction)
 			{
 				return HandleNewCategory(post);
+			}
+
+			if (submit == Constants.BlogPostClearHeroImageAction)
+			{
+				post.HeroImageUrl = string.Empty;
+				post.HeroImageAlt = string.Empty;
 			}
 
 			ValidatePostName(post);

--- a/source/DasBlog.Web/Controllers/DasBlogBaseController.cs
+++ b/source/DasBlog.Web/Controllers/DasBlogBaseController.cs
@@ -67,11 +67,11 @@ namespace DasBlog.Web.Settings
 				ViewData["Author"] = dasBlogSettings.GetUserByEmail(post.Author)?.DisplayName; ;
 				ViewData["PageImageUrl"] = (post.ImageUrl?.Length > 0) ? dasBlogSettings.RelativeToRoot(post.ImageUrl) : dasBlogSettings.MetaTags.TwitterImage;
 				ViewData["PageVideoUrl"] = (post.VideoUrl?.Length > 0) ? dasBlogSettings.RelativeToRoot(post.VideoUrl) : string.Empty;
-                ShowErrors(post);
+				ShowErrors(post);
 			}
 		}
 
-        private void ShowErrors(PostViewModel post)
+		private void ShowErrors(PostViewModel post)
         {
             if(post != null && post.Comments != null && post.Comments.CurrentComment != null && post.ErrorMessages != null && post.ErrorMessages.Count > 0)
             {

--- a/source/DasBlog.Web/Mappers/ProfilePost.cs
+++ b/source/DasBlog.Web/Mappers/ProfilePost.cs
@@ -35,6 +35,8 @@ namespace DasBlog.Web.Mappers
 				.ForMember(dest => dest.PermaLink, opt => opt.MapFrom(src => _dasBlogSettings.GeneratePostUrl(src)))
 				.ForMember(dest => dest.ImageUrl, opt => opt.MapFrom(src => ResolveImageUrl(src)))
 				.ForMember(dest => dest.ImageAlt, opt => opt.MapFrom(src => ResolveImageAlt(src)))
+				.ForMember(dest => dest.HeroImageUrl, opt => opt.MapFrom(src => src.ImageUrl ?? string.Empty))
+				.ForMember(dest => dest.HeroImageAlt, opt => opt.MapFrom(src => src.ImageAlt ?? string.Empty))
 				.ForMember(dest => dest.VideoUrl, opt => opt.MapFrom(src => src.Content.FindFirstYouTubeVideo()))
 				.ForMember(dest => dest.CreatedDateTime, opt => opt.MapFrom(src => _dasBlogSettings.GetDisplayTime(src.CreatedUtc)))
 				.ForMember(dest => dest.ModifiedDateTime, opt => opt.MapFrom(src => _dasBlogSettings.GetDisplayTime(src.ModifiedUtc)));
@@ -50,8 +52,8 @@ namespace DasBlog.Web.Mappers
 				.ForMember(dest => dest.Syndicated, opt => opt.MapFrom(src => src.Syndicated))
 				.ForMember(dest => dest.CreatedUtc, opt => opt.MapFrom(src => src.CreatedDateTime))
 				.ForMember(dest => dest.ModifiedLocalTime, opt => opt.MapFrom(src => src.ModifiedDateTime))
-				.ForMember(dest => dest.ImageUrl, opt => opt.MapFrom(src => string.IsNullOrWhiteSpace(src.ImageUrl) ? null : src.ImageUrl.Trim()))
-				.ForMember(dest => dest.ImageAlt, opt => opt.MapFrom(src => string.IsNullOrWhiteSpace(src.ImageAlt) ? null : src.ImageAlt.Trim()));
+				.ForMember(dest => dest.ImageUrl, opt => opt.MapFrom(src => string.IsNullOrWhiteSpace(src.HeroImageUrl) ? null : src.HeroImageUrl.Trim()))
+				.ForMember(dest => dest.ImageAlt, opt => opt.MapFrom(src => string.IsNullOrWhiteSpace(src.HeroImageAlt) ? null : src.HeroImageAlt.Trim()));
 
 			CreateMap<CategoryCacheEntry, CategoryViewModel>()
 				.ForMember(dest => dest.Category, opt => opt.MapFrom(src => src.DisplayName))

--- a/source/DasBlog.Web/Mappers/ProfilePost.cs
+++ b/source/DasBlog.Web/Mappers/ProfilePost.cs
@@ -33,8 +33,8 @@ namespace DasBlog.Web.Mappers
 				.ForMember(dest => dest.IsPublic, opt => opt.MapFrom(src => src.IsPublic))
 				.ForMember(dest => dest.Syndicated, opt => opt.MapFrom(src => src.Syndicated))
 				.ForMember(dest => dest.PermaLink, opt => opt.MapFrom(src => _dasBlogSettings.GeneratePostUrl(src)))
-				.ForMember(dest => dest.ImageUrl, opt => opt.MapFrom(src => src.Content.FindHeroImage().url))
-				.ForMember(dest => dest.ImageAlt, opt => opt.MapFrom(src => src.Content.FindHeroImage().alt))
+				.ForMember(dest => dest.ImageUrl, opt => opt.MapFrom(src => ResolveImageUrl(src)))
+				.ForMember(dest => dest.ImageAlt, opt => opt.MapFrom(src => ResolveImageAlt(src)))
 				.ForMember(dest => dest.VideoUrl, opt => opt.MapFrom(src => src.Content.FindFirstYouTubeVideo()))
 				.ForMember(dest => dest.CreatedDateTime, opt => opt.MapFrom(src => _dasBlogSettings.GetDisplayTime(src.CreatedUtc)))
 				.ForMember(dest => dest.ModifiedDateTime, opt => opt.MapFrom(src => _dasBlogSettings.GetDisplayTime(src.ModifiedUtc)));
@@ -49,7 +49,9 @@ namespace DasBlog.Web.Mappers
 				.ForMember(dest => dest.IsPublic, opt => opt.MapFrom(src => src.IsPublic))
 				.ForMember(dest => dest.Syndicated, opt => opt.MapFrom(src => src.Syndicated))
 				.ForMember(dest => dest.CreatedUtc, opt => opt.MapFrom(src => src.CreatedDateTime))
-				.ForMember(dest => dest.ModifiedLocalTime, opt => opt.MapFrom(src => src.ModifiedDateTime));
+				.ForMember(dest => dest.ModifiedLocalTime, opt => opt.MapFrom(src => src.ModifiedDateTime))
+				.ForMember(dest => dest.ImageUrl, opt => opt.MapFrom(src => string.IsNullOrWhiteSpace(src.ImageUrl) ? null : src.ImageUrl.Trim()))
+				.ForMember(dest => dest.ImageAlt, opt => opt.MapFrom(src => string.IsNullOrWhiteSpace(src.ImageAlt) ? null : src.ImageAlt.Trim()));
 
 			CreateMap<CategoryCacheEntry, CategoryViewModel>()
 				.ForMember(dest => dest.Category, opt => opt.MapFrom(src => src.DisplayName))
@@ -113,6 +115,26 @@ namespace DasBlog.Web.Mappers
 
 			CreateMap<StaticPage, StaticPageViewModel>();
 
+		}
+
+		private static string ResolveImageUrl(Entry src)
+		{
+			if (!string.IsNullOrWhiteSpace(src.ImageUrl))
+			{
+				return src.ImageUrl.Trim();
+			}
+
+			return (src.Content ?? string.Empty).FindHeroImage().url;
+		}
+
+		private static string ResolveImageAlt(Entry src)
+		{
+			if (!string.IsNullOrWhiteSpace(src.ImageUrl))
+			{
+				return src.ImageAlt ?? string.Empty;
+			}
+
+			return (src.Content ?? string.Empty).FindHeroImage().alt;
 		}
 
 		private IList<CategoryViewModel> ConvertCategory(string category)

--- a/source/DasBlog.Web/Models/BlogViewModels/PostViewModel.cs
+++ b/source/DasBlog.Web/Models/BlogViewModels/PostViewModel.cs
@@ -62,5 +62,19 @@ namespace DasBlog.Web.Models.BlogViewModels
 		public List<string> ErrorMessages { get; set; }
 
 		public string ImageAlt { get; set; } = string.Empty;
+
+		/// <summary>
+		/// Explicitly chosen hero image URL persisted on the underlying entry.
+		/// Bound by the editor UI. When empty, the resolved <see cref="ImageUrl"/>
+		/// falls back to in-content hero detection.
+		/// </summary>
+		[Display(Name = "Hero Image URL")]
+		public string HeroImageUrl { get; set; } = string.Empty;
+
+		/// <summary>
+		/// Alt text that accompanies <see cref="HeroImageUrl"/>.
+		/// </summary>
+		[Display(Name = "Hero Image Alt Text")]
+		public string HeroImageAlt { get; set; } = string.Empty;
 	}
 }

--- a/source/DasBlog.Web/Settings/DasBlogSettings.cs
+++ b/source/DasBlog.Web/Settings/DasBlogSettings.cs
@@ -88,6 +88,22 @@ namespace DasBlog.Web.Settings
 
 		public string RelativeToRoot(string relative)
 		{
+			if (string.IsNullOrWhiteSpace(relative))
+			{
+				return relative;
+			}
+
+			// Already absolute (http(s)://...) or protocol-relative (//...) — leave it alone.
+			// This lets callers safely pass values that may originate as either a
+			// site-relative path or a fully-qualified remote URL (e.g. an explicit
+			// hero image hosted on a CDN).
+			if (relative.StartsWith("http://", StringComparison.OrdinalIgnoreCase)
+				|| relative.StartsWith("https://", StringComparison.OrdinalIgnoreCase)
+				|| relative.StartsWith("//", StringComparison.Ordinal))
+			{
+				return relative;
+			}
+
 			if (!string.IsNullOrWhiteSpace(SiteConfiguration.Root))
 			{
 				return new Uri(new Uri(GetBaseUrl()), relative).AbsoluteUri;

--- a/source/DasBlog.Web/TagHelpers/RichEdit/JoditBuilder.cs
+++ b/source/DasBlog.Web/TagHelpers/RichEdit/JoditBuilder.cs
@@ -1,4 +1,4 @@
-using DasBlog.Services;
+﻿using DasBlog.Services;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 
 namespace DasBlog.Web.TagHelpers.RichEdit
@@ -123,6 +123,12 @@ namespace DasBlog.Web.TagHelpers.RichEdit
 						editor.s.insertHTML('<figure><img src=""' + url + '"" alt="""" /></figure>');
 						return false;
 					}});
+
+					// Expose the editor so other UI (e.g. the hero image picker)
+					// can reuse Jodit's filebrowser and read the live editor value.
+					window.dasBlogEditor = editor;
+					var ta = document.getElementById('{tagHelper.ControlId}');
+					if (ta) {{ ta.jodit = editor; }}
 				}});
 				</script>";
 

--- a/source/DasBlog.Web/Views/BlogPost/BlogPostFields.cshtml
+++ b/source/DasBlog.Web/Views/BlogPost/BlogPostFields.cshtml
@@ -86,3 +86,46 @@
         </div>
     </div>
 </div>
+
+<div class="card mb-3">
+    <div class="card-header">Hero image</div>
+    <div class="card-body">
+        <p class="text-muted small mb-3">
+            Pick the image used for social previews (OpenGraph / Twitter cards). Choose an existing image,
+            upload a new one, or paste a remote URL. Leave blank to fall back to the in-content hero image
+            (an <code>&lt;img class="hero-image"&gt;</code> tag or the first image in the post).
+        </p>
+
+        <div class="row gy-2 gx-3 align-items-md-start mb-3">
+            <div class="col-sm-8">
+                <div class="form-floating">
+                    <input asp-for="HeroImageUrl" id="HeroImageUrl" class="form-control" placeholder="https://... or content/binary/foo.jpg" />
+                    <label asp-for="HeroImageUrl" class="form-label"></label>
+                </div>
+                @Html.ValidationMessageFor(m => m.HeroImageUrl, null, new { @class = "text-danger" })
+            </div>
+            <div class="col-sm-4">
+                <div class="form-floating">
+                    <input asp-for="HeroImageAlt" id="HeroImageAlt" class="form-control" placeholder="Describe the image" />
+                    <label asp-for="HeroImageAlt" class="form-label"></label>
+                </div>
+            </div>
+        </div>
+
+        <div class="d-flex flex-wrap gap-2 mb-2">
+            <button type="button" class="btn btn-outline-primary" data-bs-toggle="modal" data-bs-target="#heroImagePickerModal">
+                Choose hero image…
+            </button>
+            <button type="submit" name="submit" value="@Constants.BlogPostClearHeroImageAction" class="btn btn-outline-secondary">
+                Clear hero image
+            </button>
+        </div>
+
+        <div id="HeroImagePreviewWrapper" class="mt-3 @(string.IsNullOrWhiteSpace(Model?.HeroImageUrl) ? "d-none" : "")">
+            <small class="text-muted d-block mb-1">Current hero image preview:</small>
+            <img id="HeroImagePreview" src="@Model?.HeroImageUrl" alt="@Model?.HeroImageAlt" class="img-fluid border rounded" style="max-height: 180px;" />
+        </div>
+    </div>
+</div>
+
+<partial name="_HeroImagePickerModal" />

--- a/source/DasBlog.Web/Views/BlogPost/_HeroImagePickerModal.cshtml
+++ b/source/DasBlog.Web/Views/BlogPost/_HeroImagePickerModal.cshtml
@@ -1,0 +1,47 @@
+@*
+    Hero image picker. Drives #HeroImageUrl / #HeroImageAlt / #HeroImagePreview.
+    Sources:
+      1. Images already in the current post body (parsed from the editor).
+      2. Server-side images, browsed via Jodit's existing filebrowser
+         (which already covers list + upload against /api/image).
+      3. A remote URL pasted directly (CDN, stock, etc.).
+*@
+
+<div class="modal fade" id="heroImagePickerModal" tabindex="-1" aria-labelledby="heroImagePickerLabel" aria-hidden="true">
+    <div class="modal-dialog modal-xl modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="heroImagePickerLabel">Choose hero image</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <h6 class="mb-1">In this post</h6>
+                <div id="heroPickerInPostStatus" class="text-muted small mb-2"></div>
+                <div id="heroPickerInPostGrid" class="row row-cols-2 row-cols-md-4 row-cols-lg-6 g-2 mb-3"></div>
+
+                <hr />
+
+                <div class="row g-3 align-items-end">
+                    <div class="col-md-4">
+                        <label class="form-label small text-muted mb-1">Server library</label>
+                        <button type="button" id="heroPickerBrowseServer" class="btn btn-outline-primary w-100">
+                            Browse server images…
+                        </button>
+                        <div class="form-text">Opens the same browser used by the editor (lists and uploads).</div>
+                    </div>
+                    <div class="col-md-8">
+                        <label class="form-label small text-muted mb-1" for="heroPickerRemoteUrl">Remote URL</label>
+                        <div class="input-group">
+                            <input id="heroPickerRemoteUrl" type="url" class="form-control" placeholder="https://cdn.example.com/photo.jpg" />
+                            <button type="button" id="heroPickerRemoteApply" class="btn btn-primary">Use URL</button>
+                        </div>
+                        <div class="form-text">Paste a fully-qualified image URL (CDN, stock photo, etc.).</div>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/source/DasBlog.Web/wwwroot/js/dasblog-ui.js
+++ b/source/DasBlog.Web/wwwroot/js/dasblog-ui.js
@@ -147,6 +147,208 @@ DasBlog.UI = (function() {
         }
     }
 
+    /**
+     * Initialize the hero image picker modal for the blog post editor.
+     * Reuses the existing /api/image/list and /api/image/upload endpoints
+     * so the editor has a single image pipeline.
+     */
+    function initHeroImagePicker() {
+        const modalEl = document.getElementById('heroImagePickerModal');
+        if (!modalEl) {
+            return;
+        }
+
+        let modalInstance = null;
+
+        function $(id) { return document.getElementById(id); }
+
+        function ensureModal() {
+            if (!modalInstance && typeof bootstrap !== 'undefined' && bootstrap.Modal) {
+                modalInstance = bootstrap.Modal.getOrCreateInstance(modalEl);
+            }
+            return modalInstance;
+        }
+
+        function applySelection(url) {
+            if (!url) return;
+            const urlInput = $('HeroImageUrl');
+            const altInput = $('HeroImageAlt');
+            const previewWrapper = $('HeroImagePreviewWrapper');
+            const previewImg = $('HeroImagePreview');
+            if (urlInput) urlInput.value = url;
+            if (previewImg) {
+                previewImg.src = url;
+                previewImg.alt = altInput ? altInput.value : '';
+            }
+            if (previewWrapper) previewWrapper.classList.remove('d-none');
+            const m = ensureModal();
+            if (m) m.hide();
+        }
+
+        function renderImageButton(grid, fullUrl, label) {
+            const col = document.createElement('div');
+            col.className = 'col';
+            const btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'btn p-1 w-100 border h-100 d-flex flex-column align-items-center hero-picker-in-post-item';
+            btn.title = label;
+            btn.dataset.heroUrl = fullUrl;
+            btn.innerHTML =
+                '<img src="' + fullUrl + '" alt="" class="img-fluid mb-1" style="max-height: 100px; object-fit: contain; pointer-events: none;" />' +
+                '<small class="text-truncate w-100" style="pointer-events: none;">' + label + '</small>';
+            col.appendChild(btn);
+            grid.appendChild(col);
+        }
+
+        function getJoditInstance() {
+            // The Jodit init script attaches the editor instance both on
+            // window.dasBlogEditor and on the underlying textarea element.
+            if (typeof window !== 'undefined' && window.dasBlogEditor) {
+                return window.dasBlogEditor;
+            }
+            const textarea = $('mytextarea');
+            if (textarea && textarea.jodit) return textarea.jodit;
+            // Jodit v4 maintains a static instances map keyed by element.
+            if (typeof window !== 'undefined' && window.Jodit && window.Jodit.instances) {
+                const inst = window.Jodit.instances['mytextarea']
+                    || (textarea && window.Jodit.instances[textarea.id]);
+                if (inst) return inst;
+            }
+            return null;
+        }
+
+        function getCurrentPostHtml() {
+            const jodit = getJoditInstance();
+            if (jodit && typeof jodit.getEditorValue === 'function') {
+                try { return jodit.getEditorValue() || ''; } catch (e) { /* ignore */ }
+            }
+            const textarea = $('mytextarea');
+            return textarea ? (textarea.value || '') : '';
+        }
+
+        function extractPostImages() {
+            const html = getCurrentPostHtml();
+            if (!html) return [];
+            const parser = new DOMParser();
+            const doc = parser.parseFromString(html, 'text/html');
+            const imgs = doc.querySelectorAll('img[src]');
+            const seen = new Set();
+            const results = [];
+            imgs.forEach(function (img) {
+                const src = (img.getAttribute('src') || '').trim();
+                if (!src || seen.has(src)) return;
+                seen.add(src);
+                let label = src;
+                const lastSlash = src.lastIndexOf('/');
+                if (lastSlash >= 0 && lastSlash < src.length - 1) {
+                    label = src.substring(lastSlash + 1);
+                }
+                results.push({ url: src, label: label });
+            });
+            return results;
+        }
+
+        function renderInPost() {
+            const inPostGrid = $('heroPickerInPostGrid');
+            const inPostStatus = $('heroPickerInPostStatus');
+            if (!inPostGrid) return;
+            inPostGrid.innerHTML = '';
+            const images = extractPostImages();
+            if (images.length === 0) {
+                if (inPostStatus) {
+                    inPostStatus.textContent = 'No images found in the current post body. Browse the server library or paste a remote URL below.';
+                }
+                return;
+            }
+            if (inPostStatus) {
+                inPostStatus.textContent = images.length + ' image' + (images.length === 1 ? '' : 's') + ' found in this post.';
+            }
+            images.forEach(function (img) {
+                renderImageButton(inPostGrid, img.url, img.label);
+            });
+        }
+
+        function openServerBrowser() {
+            const jodit = getJoditInstance();
+            if (!jodit || !jodit.filebrowser || typeof jodit.filebrowser.open !== 'function') {
+                window.alert('Server image browser is not available yet. Please wait for the editor to finish loading.');
+                return;
+            }
+            const m = ensureModal();
+            if (m) m.hide();
+            try {
+                jodit.filebrowser.open(function (data) {
+                    if (!data) return;
+                    const files = data.files || data;
+                    if (!files || !files.length) return;
+                    const first = files[0];
+                    let url = '';
+                    if (typeof first === 'string') {
+                        url = first;
+                    } else if (first && first.url) {
+                        url = first.url;
+                    } else if (first && first.name) {
+                        url = (data.baseurl || '') + first.name;
+                    }
+                    if (url) applySelection(url);
+                }, false);
+            } catch (e) {
+                window.alert('Unable to open the server image browser: ' + e.message);
+            }
+        }
+
+        function applyRemote() {
+            const input = $('heroPickerRemoteUrl');
+            if (!input) return;
+            const value = (input.value || '').trim();
+            if (!value) return;
+            applySelection(value);
+            input.value = '';
+        }
+
+        // Refresh "In this post" each time the modal opens.
+        modalEl.addEventListener('shown.bs.modal', renderInPost);
+
+        // Event delegation so the handlers survive any DOM rebuilds / timing quirks.
+        document.addEventListener('click', function (ev) {
+            const target = ev.target;
+            if (!target || target.nodeType !== 1) return;
+
+            if (target.closest('#heroPickerBrowseServer')) {
+                ev.preventDefault();
+                openServerBrowser();
+                return;
+            }
+            if (target.closest('#heroPickerRemoteApply')) {
+                ev.preventDefault();
+                applyRemote();
+                return;
+            }
+            const inPostBtn = target.closest('.hero-picker-in-post-item');
+            if (inPostBtn) {
+                ev.preventDefault();
+                applySelection(inPostBtn.dataset.heroUrl || '');
+            }
+        });
+
+        // Pressing Enter in the remote URL field should apply it.
+        document.addEventListener('keydown', function (ev) {
+            if (ev.key !== 'Enter') return;
+            const target = ev.target;
+            if (target && target.id === 'heroPickerRemoteUrl') {
+                ev.preventDefault();
+                applyRemote();
+            }
+        });
+    }
+
+    // Auto-init the hero picker when present on the page.
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initHeroImagePicker);
+    } else {
+        initHeroImagePicker();
+    }
+
     // Public API
     return {
         showSessionAlert: showSessionAlert,
@@ -154,6 +356,7 @@ DasBlog.UI = (function() {
         saveAccordionState: saveAccordionState,
         restoreAccordionState: restoreAccordionState,
         initAccordionTracking: initAccordionTracking,
-        autoDismissAlert: autoDismissAlert
+        autoDismissAlert: autoDismissAlert,
+        initHeroImagePicker: initHeroImagePicker
     };
 })();

--- a/source/DasBlog.Web/wwwroot/js/dasblog-ui.js
+++ b/source/DasBlog.Web/wwwroot/js/dasblog-ui.js
@@ -193,9 +193,22 @@ DasBlog.UI = (function() {
             btn.className = 'btn p-1 w-100 border h-100 d-flex flex-column align-items-center hero-picker-in-post-item';
             btn.title = label;
             btn.dataset.heroUrl = fullUrl;
-            btn.innerHTML =
-                '<img src="' + fullUrl + '" alt="" class="img-fluid mb-1" style="max-height: 100px; object-fit: contain; pointer-events: none;" />' +
-                '<small class="text-truncate w-100" style="pointer-events: none;">' + label + '</small>';
+
+            const img = document.createElement('img');
+            img.src = fullUrl;
+            img.alt = '';
+            img.className = 'img-fluid mb-1';
+            img.style.maxHeight = '100px';
+            img.style.objectFit = 'contain';
+            img.style.pointerEvents = 'none';
+
+            const text = document.createElement('small');
+            text.className = 'text-truncate w-100';
+            text.style.pointerEvents = 'none';
+            text.textContent = label;
+
+            btn.appendChild(img);
+            btn.appendChild(text);
             col.appendChild(btn);
             grid.appendChild(col);
         }

--- a/source/newtelligence.DasBlog.Runtime/BlogDataService.cs
+++ b/source/newtelligence.DasBlog.Runtime/BlogDataService.cs
@@ -835,9 +835,11 @@ namespace newtelligence.DasBlog.Runtime
                 currentEntry.AllowComments = entry.AllowComments;
                 currentEntry.Link = entry.Link;
                 currentEntry.ShowOnFrontPage = entry.ShowOnFrontPage;
-                currentEntry.Title = entry.Title;
+				currentEntry.Title = entry.Title;
 				currentEntry.Latitude = entry.Latitude;
 				currentEntry.Longitude = entry.Longitude;
+				currentEntry.ImageUrl = entry.ImageUrl;
+				currentEntry.ImageAlt = entry.ImageAlt;
 
                 currentEntry.Crossposts.Clear();
                 currentEntry.Crossposts.AddRange(entry.Crossposts);

--- a/source/newtelligence.DasBlog.Runtime/Entry.cs
+++ b/source/newtelligence.DasBlog.Runtime/Entry.cs
@@ -302,12 +302,14 @@ namespace newtelligence.DasBlog.Runtime
 				Entry entry2 = entry as Entry;
 				// we will only change the mod date if there has been a change to a few things
 				if (Title != entry2.Title ||
-				    Description != entry2.Description ||
-				    Content != entry2.Content ||
-				    Categories != entry2.Categories ||
-				    Author != entry2.Author ||
-				    Link != entry2.Link ||
-				    Attachments.Count != entry2.Attachments.Count)
+					Description != entry2.Description ||
+					Content != entry2.Content ||
+					Categories != entry2.Categories ||
+					Author != entry2.Author ||
+					Link != entry2.Link ||
+					ImageUrl != entry2.ImageUrl ||
+					ImageAlt != entry2.ImageAlt ||
+					Attachments.Count != entry2.Attachments.Count)
 				{
 					different = true;
 				}

--- a/source/newtelligence.DasBlog.Runtime/Entry.cs
+++ b/source/newtelligence.DasBlog.Runtime/Entry.cs
@@ -69,6 +69,8 @@ namespace newtelligence.DasBlog.Runtime
 		bool _showOnFrontPage = true;
 		bool _syndicated = true;
 		string _title;
+		string _imageUrl;
+		string _imageAlt;
 
 		[XmlAnyAttribute]
 		public XmlAttribute[] anyAttributes;
@@ -238,6 +240,27 @@ namespace newtelligence.DasBlog.Runtime
 		{
 			get { return _longitude; }
 			set { _longitude = value; }
+		}
+
+		/// <summary>
+		/// Explicitly chosen hero/main image URL for this entry. May be a site-relative
+		/// path produced by the binary upload pipeline, or an absolute remote URL.
+		/// When null or empty, callers fall back to in-content detection
+		/// (e.g. <c>&lt;img class="hero-image" ...&gt;</c> or the first image in the content).
+		/// </summary>
+		public string ImageUrl
+		{
+			get { return _imageUrl; }
+			set { _imageUrl = value; }
+		}
+
+		/// <summary>
+		/// Alt text that accompanies <see cref="ImageUrl"/>.
+		/// </summary>
+		public string ImageAlt
+		{
+			get { return _imageAlt; }
+			set { _imageAlt = value; }
 		}
 
 		#region IComparable Members


### PR DESCRIPTION
#### PR Classification
New feature: Adds explicit hero image support for blog posts.

#### PR Summary
This PR introduces the ability to set, edit, and clear a dedicated hero image and alt text for blog posts, with UI enhancements and backend persistence. It also improves URL handling and adds related unit tests.
- PostViewModel.cs, Entry.cs: Add HeroImageUrl and HeroImageAlt properties and persist them.
- BlogPostFields.cshtml, _HeroImagePickerModal.cshtml: Add UI for hero image selection and preview.
- dasblog-ui.js: Implement modal-based hero image picker with in-post, server, and remote image support.
- ProfilePost.cs, BlogPostController.cs, BlogDataService.cs: Update mapping, controller logic, and data service for hero image round-tripping and clearing.
- DasBlogSettings.cs, DasBlogSettingsTests.cs: Enhance RelativeToRoot for absolute/protocol-relative URLs and add tests.
