### PR TITLE
Improve X (Twitter) card meta validation and output

### DIFF
--- a/source/DasBlog.Tests/UnitTests/UI/TwitterCardTagHelperTests.cs
+++ b/source/DasBlog.Tests/UnitTests/UI/TwitterCardTagHelperTests.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using DasBlog.Services;
+using DasBlog.Services.ConfigFile;
+using DasBlog.Web.TagHelpers.Site;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+using Moq;
+using Xunit;
+
+namespace DasBlog.Tests.UnitTests.UI
+{
+	public class TwitterCardTagHelperTests
+	{
+		private static string ProcessTwitterCardTagHelper(MetaTags metaTags, Action<ViewContext> configureViewContext = null)
+		{
+			var settingsMock = new Mock<IDasBlogSettings>();
+			settingsMock.SetupGet(s => s.MetaTags).Returns(metaTags);
+
+			var viewContext = new ViewContext();
+			configureViewContext?.Invoke(viewContext);
+
+			var sut = new TwitterCardTagHelper(settingsMock.Object)
+			{
+				ViewContext = viewContext
+			};
+
+			var context = new TagHelperContext(new TagHelperAttributeList(), new Dictionary<object, object>(), Guid.NewGuid().ToString("N"));
+			var output = new TagHelperOutput("twitter-card", new TagHelperAttributeList(), (_, _) =>
+				Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
+
+			sut.Process(context, output);
+			return output.Content.GetContent();
+		}
+
+		[Fact]
+		[Trait("Category", "UnitTest")]
+		public void Process_BlankValues_EmitsOnlyFallbackTwitterCard()
+		{
+			var html = ProcessTwitterCardTagHelper(new MetaTags());
+
+			Assert.Contains("<meta name=\"twitter:card\" content=\"summary\" />", html);
+			Assert.DoesNotContain("twitter:site", html);
+			Assert.DoesNotContain("twitter:creator", html);
+			Assert.DoesNotContain("twitter:title", html);
+			Assert.DoesNotContain("twitter:description", html);
+			Assert.DoesNotContain("twitter:image", html);
+		}
+
+		[Fact]
+		[Trait("Category", "UnitTest")]
+		public void Process_InvalidTwitterCardValue_UsesSummaryFallback()
+		{
+			var html = ProcessTwitterCardTagHelper(new MetaTags { TwitterCard = "invalid" });
+
+			Assert.Contains("<meta name=\"twitter:card\" content=\"summary\" />", html);
+			Assert.DoesNotContain("summary_large_image", html);
+		}
+
+		[Fact]
+		[Trait("Category", "UnitTest")]
+		public void Process_PageImageMissing_UsesConfiguredTwitterImage()
+		{
+			var html = ProcessTwitterCardTagHelper(
+				new MetaTags
+				{
+					TwitterCard = "summary_large_image",
+					TwitterImage = "https://example.com/default-image.png"
+				},
+				vc => vc.ViewData["PageImageUrl"] = string.Empty);
+
+			Assert.Contains("<meta name=\"twitter:card\" content=\"summary_large_image\" />", html);
+			Assert.Contains("<meta name=\"twitter:image\" content=\"https://example.com/default-image.png\" />", html);
+		}
+
+		[Fact]
+		[Trait("Category", "UnitTest")]
+		public void Process_HandleWithoutAtPrefix_NormalizesWithAtPrefix()
+		{
+			var html = ProcessTwitterCardTagHelper(
+				new MetaTags
+				{
+					TwitterCard = "summary",
+					TwitterSite = "poppastring",
+					TwitterCreator = "@mark"
+				},
+				vc =>
+				{
+					vc.ViewData["PageTitle"] = "Post title";
+					vc.ViewData["Description"] = "Post description";
+				});
+
+			Assert.Contains("<meta name=\"twitter:site\" content=\"@poppastring\" />", html);
+			Assert.Contains("<meta name=\"twitter:creator\" content=\"@mark\" />", html);
+			Assert.Contains("<meta name=\"twitter:title\" content=\"Post title\" />", html);
+			Assert.Contains("<meta name=\"twitter:description\" content=\"Post description\" />", html);
+		}
+	}
+}

--- a/source/DasBlog.Tests/UnitTests/Web/MetaViewModelValidationTests.cs
+++ b/source/DasBlog.Tests/UnitTests/Web/MetaViewModelValidationTests.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using DasBlog.Web.Models.AdminViewModels;
+using Xunit;
+
+namespace DasBlog.Tests.UnitTests.Web
+{
+	public class MetaViewModelValidationTests
+	{
+		private static IList<ValidationResult> ValidateModel(MetaViewModel model)
+		{
+			var validationResults = new List<ValidationResult>();
+			Validator.TryValidateObject(model, new ValidationContext(model), validationResults, validateAllProperties: true);
+			return validationResults;
+		}
+
+		[Fact]
+		[Trait("Category", "UnitTest")]
+		public void ValidateModel_InvalidTwitterCard_ReturnsValidationError()
+		{
+			var model = new MetaViewModel
+			{
+				TwitterCard = "player"
+			};
+
+			var errors = ValidateModel(model);
+
+			Assert.Contains(errors, e => e.MemberNames.Contains(nameof(MetaViewModel.TwitterCard)));
+		}
+
+		[Fact]
+		[Trait("Category", "UnitTest")]
+		public void ValidateModel_InvalidTwitterHandle_ReturnsValidationError()
+		{
+			var model = new MetaViewModel
+			{
+				TwitterCard = "summary",
+				TwitterSite = "invalid handle"
+			};
+
+			var errors = ValidateModel(model);
+
+			Assert.Contains(errors, e => e.MemberNames.Contains(nameof(MetaViewModel.TwitterSite)));
+		}
+
+		[Fact]
+		[Trait("Category", "UnitTest")]
+		public void ValidateModel_ValidTwitterValues_ReturnsNoValidationErrors()
+		{
+			var model = new MetaViewModel
+			{
+				TwitterCard = "summary_large_image",
+				TwitterSite = "@poppastring",
+				TwitterCreator = "mark_downie"
+			};
+
+			var errors = ValidateModel(model);
+
+			Assert.Empty(errors);
+		}
+	}
+}

--- a/source/DasBlog.Web/Controllers/AdminController.cs
+++ b/source/DasBlog.Web/Controllers/AdminController.cs
@@ -110,6 +110,11 @@ namespace DasBlog.Web.Controllers
 				? string.Empty
 				: meta.MastodonAccount.Trim();
 
+			meta.TwitterCard = NormalizeTwitterCard(meta.TwitterCard);
+			meta.TwitterSite = NormalizeTwitterHandle(meta.TwitterSite);
+			meta.TwitterCreator = NormalizeTwitterHandle(meta.TwitterCreator);
+			meta.TwitterImage = string.IsNullOrWhiteSpace(meta.TwitterImage) ? string.Empty : meta.TwitterImage.Trim();
+
 			site.MastodonServerUrl = null;
 			site.MastodonAccount = null;
 
@@ -263,6 +268,27 @@ namespace DasBlog.Web.Controllers
 
 			TempData["SuccessMessage"] = "Comment added successfully!";
 			return RedirectToAction("ManageComments");
+		}
+
+		private static string NormalizeTwitterCard(string twitterCard)
+		{
+			if (string.Equals(twitterCard, "summary_large_image", StringComparison.OrdinalIgnoreCase))
+			{
+				return "summary_large_image";
+			}
+
+			return "summary";
+		}
+
+		private static string NormalizeTwitterHandle(string twitterHandle)
+		{
+			if (string.IsNullOrWhiteSpace(twitterHandle))
+			{
+				return string.Empty;
+			}
+
+			twitterHandle = twitterHandle.Trim();
+			return twitterHandle.StartsWith("@", StringComparison.Ordinal) ? twitterHandle : $"@{twitterHandle}";
 		}
 
 		private void BreakSiteCache()

