### PR TITLE
Google Deprecation

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -29,6 +29,13 @@ A: Yes. Themes are developed using Razor! More details can be found [here](https
 A: DasBlog Core ships with several built-in themes and includes a [theme editor](https://github.com/poppastring/dasblog-core/wiki/4.-Designing-a-theme#theme-editor) at `/admin/themes` for browsing, switching, and customizing themes directly from the browser.
 
 
+#### Q: What changed with Google analytics and captcha settings?
+A: DasBlog Core now treats this as a breaking change and no longer supports Google-specific analytics or captcha keys.
+
+For existing blogs:
+1. Remove `GoogleAnalyticsID`, `AnalyticsTrackingId`, `AnalyticsProvider`, `EnableCaptcha`, `RecaptchaSiteKey`, `RecaptchaSecretKey`, `RecaptchaMinimumScore`, `CaptchaSiteKey`, `CaptchaSecretKey`, and `CaptchaMinimumScore` from your config files.
+2. For spam protection, use Akismet moderation (`EnableSpamModeration` + `AkismetAPIKey`) and/or spam question validation (`CheesySpamQ` + `CheesySpamA`).
+
 #### Q: I am not developer, how can I support this effort?
 A: Here are a few ways you can support the DasBlog Core effort:
  * Use the product

--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ Check out the [wiki](https://github.com/poppastring/dasblog-core/wiki) for deplo
 
 Migrating from classic DasBlog? See the [migration guide](https://github.com/poppastring/dasblog-core/wiki/7.-Migrating-from-DasBlog).
 
+## Breaking changes (vNext)
+
+Google-specific analytics and captcha settings have been removed.
+
+Existing installs should migrate as follows:
+1. Remove deprecated keys from `Config/meta.config` and `Config/site.config` (`GoogleAnalyticsID`, `AnalyticsTrackingId`, `AnalyticsProvider`, `EnableCaptcha`, `RecaptchaSiteKey`, `RecaptchaSecretKey`, `RecaptchaMinimumScore`, `CaptchaSiteKey`, `CaptchaSecretKey`, `CaptchaMinimumScore`).
+2. Use built-in non-Google comment spam defenses: Akismet moderation (`EnableSpamModeration` + `AkismetAPIKey`) and/or the spam question fields (`CheesySpamQ`, `CheesySpamA`).
+
 ## Contributing
 
 We welcome contributions! See [CONTRIBUTING.md](https://github.com/poppastring/dasblog-core/blob/main/CONTRIBUTING.md) for setup instructions and guidelines.

--- a/source/DasBlog.Managers/ActivityPubManager.cs
+++ b/source/DasBlog.Managers/ActivityPubManager.cs
@@ -14,6 +14,7 @@ namespace DasBlog.Managers
 	{
 		private readonly IBlogDataService dataService;
 		private readonly IDasBlogSettings dasBlogSettings;
+		private readonly IMastodonSettingsResolver mastodonSettingsResolver;
 		private readonly string outBox;
 		private readonly string actor;
 		private readonly string carbonCopy;
@@ -22,14 +23,16 @@ namespace DasBlog.Managers
 		private const string ACTIVITYSTREAM_PUBLIC = "https://www.w3.org/ns/activitystreams#Public";
 		private const string PAGE_TRUE = "?page=true";
 
-		public ActivityPubManager(IDasBlogSettings settings, IBlogDataService dataService)
+		public ActivityPubManager(IDasBlogSettings settings, IBlogDataService dataService, IMastodonSettingsResolver mastodonSettingsResolver)
 		{
 			dasBlogSettings = settings;
 			this.dataService = dataService;
+			this.mastodonSettingsResolver = mastodonSettingsResolver;
 
-			var userrelative = string.Format("users/{0}/outbox", dasBlogSettings.SiteConfiguration.MastodonAccount);
-			var actorrelative = string.Format("users/{0}", dasBlogSettings.SiteConfiguration.MastodonAccount);
-			var ccrelative = string.Format("users/{0}/followers", dasBlogSettings.SiteConfiguration.MastodonAccount);
+			var mastodonAccount = this.mastodonSettingsResolver.GetMastodonAccount();
+			var userrelative = string.Format("users/{0}/outbox", mastodonAccount);
+			var actorrelative = string.Format("users/{0}", mastodonAccount);
+			var ccrelative = string.Format("users/{0}/followers", mastodonAccount);
 			outBox = new Uri(new Uri(dasBlogSettings.SiteConfiguration.Root), userrelative).AbsoluteUri;
 			actor = new Uri(new Uri(dasBlogSettings.SiteConfiguration.Root), actorrelative).AbsoluteUri;
 			carbonCopy = new Uri(new Uri(dasBlogSettings.SiteConfiguration.Root), ccrelative).AbsoluteUri;
@@ -51,9 +54,10 @@ namespace DasBlog.Managers
 
 		public UserPage GetUserPage(IList<Entry> page)
 		{
+			var mastodonAccount = mastodonSettingsResolver.GetMastodonAccount();
 			var ordereditems = page.Select(o => new OrderedItem
 				{
-					Id = string.Format(statusActivity, dasBlogSettings.SiteConfiguration.MastodonAccount, o.EntryId),
+					Id = string.Format(statusActivity, mastodonAccount, o.EntryId),
 					Type = "Create",
 					Actor = actor,
 					Published = DateTime.UtcNow,
@@ -78,20 +82,20 @@ namespace DasBlog.Managers
 
 		public WebFinger WebFinger(string resource)
 		{
-			string mastodonUrl = dasBlogSettings.SiteConfiguration.MastodonServerUrl;
-			string mastodonAccount = dasBlogSettings.SiteConfiguration.MastodonAccount;
+			string mastodonUrl = mastodonSettingsResolver.GetMastodonServerUrl();
+			string mastodonAccount = mastodonSettingsResolver.GetMastodonAccount();
 
-			if (string.IsNullOrEmpty(mastodonUrl) || string.IsNullOrEmpty(mastodonAccount))
+			if (string.IsNullOrWhiteSpace(resource) || string.IsNullOrWhiteSpace(mastodonUrl) || string.IsNullOrWhiteSpace(mastodonAccount))
 			{
 				return null;
 			}
 
-			if (resource.StartsWith("@"))
+			if (resource.StartsWith("@", StringComparison.Ordinal))
 			{
 				resource = resource.Remove(0, 1);
 			}
 
-			if (mastodonAccount.StartsWith("@"))
+			if (mastodonAccount.StartsWith("@", StringComparison.Ordinal))
 			{
 				mastodonAccount = mastodonAccount.Remove(0, 1);
 			}
@@ -106,8 +110,8 @@ namespace DasBlog.Managers
 			string accountUrl = new Uri(mastotonSiteUri, $"@{mastodonAccount}").AbsoluteUri;
 			string authurl = new Uri(mastotonSiteUri, "authorize_interaction").AbsoluteUri + "?uri={uri}";
 
-			if (string.IsNullOrWhiteSpace(dasBlogSettings.SiteConfiguration.MastodonServerUrl) ||
-				string.IsNullOrWhiteSpace(dasBlogSettings.SiteConfiguration.MastodonAccount))
+			if (string.IsNullOrWhiteSpace(mastodonUrl) ||
+				string.IsNullOrWhiteSpace(mastodonAccount))
 			{
 				return null;
 			}

--- a/source/DasBlog.Managers/SubscriptionManager.cs
+++ b/source/DasBlog.Managers/SubscriptionManager.cs
@@ -270,19 +270,6 @@ namespace DasBlog.Managers
 			wflogo.InnerText = dasBlogSettings.RelativeToRoot(dasBlogSettings.SiteConfiguration.ChannelImageUrl);
 			rootElements.Add(wflogo);
 
-			var wfanalytics = xdoc.CreateElement("webfeeds", "analytics", "http://webfeeds.org/rss/1.0");
-			var attribId = xdoc.CreateAttribute("id");
-			attribId.Value = dasBlogSettings.MetaTags.AnalyticsTrackingId;
-			wfanalytics.Attributes.Append(attribId);
-
-			var attribEngine = xdoc.CreateAttribute("engine");
-			attribEngine.Value = string.IsNullOrWhiteSpace(dasBlogSettings.MetaTags.AnalyticsProvider)
-				? "Analytics"
-				: dasBlogSettings.MetaTags.AnalyticsProvider;
-			wfanalytics.Attributes.Append(attribEngine);
-
-			rootElements.Add(wfanalytics);
-
 			ch.anyElements = rootElements.ToArray();
 
 			ch.Items = new RssItemCollection();

--- a/source/DasBlog.Managers/SubscriptionManager.cs
+++ b/source/DasBlog.Managers/SubscriptionManager.cs
@@ -272,11 +272,13 @@ namespace DasBlog.Managers
 
 			var wfanalytics = xdoc.CreateElement("webfeeds", "analytics", "http://webfeeds.org/rss/1.0");
 			var attribId = xdoc.CreateAttribute("id");
-			attribId.Value = dasBlogSettings.MetaTags.GoogleAnalyticsID;
+			attribId.Value = dasBlogSettings.MetaTags.AnalyticsTrackingId;
 			wfanalytics.Attributes.Append(attribId);
 
 			var attribEngine = xdoc.CreateAttribute("engine");
-			attribEngine.Value = "GoogleAnalytics";
+			attribEngine.Value = string.IsNullOrWhiteSpace(dasBlogSettings.MetaTags.AnalyticsProvider)
+				? "Analytics"
+				: dasBlogSettings.MetaTags.AnalyticsProvider;
 			wfanalytics.Attributes.Append(attribEngine);
 
 			rootElements.Add(wfanalytics);

--- a/source/DasBlog.Services/ConfigFile/Interfaces/IMetaTags.cs
+++ b/source/DasBlog.Services/ConfigFile/Interfaces/IMetaTags.cs
@@ -6,15 +6,16 @@ using System.Xml.Serialization;
 namespace DasBlog.Services.ConfigFile.Interfaces
 {
 	public interface IMetaTags
-    {
-        string MetaDescription { get; set; }
-        string MetaKeywords { get; set; }
-        string TwitterCard { get; set; }
-        string TwitterSite { get; set; }
-        string TwitterCreator { get; set; }
-        string TwitterImage { get; set; }
-        string FaceBookAdmins { get; set; }
-        string FaceBookAppID { get; set; }
-		string GoogleAnalyticsID { get; set; }
+	{
+		string MetaDescription { get; set; }
+		string MetaKeywords { get; set; }
+		string TwitterCard { get; set; }
+		string TwitterSite { get; set; }
+		string TwitterCreator { get; set; }
+		string TwitterImage { get; set; }
+		string FaceBookAdmins { get; set; }
+		string FaceBookAppID { get; set; }
+		string AnalyticsTrackingId { get; set; }
+		string AnalyticsProvider { get; set; }
 	}
 }

--- a/source/DasBlog.Services/ConfigFile/Interfaces/IMetaTags.cs
+++ b/source/DasBlog.Services/ConfigFile/Interfaces/IMetaTags.cs
@@ -15,7 +15,5 @@ namespace DasBlog.Services.ConfigFile.Interfaces
 		string TwitterImage { get; set; }
 		string FaceBookAdmins { get; set; }
 		string FaceBookAppID { get; set; }
-		string AnalyticsTrackingId { get; set; }
-		string AnalyticsProvider { get; set; }
 	}
 }

--- a/source/DasBlog.Services/ConfigFile/Interfaces/IMetaTags.cs
+++ b/source/DasBlog.Services/ConfigFile/Interfaces/IMetaTags.cs
@@ -13,5 +13,7 @@ namespace DasBlog.Services.ConfigFile.Interfaces
 		string TwitterSite { get; set; }
 		string TwitterCreator { get; set; }
 		string TwitterImage { get; set; }
+		string MastodonServerUrl { get; set; }
+		string MastodonAccount { get; set; }
 	}
 }

--- a/source/DasBlog.Services/ConfigFile/Interfaces/IMetaTags.cs
+++ b/source/DasBlog.Services/ConfigFile/Interfaces/IMetaTags.cs
@@ -13,7 +13,5 @@ namespace DasBlog.Services.ConfigFile.Interfaces
 		string TwitterSite { get; set; }
 		string TwitterCreator { get; set; }
 		string TwitterImage { get; set; }
-		string FaceBookAdmins { get; set; }
-		string FaceBookAppID { get; set; }
 	}
 }

--- a/source/DasBlog.Services/ConfigFile/Interfaces/ISiteConfig.cs
+++ b/source/DasBlog.Services/ConfigFile/Interfaces/ISiteConfig.cs
@@ -124,14 +124,6 @@ namespace DasBlog.Services.ConfigFile.Interfaces
 
         string SmtpServer { get; set; }
 
-        bool EnableCaptcha { get; set; }
-
-        string RecaptchaSiteKey { get; set; }
-
-        string RecaptchaSecretKey { get; set; } 
-
-        double RecaptchaMinimumScore { get; set; }
-
         string ChannelImageUrl { get; set; }
 
         bool EnableTitlePermaLink { get; set; }

--- a/source/DasBlog.Services/ConfigFile/MetaTags.cs
+++ b/source/DasBlog.Services/ConfigFile/MetaTags.cs
@@ -27,11 +27,5 @@ namespace DasBlog.Services.ConfigFile
 
 		[XmlElement("TwitterImage")]
 		public string TwitterImage  { get; set; }
-
-		[XmlElement("FaceBookAdmins")]
-		public string FaceBookAdmins { get; set; }
-
-		[XmlElement("FaceBookAppID")]
-		public string FaceBookAppID  { get; set; }
 	}
 }

--- a/source/DasBlog.Services/ConfigFile/MetaTags.cs
+++ b/source/DasBlog.Services/ConfigFile/MetaTags.cs
@@ -33,18 +33,5 @@ namespace DasBlog.Services.ConfigFile
 
 		[XmlElement("FaceBookAppID")]
 		public string FaceBookAppID  { get; set; }
-
-		[XmlElement("AnalyticsTrackingId")]
-		public string AnalyticsTrackingId { get; set; }
-
-		[XmlElement("AnalyticsProvider")]
-		public string AnalyticsProvider { get; set; }
-
-		[XmlIgnore]
-		public string GoogleAnalyticsID
-		{
-			get => AnalyticsTrackingId;
-			set => AnalyticsTrackingId = value;
-		}
 	}
 }

--- a/source/DasBlog.Services/ConfigFile/MetaTags.cs
+++ b/source/DasBlog.Services/ConfigFile/MetaTags.cs
@@ -34,7 +34,17 @@ namespace DasBlog.Services.ConfigFile
 		[XmlElement("FaceBookAppID")]
 		public string FaceBookAppID  { get; set; }
 
-		[XmlElement("GoogleAnalyticsID")]
-		public string GoogleAnalyticsID { get; set; }
+		[XmlElement("AnalyticsTrackingId")]
+		public string AnalyticsTrackingId { get; set; }
+
+		[XmlElement("AnalyticsProvider")]
+		public string AnalyticsProvider { get; set; }
+
+		[XmlIgnore]
+		public string GoogleAnalyticsID
+		{
+			get => AnalyticsTrackingId;
+			set => AnalyticsTrackingId = value;
+		}
 	}
 }

