### PR TITLE
Refactor delete modal rendering; auto-emit from delete link

### DIFF
--- a/source/DasBlog.Web/TagHelpers/DeletePostTagHelper.cs
+++ b/source/DasBlog.Web/TagHelpers/DeletePostTagHelper.cs
@@ -1,10 +1,16 @@
-﻿using DasBlog.Web.TagHelpers.Post;
+﻿﻿using DasBlog.Web.TagHelpers.Post;
+using Microsoft.AspNetCore.Antiforgery;
+using Microsoft.AspNetCore.Routing;
 using System;
 
 namespace DasBlog.Web.TagHelpers
 {
-	[Obsolete]
-	public class DeletePostTagHelper : PostDeleteLinkTagHelper
-	{
-	}
+[Obsolete]
+public class DeletePostTagHelper : PostDeleteLinkTagHelper
+{
+public DeletePostTagHelper(IAntiforgery antiforgery, LinkGenerator linkGenerator)
+: base(antiforgery, linkGenerator)
+{
+}
+}
 }

--- a/source/DasBlog.Web/TagHelpers/Layout/DeletePostModalRenderer.cs
+++ b/source/DasBlog.Web/TagHelpers/Layout/DeletePostModalRenderer.cs
@@ -1,0 +1,83 @@
+﻿﻿using System.Net;
+using System.Text;
+using DasBlog.Web.Models.BlogViewModels;
+using Microsoft.AspNetCore.Antiforgery;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace DasBlog.Web.TagHelpers.Layout
+{
+	internal static class DeletePostModalRenderer
+	{
+		private const string RenderedItemKeyPrefix = "DasBlog.DeleteModalRendered.";
+
+		public static bool HasBeenRendered(HttpContext httpContext, string entryId)
+		{
+			if (httpContext == null || string.IsNullOrEmpty(entryId))
+			{
+				return false;
+			}
+
+			return httpContext.Items.ContainsKey(RenderedItemKeyPrefix + entryId);
+		}
+
+		public static void MarkRendered(HttpContext httpContext, string entryId)
+		{
+			if (httpContext == null || string.IsNullOrEmpty(entryId))
+			{
+				return;
+			}
+
+			httpContext.Items[RenderedItemKeyPrefix + entryId] = true;
+		}
+
+		public static string BuildModalHtml(
+			PostViewModel post,
+			HttpContext httpContext,
+			IAntiforgery antiforgery,
+			LinkGenerator linkGenerator)
+		{
+			if (post == null || string.IsNullOrEmpty(post.EntryId))
+			{
+				return string.Empty;
+			}
+
+			var entryIdClean = post.EntryId.Replace("-", string.Empty);
+			var modalId = $"deleteModal_{entryIdClean}";
+			var formId = $"deleteForm_{entryIdClean}";
+
+			var tokens = antiforgery.GetAndStoreTokens(httpContext);
+			var action = linkGenerator.GetPathByAction(
+				httpContext,
+				action: "DeletePost",
+				controller: "BlogPost",
+				values: new { postid = post.EntryId }) ?? string.Empty;
+
+			var sb = new StringBuilder();
+			sb.Append("<div class=\"modal fade\" id=\"").Append(modalId).Append("\" tabindex=\"-1\" aria-labelledby=\"").Append(modalId).Append("Label\">\n");
+			sb.Append("    <div class=\"modal-dialog\">\n");
+			sb.Append("        <div class=\"modal-content\">\n");
+			sb.Append("            <div class=\"modal-header\">\n");
+			sb.Append("                <h5 class=\"modal-title\" id=\"").Append(modalId).Append("Label\">Confirm Delete</h5>\n");
+			sb.Append("                <button type=\"button\" class=\"btn-close\" data-bs-dismiss=\"modal\" aria-label=\"Close\"></button>\n");
+			sb.Append("            </div>\n");
+			sb.Append("            <div class=\"modal-body\">\n");
+			sb.Append("                <p>Are you sure you want to delete this post?</p>\n");
+			sb.Append("                <p><strong>").Append(WebUtility.HtmlEncode(post.Title ?? string.Empty)).Append("</strong></p>\n");
+			sb.Append("                <p class=\"text-danger\"><small>This action cannot be undone.</small></p>\n");
+			sb.Append("            </div>\n");
+			sb.Append("            <div class=\"modal-footer\">\n");
+			sb.Append("                <button type=\"button\" class=\"btn btn-secondary\" data-bs-dismiss=\"modal\">Cancel</button>\n");
+			sb.Append("                <form id=\"").Append(formId).Append("\" action=\"").Append(WebUtility.HtmlEncode(action)).Append("\" method=\"post\" class=\"dbc-delete-post-form\">\n");
+			sb.Append("                    <input name=\"").Append(tokens.FormFieldName).Append("\" type=\"hidden\" value=\"").Append(tokens.RequestToken).Append("\" />\n");
+			sb.Append("                    <button type=\"submit\" class=\"btn btn-danger\">Delete</button>\n");
+			sb.Append("                </form>\n");
+			sb.Append("            </div>\n");
+			sb.Append("        </div>\n");
+			sb.Append("    </div>\n");
+			sb.Append("</div>");
+
+			return sb.ToString();
+		}
+	}
+}

