### PR TITLE
First-run setup flow replaces default admin password

### DIFF
--- a/source/DasBlog.CLI/Program.cs
+++ b/source/DasBlog.CLI/Program.cs
@@ -18,7 +18,6 @@ namespace DasBlog.CLI
 		public const string ASPNETCORE_ENV_NAME = "ASPNETCORE_ENVIRONMENT";
 		public static string ASPNETCORE_ENVIRONMENT = Environment.GetEnvironmentVariable(ASPNETCORE_ENV_NAME);
 		public static string CONFIG_DIRECTORY = Path.Combine(Environment.CurrentDirectory, "Config");
-		public const string ADMINPASSWORD = "19-A2-85-41-44-B6-3A-8F-76-17-A6-F2-25-01-9B-12";
 		public static string SITECONFIG_FILENAME = string.Empty;
 		public static string SITESECURITYCONFIG_FILENAME = string.Empty;
 
@@ -246,26 +245,38 @@ namespace DasBlog.CLI
 
 			app.Command("resetpassword", resetCmd =>
 			{
-				resetCmd.Description = "**WARNING** Resets all user passowrds to 'admin'";
+				resetCmd.Description = "**WARNING** Clears all user passwords. The site will require first-run setup on next start.";
+				var yes = resetCmd.Option("-y|--yes", "Skip the confirmation prompt.", CommandOptionType.NoValue);
 				resetCmd.OnExecute(() =>
 				{
+					if (!yes.HasValue())
+					{
+						Console.Write("This will clear every user's password and force first-run setup on next start. Type 'reset' to confirm: ");
+						var confirmation = Console.ReadLine();
+						if (!string.Equals(confirmation?.Trim(), "reset", StringComparison.Ordinal))
+						{
+							Console.WriteLine("Aborted.");
+							return;
+						}
+					}
+
 					var serviceProvider = service.BuildServiceProvider();
 					var userService = serviceProvider.GetService<IUserService>();
 
 					var users = userService.GetAllUsers().ToList();
 
-					users.ForEach(x => x.Password = ADMINPASSWORD);
+					users.ForEach(x => x.Password = string.Empty);
 
 					var fs = serviceProvider.GetService<IConfigFileService<SiteSecurityConfigData>>();
 					if (fs.SaveConfig(new SiteSecurityConfigData() { Users = users }))
 					{
-						Console.WriteLine("All passwords reset to 'admin'");
+						Console.WriteLine("All passwords cleared. Visit the site to complete first-run setup.");
 					}
 					else
 					{
 						Console.WriteLine($"Reset failed!");
 					}
-					
+
 				});
 
 			});