--- a/source/DasBlog.Services/ConfigFile/MetaTags.cs
+++ b/source/DasBlog.Services/ConfigFile/MetaTags.cs
@@ -27,5 +27,11 @@ namespace DasBlog.Services.ConfigFile
 
 		[XmlElement("TwitterImage")]
 		public string TwitterImage  { get; set; }
+
+		[XmlElement("MastodonServerUrl")]
+		public string MastodonServerUrl { get; set; }
+
+		[XmlElement("MastodonAccount")]
+		public string MastodonAccount { get; set; }
 	}
 }

--- a/source/DasBlog.Services/ConfigFile/SiteConfig.cs
+++ b/source/DasBlog.Services/ConfigFile/SiteConfig.cs
@@ -114,10 +114,6 @@ namespace DasBlog.Services.ConfigFile
         public string ProfilesDir { get; set; }
         public string BinariesDirRelative { get; set; }
         public string SmtpServer { get; set; }
-        public bool EnableCaptcha { get; set; }
-        public string RecaptchaSiteKey { get; set; }
-        public string RecaptchaSecretKey { get; set; } 
-        public double RecaptchaMinimumScore {get; set; }
         public string ChannelImageUrl { get; set; }
         public bool EnableTitlePermaLink { get; set; }
         public bool EnableTitlePermaLinkUnique { get; set; }

