### PR TITLE
Improvements to SEO-related tag helpers

### DIFF
--- a/source/DasBlog.Tests/UnitTests/UI/SeoTagHelperTests.cs
+++ b/source/DasBlog.Tests/UnitTests/UI/SeoTagHelperTests.cs
@@ -1,0 +1,239 @@
+﻿﻿using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading.Tasks;
+using DasBlog.Web.TagHelpers.Site;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Xunit;
+
+namespace DasBlog.Tests.UnitTests.UI
+{
+	public class SeoTagHelperTests
+	{
+		private static (TagHelperContext ctx, TagHelperOutput output) MakeContext(string tagName)
+		{
+			var ctx = new TagHelperContext(new TagHelperAttributeList(), new Dictionary<object, object>(), Guid.NewGuid().ToString("N"));
+			var output = new TagHelperOutput(tagName, new TagHelperAttributeList(), (_, _) =>
+				Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
+			return (ctx, output);
+		}
+
+		private static ViewContext MakeViewContext()
+		{
+			return new ViewContext();
+		}
+
+		// ----- OpenGraphTagHelper -----
+
+		[Fact]
+		[Trait("Category", "UnitTest")]
+		public void OpenGraphTagHelper_NoOgTypeSet_DefaultsToWebsite()
+		{
+			var sut = new OpenGraphTagHelper { ViewContext = MakeViewContext() };
+			var (ctx, output) = MakeContext("open-graph");
+
+			sut.Process(ctx, output);
+
+			var html = output.Content.GetContent();
+			Assert.Contains("<meta property=\"og:type\" content=\"website\"", html);
+			Assert.DoesNotContain("content=\"article\"", html);
+		}
+
+		[Fact]
+		[Trait("Category", "UnitTest")]
+		public void OpenGraphTagHelper_OgTypeArticle_EmitsArticle()
+		{
+			var viewContext = MakeViewContext();
+			viewContext.ViewData["OgType"] = "article";
+			var sut = new OpenGraphTagHelper { ViewContext = viewContext };
+			var (ctx, output) = MakeContext("open-graph");
+
+			sut.Process(ctx, output);
+
+			Assert.Contains("<meta property=\"og:type\" content=\"article\"", output.Content.GetContent());
+		}
+
+		[Fact]
+		[Trait("Category", "UnitTest")]
+		public void OpenGraphTagHelper_OgTypeEmpty_DefaultsToWebsite()
+		{
+			var viewContext = MakeViewContext();
+			viewContext.ViewData["OgType"] = string.Empty;
+			var sut = new OpenGraphTagHelper { ViewContext = viewContext };
+			var (ctx, output) = MakeContext("open-graph");
+
+			sut.Process(ctx, output);
+
+			Assert.Contains("content=\"website\"", output.Content.GetContent());
+		}
+
+		[Fact]
+		[Trait("Category", "UnitTest")]
+		public void OpenGraphTagHelper_VideoUrlMissing_OmitsVideoMeta()
+		{
+			var sut = new OpenGraphTagHelper { ViewContext = MakeViewContext() };
+			var (ctx, output) = MakeContext("open-graph");
+
+			sut.Process(ctx, output);
+
+			Assert.DoesNotContain("og:video", output.Content.GetContent());
+		}
+
+		[Fact]
+		[Trait("Category", "UnitTest")]
+		public void OpenGraphTagHelper_VideoUrlWhitespace_OmitsVideoMeta()
+		{
+			var viewContext = MakeViewContext();
+			viewContext.ViewData["PageVideoUrl"] = "   ";
+			var sut = new OpenGraphTagHelper { ViewContext = viewContext };
+			var (ctx, output) = MakeContext("open-graph");
+
+			sut.Process(ctx, output);
+
+			Assert.DoesNotContain("og:video", output.Content.GetContent());
+		}
+
+		[Fact]
+		[Trait("Category", "UnitTest")]
+		public void OpenGraphTagHelper_VideoUrlPresent_EmitsVideoMeta()
+		{
+			var viewContext = MakeViewContext();
+			viewContext.ViewData["PageVideoUrl"] = "https://example.com/clip.mp4";
+			var sut = new OpenGraphTagHelper { ViewContext = viewContext };
+			var (ctx, output) = MakeContext("open-graph");
+
+			sut.Process(ctx, output);
+
+			Assert.Contains("<meta property=\"og:video\" content=\"https://example.com/clip.mp4\"", output.Content.GetContent());
+		}
+
+		// ----- BlogPostingSchemaTagHelper -----
+
+		private static JsonElement ProcessSchema(ViewContext viewContext)
+		{
+			var sut = new BlogPostingSchemaTagHelper { ViewContext = viewContext };
+			var (ctx, output) = MakeContext("blog-posting-schema");
+			sut.Process(ctx, output);
+			using var doc = JsonDocument.Parse(output.Content.GetContent());
+			return doc.RootElement.Clone();
+		}
+
+		[Fact]
+		[Trait("Category", "UnitTest")]
+		public void BlogPostingSchema_MinimalData_OmitsEmptyFieldsAndAuthorAndMainEntity()
+		{
+			var json = ProcessSchema(MakeViewContext());
+
+			Assert.Equal("http://schema.org", json.GetProperty("@context").GetString());
+			Assert.Equal("BlogPosting", json.GetProperty("@type").GetString());
+			Assert.False(json.TryGetProperty("headline", out _));
+			Assert.False(json.TryGetProperty("description", out _));
+			Assert.False(json.TryGetProperty("url", out _));
+			Assert.False(json.TryGetProperty("image", out _));
+			Assert.False(json.TryGetProperty("datePublished", out _));
+			Assert.False(json.TryGetProperty("dateModified", out _));
+			Assert.False(json.TryGetProperty("author", out _));
+			Assert.False(json.TryGetProperty("mainEntityOfPage", out _));
+		}
+
+		[Fact]
+		[Trait("Category", "UnitTest")]
+		public void BlogPostingSchema_DateModifiedMissing_FallsBackToDatePublished()
+		{
+			var viewContext = MakeViewContext();
+			viewContext.ViewData["DatePublished"] = "2026-06-12T10:00:00Z";
+			var json = ProcessSchema(viewContext);
+
+			Assert.Equal("2026-06-12T10:00:00Z", json.GetProperty("datePublished").GetString());
+			Assert.Equal("2026-06-12T10:00:00Z", json.GetProperty("dateModified").GetString());
+		}
+
+		[Fact]
+		[Trait("Category", "UnitTest")]
+		public void BlogPostingSchema_ExplicitDateModified_OverridesFallback()
+		{
+			var viewContext = MakeViewContext();
+			viewContext.ViewData["DatePublished"] = "2026-06-12T10:00:00Z";
+			viewContext.ViewData["DateModified"] = "2026-06-13T12:00:00Z";
+			var json = ProcessSchema(viewContext);
+
+			Assert.Equal("2026-06-13T12:00:00Z", json.GetProperty("dateModified").GetString());
+		}
+
+		[Fact]
+		[Trait("Category", "UnitTest")]
+		public void BlogPostingSchema_AuthorNameOnly_EmitsPersonWithoutUrl()
+		{
+			var viewContext = MakeViewContext();
+			viewContext.ViewData["Author"] = "Test Author";
+			var json = ProcessSchema(viewContext);
+
+			var author = json.GetProperty("author");
+			Assert.Equal("Person", author.GetProperty("@type").GetString());
+			Assert.Equal("Test Author", author.GetProperty("name").GetString());
+			Assert.False(author.TryGetProperty("url", out _));
+		}
+
+		[Fact]
+		[Trait("Category", "UnitTest")]
+		public void BlogPostingSchema_AuthorNameAndUrl_EmitsBoth()
+		{
+			var viewContext = MakeViewContext();
+			viewContext.ViewData["Author"] = "Test Author";
+			viewContext.ViewData["AuthorUrl"] = "https://example.com/";
+			var json = ProcessSchema(viewContext);
+
+			var author = json.GetProperty("author");
+			Assert.Equal("Test Author", author.GetProperty("name").GetString());
+			Assert.Equal("https://example.com/", author.GetProperty("url").GetString());
+		}
+
+		[Fact]
+		[Trait("Category", "UnitTest")]
+		public void BlogPostingSchema_AuthorAbsent_OmitsAuthorField()
+		{
+			var viewContext = MakeViewContext();
+			viewContext.ViewData["Author"] = string.Empty;
+			viewContext.ViewData["AuthorUrl"] = string.Empty;
+			var json = ProcessSchema(viewContext);
+
+			Assert.False(json.TryGetProperty("author", out _));
+		}
+
+		[Fact]
+		[Trait("Category", "UnitTest")]
+		public void BlogPostingSchema_CanonicalPresent_EmitsMainEntityOfPage()
+		{
+			var viewContext = MakeViewContext();
+			viewContext.ViewData["Canonical"] = "https://example.com/post/hello";
+			var json = ProcessSchema(viewContext);
+
+			var main = json.GetProperty("mainEntityOfPage");
+			Assert.Equal("WebPage", main.GetProperty("@type").GetString());
+			Assert.Equal("https://example.com/post/hello", main.GetProperty("@id").GetString());
+			Assert.Equal("https://example.com/post/hello", json.GetProperty("url").GetString());
+		}
+
+		[Fact]
+		[Trait("Category", "UnitTest")]
+		public void BlogPostingSchema_FullPayload_ProducesValidJson()
+		{
+			var viewContext = MakeViewContext();
+			viewContext.ViewData["PageTitle"] = "Hello \"world\"";
+			viewContext.ViewData["Description"] = "A post";
+			viewContext.ViewData["Canonical"] = "https://example.com/post/hello";
+			viewContext.ViewData["PageImageUrl"] = "https://example.com/img.png";
+			viewContext.ViewData["DatePublished"] = "2026-06-12T10:00:00Z";
+			viewContext.ViewData["Author"] = "Test Author";
+			viewContext.ViewData["AuthorUrl"] = "https://example.com/";
+
+			var json = ProcessSchema(viewContext);
+
+			Assert.Equal("Hello \"world\"", json.GetProperty("headline").GetString());
+			Assert.Equal("https://example.com/img.png", json.GetProperty("image").GetString());
+			Assert.Equal("Test Author", json.GetProperty("author").GetProperty("name").GetString());
+		}
+	}
+}

--- a/source/DasBlog.Web/Controllers/DasBlogBaseController.cs
+++ b/source/DasBlog.Web/Controllers/DasBlogBaseController.cs
@@ -64,9 +64,13 @@ namespace DasBlog.Web.Settings
 				ViewData["PermaLink"] = dasBlogSettings.RelativeToRoot(post.PermaLink);
 				ViewData["Keywords"] = string.Join(",", post.Categories.Select(x => x.Category).ToArray());
 				ViewData["Canonical"] = dasBlogSettings.RelativeToRoot(post.PermaLink);
-				ViewData["Author"] = dasBlogSettings.GetUserByEmail(post.Author)?.DisplayName; ;
+				ViewData["Author"] = dasBlogSettings.GetUserByEmail(post.Author)?.DisplayName;
+				ViewData["AuthorUrl"] = dasBlogSettings.GetBaseUrl();
 				ViewData["PageImageUrl"] = (post.ImageUrl?.Length > 0) ? dasBlogSettings.RelativeToRoot(post.ImageUrl) : dasBlogSettings.MetaTags.TwitterImage;
 				ViewData["PageVideoUrl"] = (post.VideoUrl?.Length > 0) ? dasBlogSettings.RelativeToRoot(post.VideoUrl) : string.Empty;
+				ViewData["DatePublished"] = post.CreatedDateTime.ToUniversalTime().ToString("o");
+				ViewData["DateModified"] = post.ModifiedDateTime.ToUniversalTime().ToString("o");
+				ViewData["OgType"] = "article";
 				ShowErrors(post);
 			}
 		}