--- a/source/DasBlog.Tests/UnitTests/Web/Controllers/AccountControllerSetupTests.cs
+++ b/source/DasBlog.Tests/UnitTests/Web/Controllers/AccountControllerSetupTests.cs
@@ -1,0 +1,174 @@
+﻿﻿using System.Collections.Generic;
+using DasBlog.Core.Security;
+using DasBlog.Managers.Interfaces;
+using DasBlog.Services;
+using DasBlog.Services.ConfigFile.Interfaces;
+using DasBlog.Services.Users;
+using DasBlog.Web.Controllers;
+using DasBlog.Web.Models.AccountViewModels;
+using DasBlog.Web.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace DasBlog.Tests.UnitTests.Web.Controllers
+{
+	public class AccountControllerSetupTests
+	{
+		private static AccountController Build(
+			bool setupRequired,
+			IUserService userService = null,
+			ISiteSecurityManager siteSecurityManager = null,
+			ISiteSecurityConfig siteSecurityConfig = null)
+		{
+			var firstRun = new Mock<IFirstRunService>();
+			firstRun.Setup(s => s.IsSetupRequired()).Returns(setupRequired);
+
+			userService ??= Mock.Of<IUserService>(s => s.GetAllUsers() == new List<User>());
+			siteSecurityManager ??= Mock.Of<ISiteSecurityManager>(
+				s => s.HashPassword(It.IsAny<string>()) == "HASH");
+			siteSecurityConfig ??= Mock.Of<ISiteSecurityConfig>();
+
+			var settings = Mock.Of<IDasBlogSettings>();
+			var logger = Mock.Of<ILogger<AccountController>>();
+
+			return new AccountController(
+				userManager: null,
+				signInManager: null,
+				mapper: null,
+				logger: logger,
+				settings: settings,
+				firstRunService: firstRun.Object,
+				userService: userService,
+				siteSecurityManager: siteSecurityManager,
+				siteSecurityConfig: siteSecurityConfig);
+		}
+
+		[Fact]
+		public void Setup_Get_ReturnsNotFoundWhenNotRequired()
+		{
+			var controller = Build(setupRequired: false);
+
+			var result = controller.Setup();
+
+			Assert.IsType<NotFoundResult>(result);
+		}
+
+		[Fact]
+		public void Setup_Post_ReturnsNotFoundWhenNotRequired()
+		{
+			var controller = Build(setupRequired: false);
+
+			var result = controller.Setup(new SetupViewModel());
+
+			Assert.IsType<NotFoundResult>(result);
+		}
+
+		[Fact]
+		public void Setup_Post_ReturnsViewWhenModelInvalid()
+		{
+			var controller = Build(setupRequired: true);
+			controller.ModelState.AddModelError("Password", "required");
+
+			var result = controller.Setup(new SetupViewModel());
+
+			Assert.IsType<ViewResult>(result);
+		}
+
+		[Fact]
+		public void Setup_Post_CreatesAdminAndRedirectsToLogin()
+		{
+			var userService = new Mock<IUserService>();
+			userService.Setup(s => s.GetAllUsers()).Returns(new List<User>());
+
+			var saved = new List<(User user, string original)>();
+			userService
+				.Setup(s => s.AddOrReplaceUser(It.IsAny<User>(), It.IsAny<string>()))
+				.Callback<User, string>((u, original) =>
+				{
+					saved.Add((u, original));
+					userService.Setup(s => s.GetAllUsers()).Returns(new List<User> { u });
+				});
+
+			var security = new Mock<ISiteSecurityManager>();
+			security.Setup(s => s.HashPassword("strong-pwd-1!")).Returns("HASHED");
+
+			var config = new Mock<ISiteSecurityConfig>();
+			config.SetupProperty(c => c.Users, new List<User>());
+
+			var controller = Build(
+				setupRequired: true,
+				userService: userService.Object,
+				siteSecurityManager: security.Object,
+				siteSecurityConfig: config.Object);
+
+			var model = new SetupViewModel
+			{
+				Email = "  new@example.com  ",
+				DisplayName = "  Admin Person  ",
+				Password = "strong-pwd-1!",
+				ConfirmPassword = "strong-pwd-1!"
+			};
+
+			var result = controller.Setup(model);
+
+			var redirect = Assert.IsType<RedirectToActionResult>(result);
+			Assert.Equal("Login", redirect.ActionName);
+
+			Assert.Single(saved);
+			Assert.Equal("new@example.com", saved[0].user.EmailAddress);
+			Assert.Equal("Admin Person", saved[0].user.DisplayName);
+			Assert.Equal("HASHED", saved[0].user.Password);
+			Assert.Equal(Role.Admin, saved[0].user.Role);
+			Assert.True(saved[0].user.Active);
+			Assert.Equal(string.Empty, saved[0].original);
+
+			// Cache must be synced so the freshly-saved admin is visible to subsequent logins.
+			Assert.Single(config.Object.Users);
+			Assert.Equal("new@example.com", config.Object.Users[0].EmailAddress);
+		}
+
+		[Fact]
+		public void Setup_Post_ReplacesExistingAdminPreservingOriginalEmail()
+		{
+			var existing = new User
+			{
+				Role = Role.Admin,
+				EmailAddress = "old@example.com",
+				DisplayName = "Old Admin",
+				Password = string.Empty
+			};
+			var userService = new Mock<IUserService>();
+			userService.Setup(s => s.GetAllUsers()).Returns(new List<User> { existing });
+
+			var saved = new List<(User user, string original)>();
+			userService
+				.Setup(s => s.AddOrReplaceUser(It.IsAny<User>(), It.IsAny<string>()))
+				.Callback<User, string>((u, original) => saved.Add((u, original)));
+
+			var security = new Mock<ISiteSecurityManager>();
+			security.Setup(s => s.HashPassword(It.IsAny<string>())).Returns("HASHED");
+
+			var controller = Build(
+				setupRequired: true,
+				userService: userService.Object,
+				siteSecurityManager: security.Object);
+
+			var model = new SetupViewModel
+			{
+				Email = "new@example.com",
+				DisplayName = "New Admin",
+				Password = "strong-pwd-1!",
+				ConfirmPassword = "strong-pwd-1!"
+			};
+
+			controller.Setup(model);
+
+			Assert.Single(saved);
+			Assert.Equal("old@example.com", saved[0].original);
+			Assert.Equal("new@example.com", saved[0].user.EmailAddress);
+			Assert.Equal("New Admin", saved[0].user.DisplayName);
+		}
+	}
+}