--- a/source/DasBlog.Web/TagHelpers/Layout/DeletePostModalTagHelper.cs
+++ b/source/DasBlog.Web/TagHelpers/Layout/DeletePostModalTagHelper.cs
@@ -1,78 +1,54 @@
-﻿using System.Net;
-using System.Text;
-using DasBlog.Web.Models.BlogViewModels;
+﻿using DasBlog.Web.Models.BlogViewModels;
 using Microsoft.AspNetCore.Antiforgery;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.AspNetCore.Routing;
+using System;
 
 namespace DasBlog.Web.TagHelpers.Layout
 {
+	[Obsolete("<post-delete-link> now renders its own confirmation modal. <delete-post-modal> is retained for backward compatibility with existing themes and is a no-op when the link has already emitted the modal.")]
 	[HtmlTargetElement("delete-post-modal", TagStructure = TagStructure.WithoutEndTag)]
 	public class DeletePostModalTagHelper : TagHelper
 	{
-		private readonly IAntiforgery antiforgery;
-		private readonly LinkGenerator linkGenerator;
+private readonly IAntiforgery antiforgery;
+private readonly LinkGenerator linkGenerator;
 
-		public DeletePostModalTagHelper(IAntiforgery antiforgery, LinkGenerator linkGenerator)
-		{
-			this.antiforgery = antiforgery;
-			this.linkGenerator = linkGenerator;
-		}
+public DeletePostModalTagHelper(IAntiforgery antiforgery, LinkGenerator linkGenerator)
+{
+this.antiforgery = antiforgery;
+this.linkGenerator = linkGenerator;
+}
 
-		public PostViewModel Post { get; set; }
+public PostViewModel Post { get; set; }
 
-		[ViewContext]
-		public ViewContext ViewContext { get; set; }
+[ViewContext]
+public ViewContext ViewContext { get; set; }
 
-		public override void Process(TagHelperContext context, TagHelperOutput output)
-		{
-			output.TagName = null;
-			output.TagMode = TagMode.StartTagAndEndTag;
+public override void Process(TagHelperContext context, TagHelperOutput output)
+{
+output.TagName = null;
+output.TagMode = TagMode.StartTagAndEndTag;
 
-			if (Post == null || string.IsNullOrEmpty(Post.EntryId))
-			{
-				output.SuppressOutput();
-				return;
-			}
+if (Post == null || string.IsNullOrEmpty(Post.EntryId))
+{
+output.SuppressOutput();
+return;
+}
 
-			var entryIdClean = Post.EntryId.Replace("-", string.Empty);
-			var modalId = $"deleteModal_{entryIdClean}";
-			var formId = $"deleteForm_{entryIdClean}";
+var httpContext = ViewContext?.HttpContext;
 
-			var tokens = antiforgery.GetAndStoreTokens(ViewContext.HttpContext);
-			var action = linkGenerator.GetPathByAction(
-				ViewContext.HttpContext,
-				action: "DeletePost",
-				controller: "BlogPost",
-				values: new { postid = Post.EntryId }) ?? string.Empty;
+if (DeletePostModalRenderer.HasBeenRendered(httpContext, Post.EntryId))
+{
+output.SuppressOutput();
+return;
+}
 
-			var sb = new StringBuilder();
-			sb.Append("<div class=\"modal fade\" id=\"").Append(modalId).Append("\" tabindex=\"-1\" aria-labelledby=\"").Append(modalId).Append("Label\">\n");
-			sb.Append("    <div class=\"modal-dialog\">\n");
-			sb.Append("        <div class=\"modal-content\">\n");
-			sb.Append("            <div class=\"modal-header\">\n");
-			sb.Append("                <h5 class=\"modal-title\" id=\"").Append(modalId).Append("Label\">Confirm Delete</h5>\n");
-			sb.Append("                <button type=\"button\" class=\"btn-close\" data-bs-dismiss=\"modal\" aria-label=\"Close\"></button>\n");
-			sb.Append("            </div>\n");
-			sb.Append("            <div class=\"modal-body\">\n");
-			sb.Append("                <p>Are you sure you want to delete this post?</p>\n");
-			sb.Append("                <p><strong>").Append(WebUtility.HtmlEncode(Post.Title ?? string.Empty)).Append("</strong></p>\n");
-			sb.Append("                <p class=\"text-danger\"><small>This action cannot be undone.</small></p>\n");
-			sb.Append("            </div>\n");
-			sb.Append("            <div class=\"modal-footer\">\n");
-			sb.Append("                <button type=\"button\" class=\"btn btn-secondary\" data-bs-dismiss=\"modal\">Cancel</button>\n");
-			sb.Append("                <form id=\"").Append(formId).Append("\" action=\"").Append(WebUtility.HtmlEncode(action)).Append("\" method=\"post\" class=\"dbc-delete-post-form\">\n");
-			sb.Append("                    <input name=\"").Append(tokens.FormFieldName).Append("\" type=\"hidden\" value=\"").Append(tokens.RequestToken).Append("\" />\n");
-			sb.Append("                    <button type=\"submit\" class=\"btn btn-danger\">Delete</button>\n");
-			sb.Append("                </form>\n");
-			sb.Append("            </div>\n");
-			sb.Append("        </div>\n");
-			sb.Append("    </div>\n");
-			sb.Append("</div>");
+var html = DeletePostModalRenderer.BuildModalHtml(Post, httpContext, antiforgery, linkGenerator);
+DeletePostModalRenderer.MarkRendered(httpContext, Post.EntryId);
 
-			output.Content.SetHtmlContent(sb.ToString());
-		}
-	}
+output.Content.SetHtmlContent(html);
+}
+}
 }