--- a/source/DasBlog.Web/Controllers/SiteController.cs
+++ b/source/DasBlog.Web/Controllers/SiteController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Text;
 using AutoMapper;
 using DasBlog.Managers.Interfaces;
 using DasBlog.Services.ActivityLogs;
@@ -29,13 +30,39 @@ namespace DasBlog.Web.Controllers
 
 		[Produces("text/xml")]
 		[Route("")]
-        [HttpGet("map")]
-        public ActionResult Map()
-        {
+		[HttpGet("map")]
+		public ActionResult Map()
+		{
 			var sitemap = siteManager.GetGoogleSiteMap();
 
 			return Ok(sitemap);
-        }
+		}
+
+		[Produces("application/xml")]
+		[HttpGet("/sitemap.xml")]
+		public ActionResult SitemapXml()
+		{
+			var sitemap = siteManager.GetGoogleSiteMap();
+
+			return Ok(sitemap);
+		}
+
+		[HttpGet("/robots.txt")]
+		public ActionResult RobotsTxt()
+		{
+			var scheme = Request.Scheme;
+			var host = Request.Host.ToUriComponent();
+			var pathBase = Request.PathBase.HasValue ? Request.PathBase.ToUriComponent() : string.Empty;
+			var sitemapUrl = $"{scheme}://{host}{pathBase}/sitemap.xml";
+
+			var sb = new StringBuilder();
+			sb.Append("User-agent: *\n");
+			sb.Append("Disallow: ").Append(pathBase).Append("/account/login\n");
+			sb.Append('\n');
+			sb.Append("Sitemap: ").Append(sitemapUrl).Append('\n');
+
+			return Content(sb.ToString(), "text/plain", Encoding.UTF8);
+		}
 
 		[Produces("text/plain")]
 		[HttpGet("microsummary")]