--- a/source/DasBlog.Services/Interfaces/IMastodonSettingsResolver.cs
+++ b/source/DasBlog.Services/Interfaces/IMastodonSettingsResolver.cs
@@ -1,0 +1,8 @@
+﻿namespace DasBlog.Services
+{
+	public interface IMastodonSettingsResolver
+	{
+		string GetMastodonServerUrl();
+		string GetMastodonAccount();
+	}
+}

--- a/source/DasBlog.Tests/UnitTests/Config/metaConfig.xml
+++ b/source/DasBlog.Tests/UnitTests/Config/metaConfig.xml
@@ -6,4 +6,6 @@
   <TwitterSite>@twitterhandle</TwitterSite>
   <TwitterCreator>@twitterhandle</TwitterCreator>
   <TwitterImage>http://www.somesite.com/images/defaultsiteimage.png</TwitterImage>
+  <MastodonServerUrl />
+  <MastodonAccount />
 </MetaTags>

--- a/source/DasBlog.Tests/UnitTests/Config/metaConfig.xml
+++ b/source/DasBlog.Tests/UnitTests/Config/metaConfig.xml
@@ -6,6 +6,4 @@
   <TwitterSite>@twitterhandle</TwitterSite>
   <TwitterCreator>@twitterhandle</TwitterCreator>
   <TwitterImage>http://www.somesite.com/images/defaultsiteimage.png</TwitterImage>
-  <FaceBookAdmins>fbadmin</FaceBookAdmins>
-  <FaceBookAppID>AB124321234</FaceBookAppID>
 </MetaTags>

--- a/source/DasBlog.Tests/UnitTests/Config/site.config
+++ b/source/DasBlog.Tests/UnitTests/Config/site.config
@@ -132,10 +132,6 @@
   <!-- Settings below this line are not currently in use -->
   <!-- _________________________________________________ -->
   <CommentsAllowHtml>true</CommentsAllowHtml>
-  <EnableCaptcha>false</EnableCaptcha>
-  <RecaptchaSiteKey>your_google_recaptcha_site_key_here</RecaptchaSiteKey>
-  <RecaptchaSecretKey>your_google_recaptcha_secret_key_here</RecaptchaSecretKey>
-  <RecaptchaMinimumScore>0.7</RecaptchaMinimumScore>
   <RssLanguage />
   <EnableSearchHighlight>false</EnableSearchHighlight>
   <LogBlockedReferrals>false</LogBlockedReferrals>

--- a/source/DasBlog.Tests/UnitTests/Config/site.config
+++ b/source/DasBlog.Tests/UnitTests/Config/site.config
@@ -126,8 +126,8 @@
   <CookieConsentEnabled>false</CookieConsentEnabled>
 
   <DefaultSources>data:;https:</DefaultSources>
-  <SecurityStyleSources>cloud.tinymce.com;cdn.tiny.cloud;cdn.jsdelivr.net;js.nicedit.com;www.google.com;platform.twitter.com;cdn.syndication.twimg.com;fonts.googleapis.com;maxcdn.bootstrapcdn.com</SecurityStyleSources>
-  <SecurityScriptSources>cloud.tinymce.com;cdn.tiny.cloud;cdn.jsdelivr.net;js.nicedit.com;www.google.com;cse.google.com;cdn.syndication.twimg.com;platform.twitter.com;apis.google.com;www.google-analytics.com;www.googletagservices.com;adservice.google.com;securepubads.g.doubleclick.net;ajax.aspnetcdn.com;ssl.google-analytics.com</SecurityScriptSources>
+  <SecurityStyleSources>cloud.tinymce.com;cdn.tiny.cloud;cdn.jsdelivr.net;js.nicedit.com;platform.twitter.com;cdn.syndication.twimg.com;fonts.googleapis.com;maxcdn.bootstrapcdn.com</SecurityStyleSources>
+  <SecurityScriptSources>cloud.tinymce.com;cdn.tiny.cloud;cdn.jsdelivr.net;js.nicedit.com;cdn.syndication.twimg.com;platform.twitter.com;ajax.aspnetcdn.com</SecurityScriptSources>
 
   <!-- Settings below this line are not currently in use -->
   <!-- _________________________________________________ -->