--- a/source/DasBlog.Tests/UnitTests/Web/Services/DefaultCredentialsCheckTests.cs
+++ b/source/DasBlog.Tests/UnitTests/Web/Services/DefaultCredentialsCheckTests.cs
@@ -1,0 +1,107 @@
+﻿﻿using System.Collections.Generic;
+using DasBlog.Core.Security;
+using DasBlog.Managers.Interfaces;
+using DasBlog.Services.Users;
+using DasBlog.Web.Services;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using Xunit;
+
+namespace DasBlog.Tests.UnitTests.Web.Services
+{
+	public class DefaultCredentialsCheckTests
+	{
+		private const string IdentityHashOfAdmin = "AQAAAAIAAYagAAAAEH3HFD0v2zM73SHvLLO6+wXyhqIcsmEC2T1lwIkqJzJL4cT8M5h0K3PYV0L9aGRrYg==";
+
+		private static IDefaultCredentialsCheck CreateCheck(IEnumerable<User> users, bool isDevelopment = false)
+		{
+			var userService = new Mock<IUserService>();
+			userService.Setup(s => s.GetAllUsers()).Returns(users);
+
+			var environment = new Mock<IHostEnvironment>();
+			environment.SetupGet(e => e.EnvironmentName).Returns(isDevelopment ? "Development" : "Production");
+
+			// Use a real SiteSecurityManager so VerifyHashedPassword behaves authentically.
+			var settings = new Mock<DasBlog.Services.IDasBlogSettings>().Object;
+			var security = new DasBlog.Managers.SiteSecurityManager(settings, new PasswordHasher<object>());
+
+			return new DefaultCredentialsCheck(userService.Object, environment.Object, security);
+		}
+
+		[Fact]
+		public void IsUsingDefaults_TrueForDefaultEmail()
+		{
+			var check = CreateCheck(new[]
+			{
+				new User { EmailAddress = "myemail@myemail.com", Password = "irrelevant" }
+			});
+
+			Assert.True(check.IsUsingDefaults());
+		}
+
+		[Fact]
+		public void IsUsingDefaults_TrueForEmptyPassword()
+		{
+			var check = CreateCheck(new[]
+			{
+				new User { EmailAddress = "real@example.com", Password = string.Empty }
+			});
+
+			Assert.True(check.IsUsingDefaults());
+		}
+
+		[Fact]
+		public void IsUsingDefaults_TrueForAdminStoredAsIdentityHash()
+		{
+			var hasher = new PasswordHasher<object>();
+			var adminHash = hasher.HashPassword(null, "admin");
+
+			var check = CreateCheck(new[]
+			{
+				new User { EmailAddress = "real@example.com", Password = adminHash }
+			});
+
+			Assert.True(check.IsUsingDefaults());
+		}
+
+		[Fact]
+		public void IsUsingDefaults_TrueForAdminStoredAsLegacyMd5()
+		{
+			// Legacy BitConverter-formatted MD5(UTF-16LE) of "admin"
+			const string legacyMd5OfAdmin = "19-A2-85-41-44-B6-3A-8F-76-17-A6-F2-25-01-9B-12";
+
+			var check = CreateCheck(new[]
+			{
+				new User { EmailAddress = "real@example.com", Password = legacyMd5OfAdmin }
+			});
+
+			Assert.True(check.IsUsingDefaults());
+		}
+
+		[Fact]
+		public void IsUsingDefaults_FalseForRealCredentials()
+		{
+			var hasher = new PasswordHasher<object>();
+			var strongHash = hasher.HashPassword(null, "a-much-stronger-password-1!");
+
+			var check = CreateCheck(new[]
+			{
+				new User { EmailAddress = "real@example.com", Password = strongHash }
+			});
+
+			Assert.False(check.IsUsingDefaults());
+		}
+
+		[Fact]
+		public void IsUsingDefaults_FalseInDevelopmentEvenWithDefaults()
+		{
+			var check = CreateCheck(new[]
+			{
+				new User { EmailAddress = "myemail@myemail.com", Password = string.Empty }
+			}, isDevelopment: true);
+
+			Assert.False(check.IsUsingDefaults());
+		}
+	}
+}