--- a/source/DasBlog.Web/Models/AdminViewModels/MetaViewModel.cs
+++ b/source/DasBlog.Web/Models/AdminViewModels/MetaViewModel.cs
@@ -15,24 +15,26 @@ namespace DasBlog.Web.Models.AdminViewModels
 		[StringLength(300, MinimumLength = 0, ErrorMessage = "{0} should be between 1 to 300 characters")]
 		public string MetaKeywords { get; set; }
 
-		[DisplayName("Twitter card type")]
-		[Description("Must be set to a value of 'summary'")]
-		[StringLength(300, MinimumLength = 0, ErrorMessage = "{0} should be between 1 to 300 characters")]
+		[DisplayName("X (Twitter) card type")]
+		[Description("Allowed values: summary, summary_large_image.")]
+		[RegularExpression("^(summary|summary_large_image)$", ErrorMessage = "X (Twitter) card type must be 'summary' or 'summary_large_image'.")]
 		public string TwitterCard { get; set; }
 
-		[DisplayName("Twitter site (@username)")]
-		[Description("The Twitter @username the card should be attributed to.")]
-		[StringLength(300, MinimumLength = 0, ErrorMessage = "{0} should be between 1 to 300 characters")]
+		[DisplayName("X (Twitter) site (@username)")]
+		[Description("The X (Twitter) @username this card should be attributed to.")]
+		[RegularExpression("^$|^@?[A-Za-z0-9_]{1,15}$", ErrorMessage = "X (Twitter) handle must be 1-15 letters, numbers, or underscores, optionally prefixed with @.")]
+		[StringLength(16, MinimumLength = 0, ErrorMessage = "{0} should be between 1 to 16 characters")]
 		public string TwitterSite { get; set; }
 