--- a/source/DasBlog.Web/TagHelpers/Post/PostDeleteLinkTagHelper.cs
+++ b/source/DasBlog.Web/TagHelpers/Post/PostDeleteLinkTagHelper.cs
@@ -1,39 +1,74 @@
-﻿using DasBlog.Web.Models.BlogViewModels;
+﻿﻿using DasBlog.Web.Models.BlogViewModels;
+using DasBlog.Web.TagHelpers.Layout;
+using Microsoft.AspNetCore.Antiforgery;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using Microsoft.AspNetCore.Razor.TagHelpers;
+using Microsoft.AspNetCore.Routing;
 using System.Threading.Tasks;
 
 namespace DasBlog.Web.TagHelpers.Post
 {
-	public class PostDeleteLinkTagHelper : TagHelper
-	{
-		public PostViewModel Post { get; set; }
+public class PostDeleteLinkTagHelper : TagHelper
+{
+private readonly IAntiforgery antiforgery;
+private readonly LinkGenerator linkGenerator;
 
-		public string BlogPostId { get; set; }
+public PostDeleteLinkTagHelper(IAntiforgery antiforgery, LinkGenerator linkGenerator)
+{
+this.antiforgery = antiforgery;
+this.linkGenerator = linkGenerator;
+}
 
-		public string BlogTitle { get; set; }
+public PostViewModel Post { get; set; }
 
-		public override void Process(TagHelperContext context, TagHelperOutput output)
-		{
-			if (Post != null)
-			{
-				BlogPostId = Post.EntryId;
-				BlogTitle = Post.Title;
-			}
+public string BlogPostId { get; set; }
 
-			var modalId = $"deleteModal_{BlogPostId?.Replace("-", "")}";
+public string BlogTitle { get; set; }
 
-			output.TagName = "a";
-			output.TagMode = TagMode.StartTagAndEndTag;
-			output.Attributes.SetAttribute("href", "#");
-			output.Attributes.SetAttribute("data-bs-toggle", "modal");
-			output.Attributes.SetAttribute("data-bs-target", $"#{modalId}");
-			output.Attributes.SetAttribute("role", "button");
-			output.Content.SetHtmlContent("Delete this post");
-		}
+[ViewContext]
+public ViewContext ViewContext { get; set; }
 
-		public override Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
-		{
-			return Task.Run(() => Process(context, output));
-		}
-	}
+public override void Process(TagHelperContext context, TagHelperOutput output)
+{
+if (Post != null)
+{
+BlogPostId = Post.EntryId;
+BlogTitle = Post.Title;
+}
+
+var modalId = $"deleteModal_{BlogPostId?.Replace("-", "")}";
+
+output.TagName = "a";
+output.TagMode = TagMode.StartTagAndEndTag;
+output.Attributes.SetAttribute("href", "#");
+output.Attributes.SetAttribute("data-bs-toggle", "modal");
+output.Attributes.SetAttribute("data-bs-target", $"#{modalId}");
+output.Attributes.SetAttribute("role", "button");
+output.Content.SetHtmlContent("Delete this post");
+
+// Emit the matching modal markup alongside the link so custom
+// themes don't have to remember to include <delete-post-modal />.
+// If the modal has already been emitted for this post in this
+// request (e.g. a theme calls <delete-post-modal /> explicitly),
+// this is a no-op so we don't produce a duplicate-id modal.
+var httpContext = ViewContext?.HttpContext;
+if (Post != null
+&& !string.IsNullOrEmpty(Post.EntryId)
+&& antiforgery != null
+&& linkGenerator != null
+&& httpContext != null
+&& !DeletePostModalRenderer.HasBeenRendered(httpContext, Post.EntryId))
+{
+var modalHtml = DeletePostModalRenderer.BuildModalHtml(Post, httpContext, antiforgery, linkGenerator);
+DeletePostModalRenderer.MarkRendered(httpContext, Post.EntryId);
+output.PostElement.AppendHtml(modalHtml);
+}
+}
+
+public override Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+{
+return Task.Run(() => Process(context, output));
+}
+}
 }