--- a/source/DasBlog.Tests/UnitTests/Web/Services/FirstRunServiceTests.cs
+++ b/source/DasBlog.Tests/UnitTests/Web/Services/FirstRunServiceTests.cs
@@ -1,0 +1,60 @@
+﻿﻿using System.Collections.Generic;
+using DasBlog.Core.Security;
+using DasBlog.Services.Users;
+using DasBlog.Web.Services;
+using Moq;
+using Xunit;
+
+namespace DasBlog.Tests.UnitTests.Web.Services
+{
+	public class FirstRunServiceTests
+	{
+		private static IFirstRunService Create(IEnumerable<User> users)
+		{
+			var userService = new Mock<IUserService>();
+			userService.Setup(s => s.GetAllUsers()).Returns(users);
+			return new FirstRunService(userService.Object);
+		}
+
+		[Fact]
+		public void IsSetupRequired_TrueWhenNoUsers()
+		{
+			var service = Create(new List<User>());
+			Assert.True(service.IsSetupRequired());
+		}
+
+		[Fact]
+		public void IsSetupRequired_TrueWhenAllPasswordsEmpty()
+		{
+			var service = Create(new[]
+			{
+				new User { EmailAddress = "a@example.com", Password = string.Empty },
+				new User { EmailAddress = "b@example.com", Password = "   " }
+			});
+
+			Assert.True(service.IsSetupRequired());
+		}
+
+		[Fact]
+		public void IsSetupRequired_FalseWhenAnyUserHasPassword()
+		{
+			var service = Create(new[]
+			{
+				new User { EmailAddress = "a@example.com", Password = string.Empty },
+				new User { EmailAddress = "b@example.com", Password = "hashed" }
+			});
+
+			Assert.False(service.IsSetupRequired());
+		}
+
+		[Fact]
+		public void IsSetupRequired_TrueWhenUsersIsNull()
+		{
+			var userService = new Mock<IUserService>();
+			userService.Setup(s => s.GetAllUsers()).Returns((IEnumerable<User>)null);
+			var service = new FirstRunService(userService.Object);
+
+			Assert.True(service.IsSetupRequired());
+		}
+	}
+}

--- a/source/DasBlog.Web/Config/siteSecurity.config
+++ b/source/DasBlog.Web/Config/siteSecurity.config
@@ -11,7 +11,7 @@
       <NotifyOnAllComment>true</NotifyOnAllComment>
       <NotifyOnOwnComment>true</NotifyOnOwnComment>
       <Active>true</Active>