-		[DisplayName("Twitter creator (@username)")]
-		[Description("Used when creators (contributors) differ from the twitter name associated with the site")]
-		[StringLength(300, MinimumLength = 1, ErrorMessage = "{0} should be between 1 to 300 characters")]
+		[DisplayName("X (Twitter) creator (@username)")]
+		[Description("Used when creators (contributors) differ from the X (Twitter) account associated with the site.")]
+		[RegularExpression("^$|^@?[A-Za-z0-9_]{1,15}$", ErrorMessage = "X (Twitter) handle must be 1-15 letters, numbers, or underscores, optionally prefixed with @.")]
+		[StringLength(16, MinimumLength = 0, ErrorMessage = "{0} should be between 1 to 16 characters")]
 		public string TwitterCreator { get; set; }
 
-		[DisplayName("Twitter image")]
-		[Description("The Twitter share button will use this image if no image exists in the blog post")]
-		[StringLength(300, MinimumLength = 1, ErrorMessage = "{0} should be between 1 to 300 characters")]
+		[DisplayName("X (Twitter) image")]
+		[Description("Used for X (Twitter) card previews when the blog post does not provide a page image.")]
+		[StringLength(300, MinimumLength = 0, ErrorMessage = "{0} should be between 1 to 300 characters")]
 		public string TwitterImage { get; set; }
 
 		[DisplayName("Mastodon Server")]

--- a/source/DasBlog.Web/TagHelpers/Site/TwitterCardTagHelper.cs
+++ b/source/DasBlog.Web/TagHelpers/Site/TwitterCardTagHelper.cs
@@ -26,20 +26,61 @@ namespace DasBlog.Web.TagHelpers.Site
 			output.TagMode = TagMode.StartTagAndEndTag;
 
 			var data = ViewContext.ViewData;
-			var title = data["PageTitle"]?.ToString() ?? string.Empty;
-			var description = data["Description"]?.ToString() ?? string.Empty;
-			var image = data["PageImageUrl"]?.ToString() ?? string.Empty;
+			var title = data["PageTitle"]?.ToString()?.Trim();
+			var description = data["Description"]?.ToString()?.Trim();
+			var pageImage = data["PageImageUrl"]?.ToString()?.Trim();
 
 			var tags = dasBlogSettings.MetaTags;
