### PR TITLE
Enable lowercase URLs and query strings in routing

### DIFF
--- a/source/DasBlog.Web/DasBlogServiceCollectionExtensions.cs
+++ b/source/DasBlog.Web/DasBlogServiceCollectionExtensions.cs
@@ -232,6 +232,12 @@ namespace DasBlog.Web
 			services.AddScoped<IRichEditBuilder>(SelectRichEditor)
 				.AddScoped<IBlogPostViewModelCreator, BlogPostViewModelCreator>();
 
+			services.AddRouting(options =>
+			{
+				options.LowercaseUrls = true;
+				options.LowercaseQueryStrings = true;
+			});
+
 			services
 				.AddAutoMapper((serviceProvider, mapperConfig) =>
 				{


### PR DESCRIPTION
Added routing configuration to enforce lowercase URLs and query strings by setting LowercaseUrls and LowercaseQueryStrings to true in the service collection. This ensures consistent and SEO-friendly URL formatting across the application.