### PR TITLE
Trim trailing slash from pathBase in robots.txt output

### DIFF
--- a/source/DasBlog.Web/Controllers/SiteController.cs
+++ b/source/DasBlog.Web/Controllers/SiteController.cs
@@ -52,7 +52,7 @@ namespace DasBlog.Web.Controllers
 		{
 			var scheme = Request.Scheme;
 			var host = Request.Host.ToUriComponent();
-			var pathBase = Request.PathBase.HasValue ? Request.PathBase.ToUriComponent() : string.Empty;
+			var pathBase = Request.PathBase.HasValue ? Request.PathBase.ToUriComponent().TrimEnd('/') : string.Empty;
 			var sitemapUrl = $"{scheme}://{host}{pathBase}/sitemap.xml";
 
 			var sb = new StringBuilder();


### PR DESCRIPTION
Trim trailing slash from pathBase in robots.txt output

Removes any trailing slash from pathBase when generating robots.txt, preventing double slashes in sitemap URLs and disallow paths for cleaner, more accurate output.