--- a/source/DasBlog.Web/TagHelpers/Site/BlogPostingSchemaTagHelper.cs
+++ b/source/DasBlog.Web/TagHelpers/Site/BlogPostingSchemaTagHelper.cs
@@ -26,28 +26,69 @@ namespace DasBlog.Web.TagHelpers.Site
 			output.Attributes.SetAttribute("type", "application/ld+json");
 
 			var data = ViewContext.ViewData;
-			var payload = new
+			var schemaContext = "http://schema.org";
+			var schemaType = "BlogPosting";
+			var headline = data["PageTitle"]?.ToString();
+			var description = data["Description"]?.ToString();
+			var url = data["Canonical"]?.ToString();
+			var image = data["PageImageUrl"]?.ToString();
+			var datePublished = data["DatePublished"]?.ToString();
+			var dateModified = data["DateModified"]?.ToString();
+			if (string.IsNullOrEmpty(dateModified))
 			{
-				context = "http://schema.org",
-				type = "BlogPosting",
-				headline = data["PageTitle"]?.ToString() ?? string.Empty,
-				description = data["Description"]?.ToString() ?? string.Empty,
-				url = data["Canonical"]?.ToString() ?? string.Empty,
-				image = data["PageImageUrl"]?.ToString() ?? string.Empty
-			};
+				dateModified = datePublished;
+			}
+			var authorName = data["Author"]?.ToString();
+			var authorUrl = data["AuthorUrl"]?.ToString();
+			var canonical = data["Canonical"]?.ToString();
 
 			// Build the JSON manually to preserve the @context / @type keys.
 			var sb = new StringBuilder();
 			sb.Append('{');