--- a/source/DasBlog.Web/Themes/darkly/_BlogItem.cshtml
+++ b/source/DasBlog.Web/Themes/darkly/_BlogItem.cshtml
@@ -30,7 +30,6 @@
             <post-delete-link post="@Model" />
             <span style="display:inline-block; width: 1em;"></span>
             <comment-management-link post="@Model" />
-            <delete-post-modal post="@Model" />
         </div>
         <div class="col-md-12 mb-2">
             <post-created-date post="@Model" />

--- a/source/DasBlog.Web/Themes/dasblog/_BlogItem.cshtml
+++ b/source/DasBlog.Web/Themes/dasblog/_BlogItem.cshtml
@@ -29,7 +29,6 @@
             <post-delete-link post="@Model" />
             <span style="display:inline-block; width: 1em;"></span>
             <comment-management-link post="@Model" />
-            <delete-post-modal post="@Model" />
         </div>
         <div class="col-md-12 mb-2">
             <post-created-date post="@Model" />

--- a/source/DasBlog.Web/Themes/flamingo/_BlogItem.cshtml
+++ b/source/DasBlog.Web/Themes/flamingo/_BlogItem.cshtml
@@ -40,7 +40,6 @@
             <post-delete-link post="@Model" />
             <span style="display:inline-block; width: 1em;"></span>
             <comment-management-link post="@Model" />