-      <Password>19-A2-85-41-44-B6-3A-8F-76-17-A6-F2-25-01-9B-12</Password>
+      <Password></Password>
     </User>
   </Users>
 </SiteSecurityConfig>

--- a/source/DasBlog.Web/Controllers/AccountController.cs
+++ b/source/DasBlog.Web/Controllers/AccountController.cs
@@ -1,8 +1,13 @@
 ﻿using AutoMapper;
+using DasBlog.Core.Security;
+using DasBlog.Managers.Interfaces;
 using DasBlog.Services;
 using DasBlog.Services.ActivityLogs;
+using DasBlog.Services.ConfigFile.Interfaces;
+using DasBlog.Services.Users;
 using DasBlog.Web.Identity;
 using DasBlog.Web.Models.AccountViewModels;
+using DasBlog.Web.Services;
 using DasBlog.Web.Settings;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
@@ -10,6 +15,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Logging;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace DasBlog.Web.Controllers
@@ -22,16 +28,26 @@ namespace DasBlog.Web.Controllers
 		private readonly IMapper mapper;
 		private readonly SignInManager<DasBlogUser> signInManager;
 		private readonly UserManager<DasBlogUser> userManager;
+		private readonly IFirstRunService firstRunService;
+		private readonly IUserService userService;
+		private readonly ISiteSecurityManager siteSecurityManager;
+		private readonly ISiteSecurityConfig siteSecurityConfig;
 		private const string LOGIN = "Login";
 
 		public AccountController(UserManager<DasBlogUser> userManager, SignInManager<DasBlogUser> signInManager,
-							IMapper mapper, ILogger<AccountController> logger, IDasBlogSettings settings) 
+							IMapper mapper, ILogger<AccountController> logger, IDasBlogSettings settings,
+							IFirstRunService firstRunService, IUserService userService,
+							ISiteSecurityManager siteSecurityManager, ISiteSecurityConfig siteSecurityConfig)
 							: base(settings)
 		{
 			this.signInManager = signInManager;
 			this.userManager = userManager;
 			this.logger = logger;
 			this.mapper = mapper;
+			this.firstRunService = firstRunService;
+			this.userService = userService;
+			this.siteSecurityManager = siteSecurityManager;
+			this.siteSecurityConfig = siteSecurityConfig;
 		}
 
 		[HttpGet]
@@ -115,6 +131,60 @@ namespace DasBlog.Web.Controllers
 			}
 
 			return View(model);
+		}
+
+		[HttpGet]
+		[AllowAnonymous]
+		public IActionResult Setup()
+		{
+			if (!firstRunService.IsSetupRequired())
+			{
+				return NotFound();
+			}
+
+			DefaultPage("Setup");
+			return View(new SetupViewModel());
+		}
+
+		[HttpPost]
+		[AllowAnonymous]
+		[ValidateAntiForgeryToken]
+		public IActionResult Setup(SetupViewModel model)
+		{
+			if (!firstRunService.IsSetupRequired())
+			{
+				return NotFound();
+			}
+
+			if (!ModelState.IsValid)
+			{
+				return View(model);
+			}
+
+			var users = userService.GetAllUsers().ToList();
+			var admin = users.FirstOrDefault(u => u.Role == Role.Admin);
+			var originalEmail = admin?.EmailAddress ?? string.Empty;
+
+			if (admin == null)
+			{
+				admin = new User { Role = Role.Admin, Active = true };
+			}
+
+			admin.EmailAddress = model.Email.Trim();
+			admin.DisplayName = model.DisplayName.Trim();
+			admin.Active = true;
+			admin.Password = siteSecurityManager.HashPassword(model.Password);
+
+			userService.AddOrReplaceUser(admin, originalEmail);
+
+			// Refresh the cached SecurityConfiguration.Users list so the freshly-saved
+			// admin is visible to DasBlogUserStore.FindByNameAsync on the next login.
+			siteSecurityConfig.Users = userService.GetAllUsers().ToList();
+
+			logger.LogInformation(new EventDataItem(EventCodes.SecuritySuccess, null,
+				"First-run setup completed for {email}", admin.EmailAddress));
+
+			return RedirectToAction(nameof(Login));
 		}
 	}
 }