-			sb.Append("\"@context\":").Append(JsonSerializer.Serialize(payload.context, JsonOptions)).Append(',');
-			sb.Append("\"@type\":").Append(JsonSerializer.Serialize(payload.type, JsonOptions)).Append(',');
-			sb.Append("\"headline\":").Append(JsonSerializer.Serialize(payload.headline, JsonOptions)).Append(',');
-			sb.Append("\"description\":").Append(JsonSerializer.Serialize(payload.description, JsonOptions)).Append(',');
-			sb.Append("\"url\":").Append(JsonSerializer.Serialize(payload.url, JsonOptions)).Append(',');
-			sb.Append("\"image\":").Append(JsonSerializer.Serialize(payload.image, JsonOptions));
+			sb.Append("\"@context\":").Append(JsonSerializer.Serialize(schemaContext, JsonOptions));
+			sb.Append(",\"@type\":").Append(JsonSerializer.Serialize(schemaType, JsonOptions));
+			AppendStringIfPresent(sb, "headline", headline);
+			AppendStringIfPresent(sb, "description", description);
+			AppendStringIfPresent(sb, "url", url);
+			AppendStringIfPresent(sb, "image", image);
+			AppendStringIfPresent(sb, "datePublished", datePublished);
+			AppendStringIfPresent(sb, "dateModified", dateModified);
+
+			if (!string.IsNullOrEmpty(authorName) || !string.IsNullOrEmpty(authorUrl))
+			{
+				sb.Append(",\"author\":{");
+				sb.Append("\"@type\":\"Person\"");
+				if (!string.IsNullOrEmpty(authorName))
+				{
+					sb.Append(",\"name\":").Append(JsonSerializer.Serialize(authorName, JsonOptions));
+				}
+				if (!string.IsNullOrEmpty(authorUrl))
+				{
+					sb.Append(",\"url\":").Append(JsonSerializer.Serialize(authorUrl, JsonOptions));
+				}
+				sb.Append('}');
+			}
+
+			if (!string.IsNullOrEmpty(canonical))
+			{
+				sb.Append(",\"mainEntityOfPage\":{");
+				sb.Append("\"@type\":\"WebPage\"");
+				sb.Append(",\"@id\":").Append(JsonSerializer.Serialize(canonical, JsonOptions));
+				sb.Append('}');
+			}
+
 			sb.Append('}');
 
 			output.Content.SetHtmlContent(sb.ToString());