+			var twitterCard = NormalizeTwitterCard(tags?.TwitterCard);
+			var twitterSite = NormalizeTwitterHandle(tags?.TwitterSite);
+			var twitterCreator = NormalizeTwitterHandle(tags?.TwitterCreator);
+			var twitterImage = string.IsNullOrWhiteSpace(pageImage) ? tags?.TwitterImage?.Trim() : pageImage;
+
 			var sb = new StringBuilder();
-			sb.Append("<meta name=\"twitter:card\" content=\"").Append(WebUtility.HtmlEncode(tags?.TwitterCard ?? string.Empty)).Append("\" />\n");
-			sb.Append("<meta name=\"twitter:site\" content=\"").Append(WebUtility.HtmlEncode(tags?.TwitterSite ?? string.Empty)).Append("\" />\n");
-			sb.Append("<meta name=\"twitter:creator\" content=\"").Append(WebUtility.HtmlEncode(tags?.TwitterCreator ?? string.Empty)).Append("\" />\n");
-			sb.Append("<meta name=\"twitter:title\" content=\"").Append(WebUtility.HtmlEncode(title)).Append("\" />\n");
-			sb.Append("<meta name=\"twitter:description\" content=\"").Append(WebUtility.HtmlEncode(description)).Append("\" />\n");
-			sb.Append("<meta name=\"twitter:image\" content=\"").Append(WebUtility.HtmlEncode(image)).Append("\" />");
+			AppendMetaTag(sb, "twitter:card", twitterCard);
+			AppendMetaTag(sb, "twitter:site", twitterSite);
+			AppendMetaTag(sb, "twitter:creator", twitterCreator);
+			AppendMetaTag(sb, "twitter:title", title);
+			AppendMetaTag(sb, "twitter:description", description);
+			AppendMetaTag(sb, "twitter:image", twitterImage);
 
 			output.Content.SetHtmlContent(sb.ToString());
+		}
+
+		private static string NormalizeTwitterCard(string twitterCard)
+		{
+			if (string.Equals(twitterCard, "summary_large_image", System.StringComparison.OrdinalIgnoreCase))
+			{
+				return "summary_large_image";
+			}
+
+			return "summary";
+		}
+
+		private static string NormalizeTwitterHandle(string twitterHandle)
+		{
+			if (string.IsNullOrWhiteSpace(twitterHandle))
+			{
+				return null;
+			}
+
+			twitterHandle = twitterHandle.Trim();
+			return twitterHandle.StartsWith("@", System.StringComparison.Ordinal) ? twitterHandle : $"@{twitterHandle}";
+		}
+
+		private static void AppendMetaTag(StringBuilder sb, string tagName, string value)
+		{
+			if (string.IsNullOrWhiteSpace(value))
+			{
+				return;
+			}
+
+			if (sb.Length > 0)
+			{
+				sb.Append('\n');
+			}
+
+			sb.Append("<meta name=\"").Append(tagName).Append("\" content=\"").Append(WebUtility.HtmlEncode(value)).Append("\" />");
 		}
 	}
 }

--- a/source/DasBlog.Web/Views/Shared/_Admin_Social.cshtml
+++ b/source/DasBlog.Web/Views/Shared/_Admin_Social.cshtml
@@ -41,7 +41,7 @@
     <div class="col-sm-4">
         <div class="form-floating">
             @Html.DropDownListFor(n => n.MetaConfig.TwitterCard,
-                new SelectList(new TwitterCardViewModel().Init(), "Id", "Name"),
+                new SelectList(new TwitterCardViewModel().Init(), "Id", "Name", Model.MetaConfig.TwitterCard),
                 new { @class = "form-select col-3", id = "twitterCard" })
             @Html.LabelFor(m => @Model.MetaConfig.TwitterCard, null, new { @class = "form-label", @for = "twitterCard" })
         </div>


### PR DESCRIPTION
Improve X (Twitter) card meta validation and output

Refactor MetaViewModel to use "X (Twitter)" naming and add stricter validation for card type and handle format. Normalize and trim Twitter card values and handles in AdminController. Update TwitterCardTagHelper to emit only valid, normalized meta tags. Enhance admin UI dropdown for card type selection. Add unit tests for MetaViewModel validation and TwitterCardTagHelper output.