--- a/source/DasBlog.Web/DasBlogServiceCollectionExtensions.cs
+++ b/source/DasBlog.Web/DasBlogServiceCollectionExtensions.cs
@@ -105,7 +105,8 @@ namespace DasBlog.Web
 				.AddSingleton<IThemeManager, ThemeManager>()
 				.AddSingleton<IThemeContentValidator, ThemeContentValidator>()
 				.AddSingleton<IStaticPageManager, StaticPageManager>()
-				.AddScoped<IDefaultCredentialsCheck, DefaultCredentialsCheck>();
+				.AddScoped<IDefaultCredentialsCheck, DefaultCredentialsCheck>()
+				.AddSingleton<IFirstRunService, FirstRunService>();
 
 			services				
 				.AddTransient<IUserStore<DasBlogUser>, DasBlogUserStore>()

--- a/source/DasBlog.Web/Models/AccountViewModels/SetupViewModel.cs
+++ b/source/DasBlog.Web/Models/AccountViewModels/SetupViewModel.cs
@@ -1,0 +1,28 @@
+﻿﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+
+namespace DasBlog.Web.Models.AccountViewModels
+{
+	public class SetupViewModel
+	{
+		[Required]
+		[EmailAddress]
+		[DisplayName("Admin email")]
+		public string Email { get; set; }
+
+		[Required]
+		[DisplayName("Display name")]
+		public string DisplayName { get; set; }
+
+		[Required]
+		[DataType(DataType.Password)]
+		[StringLength(100, MinimumLength = 8, ErrorMessage = "Password must be at least 8 characters.")]
+		public string Password { get; set; }
+
+		[Required]
+		[DataType(DataType.Password)]
+		[DisplayName("Confirm password")]
+		[Compare(nameof(Password), ErrorMessage = "Passwords do not match.")]
+		public string ConfirmPassword { get; set; }
+	}
+}

--- a/source/DasBlog.Web/Program.cs
+++ b/source/DasBlog.Web/Program.cs
@@ -4,6 +4,7 @@ using DasBlog.Services.FileManagement;
 using DasBlog.Services.Scheduler;
 using DasBlog.Services.Site;
 using DasBlog.Web;
+using DasBlog.Web.Services;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.RateLimiting;
@@ -138,6 +139,8 @@ if (basePath != "/")
 app.UseForwardedHeaders();
 app.UseDasBlogStaticFiles(env, paths);
 app.UseCookiePolicy();
+
+app.UseFirstRunSetup();
 
 app.UseAuthentication();
 app.UseDasBlogThreadPrincipal();

--- a/source/DasBlog.Web/Services/DefaultCredentialsCheck.cs
+++ b/source/DasBlog.Web/Services/DefaultCredentialsCheck.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using DasBlog.Managers.Interfaces;
 using DasBlog.Services.Users;
 using Microsoft.Extensions.Hosting;
 
@@ -12,16 +13,21 @@ namespace DasBlog.Web.Services
 
 	public class DefaultCredentialsCheck : IDefaultCredentialsCheck
 	{
-		private const string DEFAULT_EMAIL = "myemail@myemail.com";
-		private const string DEFAULT_PASSWORD_HASH = "19-A2-85-41-44-B6-3A-8F-76-17-A6-F2-25-01-9B-12";
+		internal const string DEFAULT_EMAIL = "myemail@myemail.com";
+		internal const string DEFAULT_PASSWORD = "admin";
 
 		private readonly IUserService userService;
 		private readonly IHostEnvironment hostEnvironment;
+		private readonly ISiteSecurityManager siteSecurityManager;
 
-		public DefaultCredentialsCheck(IUserService userService, IHostEnvironment hostEnvironment)
+		public DefaultCredentialsCheck(
+			IUserService userService,
+			IHostEnvironment hostEnvironment,
+			ISiteSecurityManager siteSecurityManager)
 		{
 			this.userService = userService;
 			this.hostEnvironment = hostEnvironment;
+			this.siteSecurityManager = siteSecurityManager;
 		}
 
 		public bool IsUsingDefaults()
@@ -33,9 +39,15 @@ namespace DasBlog.Web.Services
 			}
 
 			var users = userService.GetAllUsers();