+		}
+
+		private static void AppendStringIfPresent(StringBuilder sb, string name, string value)
+		{
+			if (string.IsNullOrEmpty(value))
+			{
+				return;
+			}
+			sb.Append(',').Append('"').Append(name).Append("\":").Append(JsonSerializer.Serialize(value, JsonOptions));
 		}
 	}
 }

--- a/source/DasBlog.Web/TagHelpers/Site/OpenGraphTagHelper.cs
+++ b/source/DasBlog.Web/TagHelpers/Site/OpenGraphTagHelper.cs
@@ -22,15 +22,23 @@ namespace DasBlog.Web.TagHelpers.Site
 			var title = data["PageTitle"]?.ToString() ?? string.Empty;
 			var image = data["PageImageUrl"]?.ToString() ?? string.Empty;
 			var description = data["Description"]?.ToString() ?? string.Empty;
-			var video = data["PageVideoUrl"]?.ToString() ?? string.Empty;
+			var video = data["PageVideoUrl"]?.ToString()?.Trim() ?? string.Empty;
+			var ogType = data["OgType"]?.ToString();
+			if (string.IsNullOrEmpty(ogType))
+			{
+				ogType = "website";
+			}
 
 			var sb = new StringBuilder();
 			sb.Append("<meta property=\"og:url\" content=\"").Append(WebUtility.HtmlEncode(canonical)).Append("\" />\n");
 			sb.Append("<meta property=\"og:title\" content=\"").Append(WebUtility.HtmlEncode(title)).Append("\" />\n");
 			sb.Append("<meta property=\"og:image\" content=\"").Append(WebUtility.HtmlEncode(image)).Append("\" />\n");
 			sb.Append("<meta property=\"og:description\" content=\"").Append(WebUtility.HtmlEncode(description)).Append("\" />\n");
-			sb.Append("<meta property=\"og:video\" content=\"").Append(WebUtility.HtmlEncode(video)).Append("\" />\n");
-			sb.Append("<meta property=\"og:type\" content=\"article\" />");
+			if (!string.IsNullOrEmpty(video))
+			{
+				sb.Append("<meta property=\"og:video\" content=\"").Append(WebUtility.HtmlEncode(video)).Append("\" />\n");
+			}
+			sb.Append("<meta property=\"og:type\" content=\"").Append(WebUtility.HtmlEncode(ogType)).Append("\" />");
 
 			output.Content.SetHtmlContent(sb.ToString());
 		}


### PR DESCRIPTION
#### PR Classification
Enhancement and test coverage for SEO-related tag helpers, plus improvements to sitemap and robots.txt endpoints.

#### PR Summary
This PR refactors and extends SEO metadata generation, adds comprehensive unit tests, and improves site map and robots.txt handling.
- SeoTagHelperTests.cs: Adds extensive unit tests for OpenGraphTagHelper and BlogPostingSchemaTagHelper.
- DasBlogBaseController.cs: Sets additional ViewData fields (AuthorUrl, DatePublished, DateModified, OgType) for single post rendering.
- SiteController.cs: Refactors map endpoint, adds /sitemap.xml and a dynamic /robots.txt endpoint.
- BlogPostingSchemaTagHelper.cs: Refactors JSON-LD schema output to omit empty fields and handle author and canonical logic.
- OpenGraphTagHelper.cs: Adds OgType support, improves og:video handling, and refines meta tag output logic.