--- a/source/DasBlog.Tests/UnitTests/Managers/ActivityPubManagerTest.cs
+++ b/source/DasBlog.Tests/UnitTests/Managers/ActivityPubManagerTest.cs
@@ -16,6 +16,7 @@ namespace DasBlog.Tests.UnitTests.Managers
     public class ActivityPubManagerTest
     {
         private Mock<IDasBlogSettings> settingsMock;
+        private Mock<IMastodonSettingsResolver> mastodonSettingsResolverMock;
         private Mock<ISiteConfig> siteConfigMock;
         private Mock<IBlogDataService> dataServiceMock;
         public ActivityPubManagerTest()
@@ -33,9 +34,12 @@ namespace DasBlog.Tests.UnitTests.Managers
 			siteConfigMock.SetupGet(c => c.DisplayTimeZoneIndex).Returns(0);
 			siteConfigMock.SetupGet(c => c.AdjustDisplayTimeZone).Returns(false);
 			siteConfigMock.SetupGet(c => c.MastodonAccount).Returns("testuser");
-            siteConfigMock.SetupGet(c => c.MastodonServerUrl).Returns("https://mastodon.example.com");
-            settingsMock.Setup(s => s.SiteConfiguration).Returns(siteConfigMock.Object);
-            dataServiceMock = new Mock<IBlogDataService>();
+			siteConfigMock.SetupGet(c => c.MastodonServerUrl).Returns("https://mastodon.example.com");
+			settingsMock.Setup(s => s.SiteConfiguration).Returns(siteConfigMock.Object);
+			mastodonSettingsResolverMock = new Mock<IMastodonSettingsResolver>();
+			mastodonSettingsResolverMock.Setup(s => s.GetMastodonAccount()).Returns("testuser");
+			mastodonSettingsResolverMock.Setup(s => s.GetMastodonServerUrl()).Returns("https://mastodon.example.com");
+			dataServiceMock = new Mock<IBlogDataService>();
 
             dataServiceMock.Setup(d => d.GetEntriesForMonth(It.IsAny<DateTime>(), It.IsAny<DateTimeZone>(), It.IsAny<string>())).Returns(new EntryCollection());
             var entryForPage = new EntryCollection();
@@ -45,7 +49,7 @@ namespace DasBlog.Tests.UnitTests.Managers
 
         private ActivityPubManager CreateManager()
         {
-            return new ActivityPubManager(settingsMock.Object, dataServiceMock.Object);
+            return new ActivityPubManager(settingsMock.Object, dataServiceMock.Object, mastodonSettingsResolverMock.Object);
         }
 
 		private ArchiveManager CreateArchiveManager()

--- a/source/DasBlog.Tests/UnitTests/SiteConfigTest.cs
+++ b/source/DasBlog.Tests/UnitTests/SiteConfigTest.cs
@@ -45,10 +45,6 @@ namespace DasBlog.Tests.UnitTests
 		public string ProfilesDir { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 		public string BinariesDirRelative { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 		public string SmtpServer { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-		public bool EnableCaptcha { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-		public string RecaptchaSiteKey { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-		public string RecaptchaSecretKey { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-		public double RecaptchaMinimumScore { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 		public string ChannelImageUrl { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 		public bool EnableTitlePermaLink { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 		public bool EnableTitlePermaLinkUnique { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }

--- a/source/DasBlog.Web/Config/meta.Development.config
+++ b/source/DasBlog.Web/Config/meta.Development.config
@@ -8,5 +8,6 @@
   <TwitterImage>http://www.somesite.com/images/defaultsiteimage.png</TwitterImage>
   <FaceBookAdmins>fbadmin</FaceBookAdmins>
   <FaceBookAppID>AB124321234</FaceBookAppID>
-  <GoogleAnalyticsID>UA</GoogleAnalyticsID>
+  <AnalyticsTrackingId></AnalyticsTrackingId>
+  <AnalyticsProvider></AnalyticsProvider>
 </MetaTags>

--- a/source/DasBlog.Web/Config/meta.Development.config
+++ b/source/DasBlog.Web/Config/meta.Development.config
@@ -6,4 +6,6 @@
   <TwitterSite>@twitterhandle</TwitterSite>
   <TwitterCreator>@twitterhandle</TwitterCreator>
   <TwitterImage>http://www.somesite.com/images/defaultsiteimage.png</TwitterImage>
+  <MastodonServerUrl />
+  <MastodonAccount />
 </MetaTags>

--- a/source/DasBlog.Web/Config/meta.Development.config
+++ b/source/DasBlog.Web/Config/meta.Development.config
@@ -8,6 +8,4 @@
   <TwitterImage>http://www.somesite.com/images/defaultsiteimage.png</TwitterImage>
   <FaceBookAdmins>fbadmin</FaceBookAdmins>
   <FaceBookAppID>AB124321234</FaceBookAppID>
-  <AnalyticsTrackingId></AnalyticsTrackingId>
-  <AnalyticsProvider></AnalyticsProvider>
 </MetaTags>

--- a/source/DasBlog.Web/Config/meta.Development.config
+++ b/source/DasBlog.Web/Config/meta.Development.config
@@ -6,6 +6,4 @@
   <TwitterSite>@twitterhandle</TwitterSite>
   <TwitterCreator>@twitterhandle</TwitterCreator>
   <TwitterImage>http://www.somesite.com/images/defaultsiteimage.png</TwitterImage>
-  <FaceBookAdmins>fbadmin</FaceBookAdmins>
-  <FaceBookAppID>AB124321234</FaceBookAppID>
 </MetaTags>

--- a/source/DasBlog.Web/Config/meta.config
+++ b/source/DasBlog.Web/Config/meta.config
@@ -8,5 +8,6 @@
   <TwitterImage>http://www.somesite.com/images/defaultsiteimage.png</TwitterImage>
   <FaceBookAdmins>fbadmin</FaceBookAdmins>
   <FaceBookAppID>AB124321234</FaceBookAppID>
-  <GoogleAnalyticsID>UA</GoogleAnalyticsID>
+  <AnalyticsTrackingId></AnalyticsTrackingId>
+  <AnalyticsProvider></AnalyticsProvider>
 </MetaTags>

--- a/source/DasBlog.Web/Config/meta.config
+++ b/source/DasBlog.Web/Config/meta.config
@@ -6,4 +6,6 @@
   <TwitterSite>@twitterhandle</TwitterSite>
   <TwitterCreator>@twitterhandle</TwitterCreator>
   <TwitterImage>http://www.somesite.com/images/defaultsiteimage.png</TwitterImage>
+  <MastodonServerUrl />
+  <MastodonAccount />
 </MetaTags>

--- a/source/DasBlog.Web/Config/meta.config
+++ b/source/DasBlog.Web/Config/meta.config
@@ -8,6 +8,4 @@
   <TwitterImage>http://www.somesite.com/images/defaultsiteimage.png</TwitterImage>
   <FaceBookAdmins>fbadmin</FaceBookAdmins>
   <FaceBookAppID>AB124321234</FaceBookAppID>
-  <AnalyticsTrackingId></AnalyticsTrackingId>
-  <AnalyticsProvider></AnalyticsProvider>
 </MetaTags>

--- a/source/DasBlog.Web/Config/meta.config
+++ b/source/DasBlog.Web/Config/meta.config
@@ -6,6 +6,4 @@
   <TwitterSite>@twitterhandle</TwitterSite>
   <TwitterCreator>@twitterhandle</TwitterCreator>
   <TwitterImage>http://www.somesite.com/images/defaultsiteimage.png</TwitterImage>
-  <FaceBookAdmins>fbadmin</FaceBookAdmins>
-  <FaceBookAppID>AB124321234</FaceBookAppID>
 </MetaTags>

--- a/source/DasBlog.Web/Config/site.Development.config
+++ b/source/DasBlog.Web/Config/site.Development.config
@@ -34,8 +34,6 @@
   <LogDir>logs</LogDir>
   <BinariesDir>content/binary</BinariesDir>
   <SmtpServer>localhost</SmtpServer>
-  <EnableCaptcha>false</EnableCaptcha>
-  <RecaptchaMinimumScore>0</RecaptchaMinimumScore>
   <EnableTitlePermaLink>false</EnableTitlePermaLink>
   <EnableTitlePermaLinkUnique>false</EnableTitlePermaLinkUnique>
   <EnableTitlePermaLinkSpaces>false</EnableTitlePermaLinkSpaces>

--- a/source/DasBlog.Web/Config/site.config
+++ b/source/DasBlog.Web/Config/site.config
@@ -138,10 +138,6 @@
   <!-- Settings below this line are not currently in use -->
   <!-- _________________________________________________ -->
   <CommentsAllowHtml>true</CommentsAllowHtml>
-  <EnableCaptcha>false</EnableCaptcha>
-  <RecaptchaSiteKey>your_google_recaptcha_site_key_here</RecaptchaSiteKey>
-  <RecaptchaSecretKey>your_google_recaptcha_secret_key_here</RecaptchaSecretKey>
-  <RecaptchaMinimumScore>0.7</RecaptchaMinimumScore>
   <RssLanguage />
   <EnableSearchHighlight>false</EnableSearchHighlight>
   <LogBlockedReferrals>false</LogBlockedReferrals>

--- a/source/DasBlog.Web/Controllers/ActivityPubController.cs
+++ b/source/DasBlog.Web/Controllers/ActivityPubController.cs
@@ -15,13 +15,15 @@ namespace DasBlog.Web.Controllers
 	public class ActivityPubController : DasBlogBaseController
 	{
 		private readonly IDasBlogSettings dasBlogSettings;
+		private readonly IMastodonSettingsResolver mastodonSettingsResolver;
 		private readonly IActivityPubManager activityPubManager;
 		private readonly IBlogManager blogManager;
 		private readonly IMapper mapper;
 
-		public ActivityPubController(IActivityPubManager activityPubManager, IBlogManager blogManager, IDasBlogSettings dasBlogSettings, IMapper mapper) : base(dasBlogSettings)
+		public ActivityPubController(IActivityPubManager activityPubManager, IBlogManager blogManager, IDasBlogSettings dasBlogSettings, IMastodonSettingsResolver mastodonSettingsResolver, IMapper mapper) : base(dasBlogSettings)
 		{
 			this.dasBlogSettings = dasBlogSettings;
+			this.mastodonSettingsResolver = mastodonSettingsResolver;
 			this.activityPubManager = activityPubManager;
 			this.blogManager = blogManager;
 			this.mapper = mapper;
@@ -30,7 +32,12 @@ namespace DasBlog.Web.Controllers
 		[HttpGet(".well-known/webfinger")]
 		public ActionResult WebFinger(string resource)
 		{
-			if (resource.StartsWith("acct:"))
+			if (string.IsNullOrWhiteSpace(resource))
+			{
+				return NoContent();
+			}
+
+			if (resource.StartsWith("acct:", StringComparison.OrdinalIgnoreCase))
 			{
 				resource = resource.Remove(0, 5);
 			}
@@ -52,8 +59,13 @@ namespace DasBlog.Web.Controllers
 		[Route("users/{user}")]
 		public IActionResult Actor(string user)
 		{
-			var mastodonAccount = dasBlogSettings.SiteConfiguration.MastodonAccount;
-			if (mastodonAccount.StartsWith("@"))
+			var mastodonAccount = mastodonSettingsResolver.GetMastodonAccount();
+			if (string.IsNullOrWhiteSpace(mastodonAccount))
+			{
+				return NotFound();
+			}
+
+			if (mastodonAccount.StartsWith("@", StringComparison.Ordinal))
 			{
 				mastodonAccount = mastodonAccount.Remove(0, 1);
 			}
@@ -90,8 +102,13 @@ namespace DasBlog.Web.Controllers
 		[Route("users/{user}/outbox")]
 		public IActionResult GetUser(string user, bool page)
 		{
-			string mastodonAccount = dasBlogSettings.SiteConfiguration.MastodonAccount;
-			if (mastodonAccount.StartsWith("@"))
+			string mastodonAccount = mastodonSettingsResolver.GetMastodonAccount();
+			if (string.IsNullOrWhiteSpace(mastodonAccount))
+			{
+				return NotFound();
+			}
+
+			if (mastodonAccount.StartsWith("@", StringComparison.Ordinal))
 			{
 				mastodonAccount = mastodonAccount.Remove(0, 1);
 			}

--- a/source/DasBlog.Web/Controllers/AdminController.cs
+++ b/source/DasBlog.Web/Controllers/AdminController.cs
@@ -100,20 +100,18 @@ namespace DasBlog.Web.Controllers
 				site.SmtpPassword = dasBlogSettings.SiteConfiguration.SmtpPassword;
 			}
 
-			// Mastodon settings are canonical in meta.config. If the posted meta values are empty,
-			// resolve from current config one last time, then clear the legacy site.config values.
-			if (string.IsNullOrWhiteSpace(meta.MastodonServerUrl))
-			{
-				meta.MastodonServerUrl = mastodonSettingsResolver.GetMastodonServerUrl();
-			}
+			// Mastodon settings are canonical in meta.config.
+			// Persist explicit blanks when values are empty instead of backfilling.
+			meta.MastodonServerUrl = string.IsNullOrWhiteSpace(meta.MastodonServerUrl)
+				? string.Empty
+				: meta.MastodonServerUrl.Trim();
 
-			if (string.IsNullOrWhiteSpace(meta.MastodonAccount))
-			{
-				meta.MastodonAccount = mastodonSettingsResolver.GetMastodonAccount();
-			}
+			meta.MastodonAccount = string.IsNullOrWhiteSpace(meta.MastodonAccount)
+				? string.Empty
+				: meta.MastodonAccount.Trim();
 
-			site.MastodonServerUrl = string.Empty;
-			site.MastodonAccount = string.Empty;
+			site.MastodonServerUrl = null;
+			site.MastodonAccount = null;
 
 			if (!fileSystemBinaryManager.SaveSiteConfig(site))
 			{

--- a/source/DasBlog.Web/Controllers/AdminController.cs
+++ b/source/DasBlog.Web/Controllers/AdminController.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -25,6 +25,7 @@ namespace DasBlog.Web.Controllers
 	public class AdminController : DasBlogBaseController
 	{
 		private readonly IDasBlogSettings dasBlogSettings;
+		private readonly IMastodonSettingsResolver mastodonSettingsResolver;
 		private readonly IFileSystemBinaryManager fileSystemBinaryManager;
 		private readonly IMapper mapper;
 		private readonly IBlogManager blogManager;
@@ -35,10 +36,11 @@ namespace DasBlog.Web.Controllers
 		private readonly ISiteSecurityManager siteSecurityManager;
 		private readonly List<PostViewModel> posts = [];	
 
-		public AdminController(IDasBlogSettings dasBlogSettings, IFileSystemBinaryManager fileSystemBinaryManager, IMapper mapper,
+		public AdminController(IDasBlogSettings dasBlogSettings, IMastodonSettingsResolver mastodonSettingsResolver, IFileSystemBinaryManager fileSystemBinaryManager, IMapper mapper,
 								IBlogManager blogManager, ICommentManager commentManager, IHostApplicationLifetime appLifetime, ILogger<AdminController> logger, IMemoryCache memoryCache, ISiteSecurityManager siteSecurityManager) : base(dasBlogSettings)
 		{
 			this.dasBlogSettings = dasBlogSettings;
+			this.mastodonSettingsResolver = mastodonSettingsResolver;
 			this.fileSystemBinaryManager = fileSystemBinaryManager;
 			this.mapper = mapper;
 			this.blogManager = blogManager;
@@ -60,6 +62,16 @@ namespace DasBlog.Web.Controllers
 			dbsvm.MetaConfig = mapper.Map<MetaViewModel>(dasBlogSettings.MetaTags);
 			dbsvm.SiteConfig = mapper.Map<SiteViewModel>(dasBlogSettings.SiteConfiguration);
 			dbsvm.Posts = posts;
+
+			if (string.IsNullOrWhiteSpace(dbsvm.MetaConfig.MastodonServerUrl))
+			{
+				dbsvm.MetaConfig.MastodonServerUrl = mastodonSettingsResolver.GetMastodonServerUrl();
+			}
+
+			if (string.IsNullOrWhiteSpace(dbsvm.MetaConfig.MastodonAccount))
+			{
+				dbsvm.MetaConfig.MastodonAccount = mastodonSettingsResolver.GetMastodonAccount();
+			}
 
 			return View(dbsvm);
 		}
@@ -87,6 +99,21 @@ namespace DasBlog.Web.Controllers
 			{
 				site.SmtpPassword = dasBlogSettings.SiteConfiguration.SmtpPassword;
 			}
+
+			// Mastodon settings are canonical in meta.config. If the posted meta values are empty,
+			// resolve from current config one last time, then clear the legacy site.config values.
+			if (string.IsNullOrWhiteSpace(meta.MastodonServerUrl))
+			{
+				meta.MastodonServerUrl = mastodonSettingsResolver.GetMastodonServerUrl();
+			}
+
+			if (string.IsNullOrWhiteSpace(meta.MastodonAccount))
+			{
+				meta.MastodonAccount = mastodonSettingsResolver.GetMastodonAccount();
+			}
+
+			site.MastodonServerUrl = string.Empty;
+			site.MastodonAccount = string.Empty;
 
 			if (!fileSystemBinaryManager.SaveSiteConfig(site))
 			{

--- a/source/DasBlog.Web/Controllers/BlogPostController.cs
+++ b/source/DasBlog.Web/Controllers/BlogPostController.cs
@@ -18,7 +18,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
-using reCAPTCHA.AspNetCore;
 using Markdig;
 using DasBlog.Core.Extensions;
 using System.Text.RegularExpressions;
@@ -45,13 +44,12 @@ namespace DasBlog.Web.Controllers
 		private readonly IBlogPostViewModelCreator modelViewCreator;
 		private readonly IMemoryCache memoryCache;
 		private readonly IExternalEmbeddingHandler embeddingHandler;
-		private readonly IRecaptchaService recaptcha;
 		private readonly IDasBlogPathResolver pathResolver;
 
 		
 		public BlogPostController(IBlogManager blogManager, ICommentManager commentManager, ISearchManager searchManager, IHttpContextAccessor httpContextAccessor, IDasBlogSettings dasBlogSettings,
 									IMapper mapper, ICategoryManager categoryManager, IFileSystemBinaryManager binaryManager, ILogger<BlogPostController> logger,
-									IBlogPostViewModelCreator modelViewCreator, IMemoryCache memoryCache, IExternalEmbeddingHandler embeddingHandler, IRecaptchaService recaptcha,
+									IBlogPostViewModelCreator modelViewCreator, IMemoryCache memoryCache, IExternalEmbeddingHandler embeddingHandler,
 									IDasBlogPathResolver pathResolver)
 									: base(dasBlogSettings)
 		{
@@ -67,7 +65,6 @@ namespace DasBlog.Web.Controllers
 			this.modelViewCreator = modelViewCreator;
 			this.memoryCache = memoryCache;
 			this.embeddingHandler = embeddingHandler;
-			this.recaptcha = recaptcha;
 			this.pathResolver = pathResolver;
 		}
 
@@ -475,17 +472,6 @@ namespace DasBlog.Web.Controllers
 				}
 			}
 
-			if (dasBlogSettings.SiteConfiguration.EnableCaptcha)
-			{
-				var recaptchaTask = recaptcha.Validate(Request);
-				recaptchaTask.Wait();
-				var recaptchaResult = recaptchaTask.Result;
-				if ((!recaptchaResult.success || recaptchaResult.score != 0) &&
-					  recaptchaResult.score < dasBlogSettings.SiteConfiguration.RecaptchaMinimumScore)
-				{
-					errors.Add("Unfinished Captcha. Please finish the captcha by clicking 'I'm not a robot' and try again.");
-				}
-			}
 
 			if (errors.Count > 0)
 			{

--- a/source/DasBlog.Web/DasBlog.Web.csproj
+++ b/source/DasBlog.Web/DasBlog.Web.csproj
@@ -31,7 +31,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" />
     <PackageReference Include="NetEscapades.Extensions.Logging.RollingFile" />
     <PackageReference Include="NWebsec.AspNetCore.Middleware" />
-    <PackageReference Include="reCAPTCHA.AspNetCore" />
     <PackageReference Include="Quartz.AspNetCore" />
     <PackageReference Include="NuGet.Protocol" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />

--- a/source/DasBlog.Web/DasBlogServiceCollectionExtensions.cs
+++ b/source/DasBlog.Web/DasBlogServiceCollectionExtensions.cs
@@ -31,7 +31,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using newtelligence.DasBlog.Runtime;
-using reCAPTCHA.AspNetCore;
 using System;
 using System.Linq;
 using System.Reflection;
@@ -202,11 +201,6 @@ namespace DasBlog.Web
 					options.MinimumSameSitePolicy = SameSiteMode.Lax;
 			});
 
-			services.AddRecaptcha(options =>
-			{
-				options.SiteKey = configuration.GetSection("RecaptchaSiteKey").Value;
-				options.SecretKey = configuration.GetSection("RecaptchaSecretKey").Value;
-			});
 
 			return services;
 		}

--- a/source/DasBlog.Web/DasBlogServiceCollectionExtensions.cs
+++ b/source/DasBlog.Web/DasBlogServiceCollectionExtensions.cs
@@ -81,6 +81,7 @@ namespace DasBlog.Web
 		{
 			services
 				.AddSingleton<IDasBlogSettings, DasBlogSettings>()
+				.AddSingleton<IMastodonSettingsResolver, MastodonSettingsResolver>()
 				.AddSingleton<IUrlResolver>(sp => sp.GetRequiredService<IDasBlogSettings>())
 				.AddSingleton<ITimeZoneService>(sp => sp.GetRequiredService<IDasBlogSettings>())
 				.AddSingleton<IContentProcessor>(sp => sp.GetRequiredService<IDasBlogSettings>())

--- a/source/DasBlog.Web/Models/AdminViewModels/MetaViewModel.cs
+++ b/source/DasBlog.Web/Models/AdminViewModels/MetaViewModel.cs
@@ -43,12 +43,5 @@ namespace DasBlog.Web.Models.AdminViewModels
 		[Description("")]
 		public string FaceBookAppID { get; set; }
 
-		[DisplayName("Analytics Tracking ID")]
-		[Description("Tracking identifier used in the RSS feed analytics extension.")]
-		public string AnalyticsTrackingId { get; set; }
-
-		[DisplayName("Analytics Provider")]
-		[Description("Analytics engine name written into the RSS feed analytics extension.")]
-		public string AnalyticsProvider { get; set; }
-	}
-}
+			}
+		}

--- a/source/DasBlog.Web/Models/AdminViewModels/MetaViewModel.cs
+++ b/source/DasBlog.Web/Models/AdminViewModels/MetaViewModel.cs
@@ -35,5 +35,14 @@ namespace DasBlog.Web.Models.AdminViewModels
 		[StringLength(300, MinimumLength = 1, ErrorMessage = "{0} should be between 1 to 300 characters")]
 		public string TwitterImage { get; set; }
 
-			}
-		}
+		[DisplayName("Mastodon Server")]
+		[Description("")]
+		[DataType(DataType.Url, ErrorMessage = "Invalid URL format")]
+		public string MastodonServerUrl { get; set; }
+
+		[DisplayName("Mastodon Account (@username)")]
+		[Description("")]
+		[RegularExpression("(@)((?:[A-Za-z0-9-_]*))")]
+		public string MastodonAccount { get; set; }
+	}
+}

--- a/source/DasBlog.Web/Models/AdminViewModels/MetaViewModel.cs
+++ b/source/DasBlog.Web/Models/AdminViewModels/MetaViewModel.cs
@@ -35,13 +35,5 @@ namespace DasBlog.Web.Models.AdminViewModels
 		[StringLength(300, MinimumLength = 1, ErrorMessage = "{0} should be between 1 to 300 characters")]
 		public string TwitterImage { get; set; }
 
-		[DisplayName("Facebook Admin")]
-		[Description("")]
-		public string FaceBookAdmins { get; set; }
-
-		[DisplayName("Facebook App Id")]
-		[Description("")]
-		public string FaceBookAppID { get; set; }
-
 			}
 		}

--- a/source/DasBlog.Web/Models/AdminViewModels/MetaViewModel.cs
+++ b/source/DasBlog.Web/Models/AdminViewModels/MetaViewModel.cs
@@ -43,8 +43,12 @@ namespace DasBlog.Web.Models.AdminViewModels
 		[Description("")]
 		public string FaceBookAppID { get; set; }
 
-		[DisplayName("Google Analytics ID")]
-		[Description("Used in the RSS Feed")]
-		public string GoogleAnalyticsID {get; set;}
+		[DisplayName("Analytics Tracking ID")]
+		[Description("Tracking identifier used in the RSS feed analytics extension.")]
+		public string AnalyticsTrackingId { get; set; }
+
+		[DisplayName("Analytics Provider")]
+		[Description("Analytics engine name written into the RSS feed analytics extension.")]
+		public string AnalyticsProvider { get; set; }
 	}
 }

--- a/source/DasBlog.Web/Models/AdminViewModels/SiteViewModel.cs
+++ b/source/DasBlog.Web/Models/AdminViewModels/SiteViewModel.cs
@@ -148,24 +148,6 @@ namespace DasBlog.Web.Models.AdminViewModels
 		[StringLength(300, MinimumLength = 1, ErrorMessage = "{0} should be between 1 to 300 characters")]
 		public string CheesySpamA { get; set; }
 
-		[DisplayName("Enable Captcha")]
-		[Description("Let's You Decide if you want to use Google's reCAPTCHA to prevent Bots from spamming the comments on your posts.")]
-        public bool EnableCaptcha { get; set; }
-
-       	[DisplayName("reCAPTCHA Minimum Score")]
-		[Description("Minimum Score for the reCAPTCHA to be considered pass. For example if you are asked to identify an image at least 50% of the images must be identified if score if 0.5")]
-		[Range(0.0, 1.0, ErrorMessage = "Values should be between 0 and 1")]
-        public double RecaptchaMinimumScore { get; set; }
-        
-       	[DisplayName("reCAPTCHA Site Key")]
-		[Description("reCAPTCHA site key based from Google reCAPTCHA Admin Site.")]
-		[StringLength(300, MinimumLength = 1, ErrorMessage = "{0} should be between 1 to 300 characters")]
-        public string RecaptchaSiteKey { get; set; }
-        
-       	[DisplayName("Google reCAPTCHA Secret Key")]
-		[Description("reCAPTCHA secret key based on Google reCAPTCHA Admin Site.")]
-		[StringLength(300, MinimumLength = 1, ErrorMessage = "{0} should be between 1 to 300 characters")]
-        public string RecaptchaSecretKey { get; set; }
 
 		[DisplayName("Style Sources (seperate by semi colon)")]
 		[Description("")]

--- a/source/DasBlog.Web/Services/MastodonSettingsResolver.cs
+++ b/source/DasBlog.Web/Services/MastodonSettingsResolver.cs
@@ -1,0 +1,38 @@
+﻿using DasBlog.Services;
+
+namespace DasBlog.Web.Services
+{
+	/// <summary>
+	/// Resolves Mastodon settings while we migrate canonical storage from site.config to meta.config.
+	/// Meta config wins; site config remains the fallback so existing installs continue to work.
+	/// </summary>
+	public sealed class MastodonSettingsResolver : IMastodonSettingsResolver
+	{
+		private readonly IDasBlogSettings dasBlogSettings;
+
+		public MastodonSettingsResolver(IDasBlogSettings dasBlogSettings)
+		{
+			this.dasBlogSettings = dasBlogSettings;
+		}
+
+		public string GetMastodonServerUrl()
+		{
+			if (!string.IsNullOrWhiteSpace(dasBlogSettings.MetaTags?.MastodonServerUrl))
+			{
+				return dasBlogSettings.MetaTags.MastodonServerUrl;
+			}
+
+			return dasBlogSettings.SiteConfiguration.MastodonServerUrl;
+		}
+
+		public string GetMastodonAccount()
+		{
+			if (!string.IsNullOrWhiteSpace(dasBlogSettings.MetaTags?.MastodonAccount))
+			{
+				return dasBlogSettings.MetaTags.MastodonAccount;
+			}
+
+			return dasBlogSettings.SiteConfiguration.MastodonAccount;
+		}
+	}
+}

--- a/source/DasBlog.Web/Views/Admin/Settings.cshtml
+++ b/source/DasBlog.Web/Views/Admin/Settings.cshtml
@@ -238,11 +238,7 @@
     @Html.HiddenFor(@m => m.SiteConfig.EnableDefaultLatLongForNonGeoCodedPosts)
     @Html.HiddenFor(@m => m.SiteConfig.HtmlTidyContent)
 
-
-        @Html.HiddenFor(@m => m.MetaConfig.FaceBookAdmins)
-        @Html.HiddenFor(@m => m.MetaConfig.FaceBookAppID)
-
-    </form>
+        </form>
 
     <!-- Confirmation Modal using reusable partial -->
     <partial name="_ConfirmationModalPartial" view-data="ViewData" />

--- a/source/DasBlog.Web/Views/Shared/_Admin_Comments.cshtml
+++ b/source/DasBlog.Web/Views/Shared/_Admin_Comments.cshtml
@@ -57,34 +57,6 @@
     </div>
 </div>
 
-<div class="col-md-12">
-    @Html.CheckBoxFor(m => @Model.SiteConfig.EnableCaptcha, new { @class = "form-check-input" })
-    @Html.LabelFor(m => @Model.SiteConfig.EnableCaptcha, null, new { @class = "col-check-label" })
-</div>
-
-<div class="row gy-2 gx-3 align-items-md-start">
-    <div class="col-sm-4">
-        <div class="form-floating">
-            @Html.TextBox("SiteConfig.RecaptchaMinimumScore", Model.SiteConfig.RecaptchaMinimumScore.ToString(System.Globalization.CultureInfo.InvariantCulture), new { type = "number", step = "0.1", @class = "form-control", id = "recaptchaMinimumScore" })
-            @Html.LabelFor(m => @Model.SiteConfig.RecaptchaMinimumScore, null, new { @class = "form-label", @for = "recaptchaMinimumScore" })
-        </div>
-        @Html.ValidationMessageFor(m => m.SiteConfig.RecaptchaMinimumScore, null, new { @class = "text-danger" })
-    </div>
-    <div class="col-sm-4">
-        <div class="form-floating">
-            @Html.TextBoxFor(m => @Model.SiteConfig.RecaptchaSiteKey, null, new { @class = "form-control", id = "recaptchaSiteKey" })
-            @Html.LabelFor(m => @Model.SiteConfig.RecaptchaSiteKey, null, new { @class = "form-label", @for = "recaptchaSiteKey" })
-        </div>
-        @Html.ValidationMessageFor(m => m.SiteConfig.RecaptchaSiteKey, null, new { @class = "text-danger" })
-    </div>
-    <div class="col-sm-4">
-        <div class="form-floating">
-            @Html.TextBoxFor(m => @Model.SiteConfig.RecaptchaSecretKey, null, new { @class = "form-control", id = "recaptchaSecretKey" })
-            @Html.LabelFor(m => @Model.SiteConfig.RecaptchaSecretKey, null, new { @class = "form-label", @for = "recaptchaSecretKey" })
-        </div>
-        @Html.ValidationMessageFor(m => m.SiteConfig.RecaptchaSecretKey, null, new { @class = "text-danger" })
-    </div>
-</div>
 
 <div class="row gy-2 gx-3 mt-4 mb-3">
     <div class="col-12">
@@ -119,27 +91,14 @@
 <script>
     document.addEventListener('DOMContentLoaded', function () {
         const enableCommentsCheckbox = document.querySelector('[id$="EnableComments"]');
-        const enableCaptchaCheckbox = document.querySelector('[id$="EnableCaptcha"]');
         const enableCommentDaysCheckbox = document.querySelector('[id$="EnableCommentDays"]');
         const daysCommentsAllowedTextbox = document.getElementById('daysCommentsAllowed');
         const enableSpamModerationCheckbox = document.getElementById('enableSpamModeration');
         const akismetApiKeyTextbox = document.getElementById('akismetAPIKey');
-        const recaptchaFields = [
-            document.getElementById('recaptchaMinimumScore'),
-            document.getElementById('recaptchaSiteKey'),
-            document.getElementById('recaptchaSecretKey')
-        ];
         // All form fields in the Comments section except EnableComments
         const commentsSection = document.getElementById('collapseComments');
         const allFormFields = Array.from(commentsSection.querySelectorAll('input, select, textarea'))
             .filter(el => el !== enableCommentsCheckbox);
-
-        function toggleRecaptchaFields() {
-            const isEnabled = enableCaptchaCheckbox.checked && enableCommentsCheckbox.checked;
-            recaptchaFields.forEach(field => {
-                field.disabled = !isEnabled;
-            });
-        }
 
         function toggleDaysCommentsAllowed() {
             const isEnabled = enableCommentDaysCheckbox.checked && enableCommentsCheckbox.checked;
@@ -159,7 +118,6 @@
             });
             // If enabled, apply field-specific logic
             if (enabled) {
-                toggleRecaptchaFields();
                 toggleDaysCommentsAllowed();
                 toggleAkismetApiKey();
             }
@@ -169,9 +127,6 @@
         toggleAllFields();
         // Listen for changes
         enableCommentsCheckbox.addEventListener('change', toggleAllFields);
-        enableCaptchaCheckbox.addEventListener('change', function () {
-            if (enableCommentsCheckbox.checked) toggleRecaptchaFields();
-        });
         enableCommentDaysCheckbox.addEventListener('change', function () {
             if (enableCommentsCheckbox.checked) toggleDaysCommentsAllowed();
         });

--- a/source/DasBlog.Web/Views/Shared/_Admin_Social.cshtml
+++ b/source/DasBlog.Web/Views/Shared/_Admin_Social.cshtml
@@ -55,20 +55,3 @@
         @Html.ValidationMessageFor(m => m.MetaConfig.TwitterImage, null, new { @class = "text-danger" })
     </div>
 </div>
-
-<div class="row gy-2 gx-3 align-items-md-start mb-3">
-    <div class="col-sm-4">
-        <div class="form-floating">
-            @Html.TextBoxFor(m => @Model.MetaConfig.AnalyticsTrackingId, null, new { @class = "form-control", id = "analyticsTrackingId" })
-            @Html.LabelFor(m => @Model.MetaConfig.AnalyticsTrackingId, null, new { @class = "form-label", @for = "analyticsTrackingId" })
-        </div>
-        @Html.ValidationMessageFor(m => m.MetaConfig.AnalyticsTrackingId, null, new { @class = "text-danger" })
-    </div>
-    <div class="col-sm-4">
-        <div class="form-floating">
-            @Html.TextBoxFor(m => @Model.MetaConfig.AnalyticsProvider, null, new { @class = "form-control", id = "analyticsProvider" })
-            @Html.LabelFor(m => @Model.MetaConfig.AnalyticsProvider, null, new { @class = "form-label", @for = "analyticsProvider" })
-        </div>
-        @Html.ValidationMessageFor(m => m.MetaConfig.AnalyticsProvider, null, new { @class = "text-danger" })
-    </div>
-</div>

--- a/source/DasBlog.Web/Views/Shared/_Admin_Social.cshtml
+++ b/source/DasBlog.Web/Views/Shared/_Admin_Social.cshtml
@@ -59,9 +59,16 @@
 <div class="row gy-2 gx-3 align-items-md-start mb-3">
     <div class="col-sm-4">
         <div class="form-floating">
-            @Html.TextBoxFor(m => @Model.MetaConfig.GoogleAnalyticsID, null, new { @class = "form-control", id = "googleAnalyticsID" })
-            @Html.LabelFor(m => @Model.MetaConfig.GoogleAnalyticsID, null, new { @class = "form-label", @for = "googleAnalyticsID" })
+            @Html.TextBoxFor(m => @Model.MetaConfig.AnalyticsTrackingId, null, new { @class = "form-control", id = "analyticsTrackingId" })
+            @Html.LabelFor(m => @Model.MetaConfig.AnalyticsTrackingId, null, new { @class = "form-label", @for = "analyticsTrackingId" })
         </div>
-        @Html.ValidationMessageFor(m => m.MetaConfig.GoogleAnalyticsID, null, new { @class = "text-danger" })
+        @Html.ValidationMessageFor(m => m.MetaConfig.AnalyticsTrackingId, null, new { @class = "text-danger" })
+    </div>
+    <div class="col-sm-4">
+        <div class="form-floating">
+            @Html.TextBoxFor(m => @Model.MetaConfig.AnalyticsProvider, null, new { @class = "form-control", id = "analyticsProvider" })
+            @Html.LabelFor(m => @Model.MetaConfig.AnalyticsProvider, null, new { @class = "form-label", @for = "analyticsProvider" })
+        </div>
+        @Html.ValidationMessageFor(m => m.MetaConfig.AnalyticsProvider, null, new { @class = "text-danger" })
     </div>
 </div>

--- a/source/DasBlog.Web/Views/Shared/_Admin_Social.cshtml
+++ b/source/DasBlog.Web/Views/Shared/_Admin_Social.cshtml
@@ -6,17 +6,17 @@
 <div class="row gy-2 gx-3 align-items-md-start mb-3">
     <div class="col-sm-4">
         <div class="form-floating">
-            @Html.TextBoxFor(m => @Model.SiteConfig.MastodonServerUrl, null, new { @class = "form-control", id = "mastodonServerUrl" })
-            @Html.LabelFor(m => @Model.SiteConfig.MastodonServerUrl, null, new { @class = "form-label", @for = "mastodonServerUrl" })
+            @Html.TextBoxFor(m => @Model.MetaConfig.MastodonServerUrl, null, new { @class = "form-control", id = "mastodonServerUrl" })
+            @Html.LabelFor(m => @Model.MetaConfig.MastodonServerUrl, null, new { @class = "form-label", @for = "mastodonServerUrl" })
         </div>
-        @Html.ValidationMessageFor(m => m.SiteConfig.MastodonServerUrl, null, new { @class = "text-danger" })
+        @Html.ValidationMessageFor(m => m.MetaConfig.MastodonServerUrl, null, new { @class = "text-danger" })
     </div>
     <div class="col-sm-4">
         <div class="form-floating">
-            @Html.TextBoxFor(m => @Model.SiteConfig.MastodonAccount, null, new { @class = "form-control", id = "mastodonAccount" })
-            @Html.LabelFor(m => @Model.SiteConfig.MastodonAccount, null, new { @class = "form-label", @for = "mastodonAccount" })
+            @Html.TextBoxFor(m => @Model.MetaConfig.MastodonAccount, null, new { @class = "form-control", id = "mastodonAccount" })
+            @Html.LabelFor(m => @Model.MetaConfig.MastodonAccount, null, new { @class = "form-label", @for = "mastodonAccount" })
         </div>
-        @Html.ValidationMessageFor(m => m.SiteConfig.MastodonAccount, null, new { @class = "text-danger" })
+        @Html.ValidationMessageFor(m => m.MetaConfig.MastodonAccount, null, new { @class = "text-danger" })
     </div> 
 </div>
 

--- a/source/DasBlog.Web/Views/Shared/_CommentAddPartial.cshtml
+++ b/source/DasBlog.Web/Views/Shared/_CommentAddPartial.cshtml
@@ -1,11 +1,7 @@
 ﻿@using DasBlog.Core.Common;
 @using DasBlog.Services;
-@using Microsoft.Extensions.Options;
-@using reCAPTCHA.AspNetCore;
-@using reCAPTCHA.AspNetCore.Versions;
 @model DasBlog.Web.Models.BlogViewModels.AddCommentViewModel
 @inject IDasBlogSettings dasBlogSettings
-@inject IOptions<RecaptchaSettings> RecaptchaSettings
 
 
 <form asp-controller="post" asp-action="comments" method="post">
@@ -63,17 +59,6 @@
             </div>
         </div>
 
-        @if(dasBlogSettings.SiteConfiguration.EnableCaptcha)
-        {
-            <div class="row gy-2 gx-3 align-items-md-start mb-3">
-                <div class="col-sm-3">
-                    <div class="form-floating">
-                        @(Html.Recaptcha<RecaptchaV2Checkbox>(RecaptchaSettings?.Value))
-                    </div>
-
-                </div>
-            </div>
-        }
 
         <div class="row gy-2 gx-3 align-items-md-start mb-3">
             <div class="col-sm-2">

--- a/source/Directory.Packages.props
+++ b/source/Directory.Packages.props
@@ -5,7 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
-    <PackageVersion Include="reCAPTCHA.AspNetCore" Version="3.0.10" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="AutoMapper" Version="15.1.3" />


### PR DESCRIPTION
#### PR Classification
Deprecation and code cleanup to remove Google Analytics and reCAPTCHA support, update Mastodon settings handling, and improve documentation.

#### PR Summary
This PR removes all Google Analytics and reCAPTCHA support, migrates Mastodon settings to meta.config, and updates related code and documentation. It also simplifies the comments UI and refactors dependency injection for Mastodon settings.
- Removed all Google Analytics and reCAPTCHA logic from controllers, managers, ViewModels, and Razor views.
- Introduced IMastodonSettingsResolver and MastodonSettingsResolver, updating all Mastodon references to use meta.config with fallback.
- Updated AdminController, ActivityPubManager, ActivityPubController, and related tests to use the new Mastodon settings resolver.
- Cleaned up comments admin UI and comment submission logic, removing all captcha-related fields and validation.
- Updated README.md and FAQ.md to document the breaking changes and migration steps.