-            <delete-post-modal post="@Model" />
         </div>
     </div>
 

--- a/source/DasBlog.Web/Themes/flatly/_BlogItem.cshtml
+++ b/source/DasBlog.Web/Themes/flatly/_BlogItem.cshtml
@@ -30,7 +30,6 @@
             <post-delete-link post="@Model" />
             <span style="display:inline-block; width: 1em;"></span>
             <comment-management-link post="@Model" />
-            <delete-post-modal post="@Model" />
         </div>
         <div class="col-md-12 mb-2">
             <post-created-date post="@Model" />

--- a/source/DasBlog.Web/Themes/kindofblue/_BlogItem.cshtml
+++ b/source/DasBlog.Web/Themes/kindofblue/_BlogItem.cshtml
@@ -34,7 +34,6 @@
             <post-delete-link post="@Model" />
             <span style="display:inline-block; width: 1em;"></span>
             <comment-management-link post="@Model" />
-            <delete-post-modal post="@Model" />
         </div>
     </div>
 

--- a/source/DasBlog.Web/Themes/median/_BlogItem.cshtml
+++ b/source/DasBlog.Web/Themes/median/_BlogItem.cshtml
@@ -34,7 +34,6 @@
                 <post-delete-link post="@Model" />
                 <span style="display:inline-block; width: 1em;"></span>
                 <comment-management-link post="@Model" />
-                <delete-post-modal post="@Model" />
             </div>
             <div class="col-md-12 mb-2">
                 <post-comment-link post="@Model" />

--- a/source/DasBlog.Web/Views/Shared/_DeleteConfirmationModalPartial.cshtml
+++ b/source/DasBlog.Web/Views/Shared/_DeleteConfirmationModalPartial.cshtml
@@ -1,6 +1,9 @@
 @*
-    OBSOLETE: This partial is retained for backward compatibility with existing themes and forks.
-    For new code, prefer the TagHelper directly:  <delete-post-modal post="@Model" />
+    OBSOLETE: <post-delete-link post="@Model" /> now renders its own
+    confirmation modal, so neither this partial nor the <delete-post-modal>
+    tag helper is required in new themes. This partial is retained for
+    backward compatibility with existing themes and forks; it is a no-op
+    when the link has already emitted the modal for the same post.
     No removal is planned.
 *@
 @model DasBlog.Web.Models.BlogViewModels.PostViewModel


### PR DESCRIPTION
Refactor delete modal rendering; auto-emit from delete link

Centralize delete modal HTML in DeletePostModalRenderer and ensure each modal is rendered only once per post per request. Update PostDeleteLinkTagHelper to emit the modal automatically and accept dependencies via DI. Mark DeletePostTagHelper and DeletePostModalTagHelper as obsolete, updating their logic to use the new renderer. Remove explicit <delete-post-modal> usage from _BlogItem.cshtml. Update _DeleteConfirmationModalPartial.cshtml with obsolescence notes for backward compatibility. Prevent duplicate modal markup and IDs in themes.