+			if (users == null)
+			{
+				return true;
+			}
+
 			return users.Any(u =>
 				string.Equals(u.EmailAddress, DEFAULT_EMAIL, StringComparison.OrdinalIgnoreCase)
-				|| u.Password == DEFAULT_PASSWORD_HASH);
+				|| string.IsNullOrWhiteSpace(u.Password)
+				|| siteSecurityManager.VerifyHashedPassword(u.Password, DEFAULT_PASSWORD));
 		}
 	}
 }

--- a/source/DasBlog.Web/Services/FirstRunService.cs
+++ b/source/DasBlog.Web/Services/FirstRunService.cs
@@ -1,0 +1,37 @@
+﻿﻿using System.Linq;
+using DasBlog.Services.Users;
+
+namespace DasBlog.Web.Services
+{
+	public interface IFirstRunService
+	{
+		/// <summary>
+		/// Returns true when the site has no usable admin credentials and the
+		/// operator must complete the first-run setup flow before logging in.
+		/// </summary>
+		bool IsSetupRequired();
+	}
+
+	public class FirstRunService : IFirstRunService
+	{
+		private readonly IUserService userService;
+
+		public FirstRunService(IUserService userService)
+		{
+			this.userService = userService;
+		}
+
+		public bool IsSetupRequired()
+		{
+			var users = userService.GetAllUsers()?.ToList();
+			if (users == null || users.Count == 0)
+			{
+				return true;
+			}
+
+			// If every stored user has an empty password, the operator hasn't
+			// completed setup yet (this is the state the shipped template uses).
+			return users.All(u => string.IsNullOrWhiteSpace(u.Password));
+		}
+	}
+}

--- a/source/DasBlog.Web/Services/FirstRunSetupMiddleware.cs
+++ b/source/DasBlog.Web/Services/FirstRunSetupMiddleware.cs
@@ -1,0 +1,65 @@
+﻿﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace DasBlog.Web.Services
+{
+	/// <summary>
+	/// Redirects all non-setup traffic to <c>/account/setup</c> when the site has
+	/// no usable admin credentials, so a fresh install can't be browsed or driven
+	/// until an operator establishes the initial admin user.
+	/// </summary>
+	public class FirstRunSetupMiddleware
+	{
+		private const string SetupPath = "/account/setup";
+
+		private readonly RequestDelegate next;
+
+		public FirstRunSetupMiddleware(RequestDelegate next)
+		{
+			this.next = next;
+		}
+
+		public async Task InvokeAsync(HttpContext context, IFirstRunService firstRunService)
+		{
+			if (firstRunService.IsSetupRequired() && ShouldGate(context.Request.Path))
+			{
+				context.Response.Redirect(SetupPath);
+				return;
+			}
+
+			await next(context);
+		}
+
+		private static bool ShouldGate(PathString path)
+		{
+			var value = path.Value ?? string.Empty;
+
+			if (value.StartsWith(SetupPath, StringComparison.OrdinalIgnoreCase))
+			{
+				return false;
+			}
+
+			if (value.StartsWith("/health", StringComparison.OrdinalIgnoreCase))
+			{
+				return false;
+			}
+
+			if (value.StartsWith("/home/error", StringComparison.OrdinalIgnoreCase))
+			{
+				return false;
+			}
+
+			return true;
+		}
+	}
+
+	public static class FirstRunSetupMiddlewareExtensions
+	{
+		public static IApplicationBuilder UseFirstRunSetup(this IApplicationBuilder app)
+		{
+			return app.UseMiddleware<FirstRunSetupMiddleware>();
+		}
+	}
+}

--- a/source/DasBlog.Web/Views/Account/Setup.cshtml
+++ b/source/DasBlog.Web/Views/Account/Setup.cshtml
@@ -1,0 +1,67 @@
+﻿@model DasBlog.Web.Models.AccountViewModels.SetupViewModel
+
+@{
+    ViewBag.Title = "First-run setup";
+    Layout = "../../Themes/dasblog/_Layout.cshtml";
+}
+
+<h2>@ViewData["Title"]</h2>
+<p class="lead">
+    This blog has no admin credentials configured. Create the initial admin user below
+    to finish setup. You'll be redirected to the login page when you're done.
+</p>
+<hr />
+<form asp-controller="Account" asp-action="Setup" method="post" class="form-horizontal">
+    <div class="row gy-2 gx-3 justify-content-md-center mb-3">
+        <div class="col-sm-4">
+            <div class="form-floating">
+                @Html.TextBoxFor(m => Model.Email, null, new { @class = "form-control", id = "EmailSetup" })
+                @Html.LabelFor(m => Model.Email, null, new { @class = "form-label", @for = "EmailSetup" })
+            </div>
+            @Html.ValidationMessageFor(m => m.Email, null, new { @class = "text-danger" })
+        </div>
+    </div>
+
+    <div class="row gy-2 gx-3 justify-content-md-center mb-3">
+        <div class="col-sm-4">
+            <div class="form-floating">
+                @Html.TextBoxFor(m => Model.DisplayName, null, new { @class = "form-control", id = "DisplayNameSetup" })
+                @Html.LabelFor(m => Model.DisplayName, null, new { @class = "form-label", @for = "DisplayNameSetup" })
+            </div>
+            @Html.ValidationMessageFor(m => m.DisplayName, null, new { @class = "text-danger" })
+        </div>
+    </div>
+
+    <div class="row gy-2 gx-3 justify-content-md-center mb-3">
+        <div class="col-sm-4">
+            <div class="form-floating">
+                @Html.TextBoxFor(m => Model.Password, null, new { @class = "form-control", id = "PasswordSetup", Type = "password" })
+                @Html.LabelFor(m => Model.Password, null, new { @class = "form-label", @for = "PasswordSetup" })
+            </div>
+            @Html.ValidationMessageFor(m => m.Password, null, new { @class = "text-danger" })
+        </div>
+    </div>
+
+    <div class="row gy-2 gx-3 justify-content-md-center mb-3">
+        <div class="col-sm-4">
+            <div class="form-floating">
+                @Html.TextBoxFor(m => Model.ConfirmPassword, null, new { @class = "form-control", id = "ConfirmPasswordSetup", Type = "password" })
+                @Html.LabelFor(m => Model.ConfirmPassword, null, new { @class = "form-label", @for = "ConfirmPasswordSetup" })
+            </div>
+            @Html.ValidationMessageFor(m => m.ConfirmPassword, null, new { @class = "text-danger" })
+        </div>
+    </div>
+
+    <div class="d-flex flex-wrap justify-content-md-center">
+        <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+    </div>
+
+    <hr />
+    <div class="d-flex flex-wrap justify-content-md-center">
+        <button id="SetupButton" type="submit" class="btn btn-primary me-2">Complete setup</button>
+    </div>
+</form>
+
+@section Scripts {
+    @{ await Html.RenderPartialAsync("_ValidationScriptsPartial"); }
+}


### PR DESCRIPTION
First-run setup flow replaces default admin password

Implement secure first-run setup: add setup form, middleware, and service to require admin creation before site use. CLI reset now clears passwords. Update default credentials check, config template, DI, and add related unit tests.