### PR TITLE
Populate categories in settings view model

### DIFF
--- a/source/DasBlog.Web/Controllers/AdminController.cs
+++ b/source/DasBlog.Web/Controllers/AdminController.cs
@@ -62,6 +62,7 @@ namespace DasBlog.Web.Controllers
 			dbsvm.MetaConfig = mapper.Map<MetaViewModel>(dasBlogSettings.MetaTags);
 			dbsvm.SiteConfig = mapper.Map<SiteViewModel>(dasBlogSettings.SiteConfiguration);
 			dbsvm.Posts = posts;
+			dbsvm.Categories = blogManager.GetCategories().Select(p => p.Name).ToList();
 
 			if (string.IsNullOrWhiteSpace(dbsvm.MetaConfig.MastodonServerUrl))
 			{
@@ -85,6 +86,7 @@ namespace DasBlog.Web.Controllers
 			if (ModelState.ErrorCount > 0)
 			{
 				settings.Posts = posts;
+				settings.Categories = blogManager.GetCategories().Select(p => p.Name).ToList();
 				return View("Settings", settings);
 			}
 

--- a/source/DasBlog.Web/Models/AdminViewModels/DasBlogSettingsViewModel.cs
+++ b/source/DasBlog.Web/Models/AdminViewModels/DasBlogSettingsViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using DasBlog.Web.Models.BlogViewModels;
 
 namespace DasBlog.Web.Models.AdminViewModels
@@ -8,5 +9,6 @@ namespace DasBlog.Web.Models.AdminViewModels
 		public MetaViewModel MetaConfig { get; set; }
 		public SiteViewModel SiteConfig { get; set; }
 		public List<PostViewModel> Posts { get; set; }
+		public IReadOnlyList<string> Categories { get; set; } = Array.Empty<string>();
 	}
 }

--- a/source/DasBlog.Web/Views/Shared/_Admin_FrontPage.cshtml
+++ b/source/DasBlog.Web/Views/Shared/_Admin_FrontPage.cshtml
@@ -1,9 +1,7 @@
 ﻿@using AutoMapper
 @using DasBlog.Web.Models.AdminViewModels
-@using DasBlog.Managers.Interfaces
 
 @inject IDasBlogSettings dasBlogSettings
-@inject IBlogManager blogManager
 @model DasBlogSettingsViewModel
 
 <div class="row gy-2 gx-3 align-items-md-start mb-3">
@@ -41,7 +39,7 @@
     <div class="col-sm-4">
         <div class="form-floating">            
             @Html.DropDownListFor(n => n.SiteConfig.FrontPageCategory,
-                        new SelectList(new DasBlog.Web.Models.AdminViewModels.CategoryListViewModel().Init(blogManager.GetCategories().Select(p => p.Name).ToList()), "Category", "Name"),
+                        new SelectList(new DasBlog.Web.Models.AdminViewModels.CategoryListViewModel().Init(Model.Categories.ToList()), "Category", "Name"),
                         new { @class = "form-select", id = "frontPageCategory" })
 
             @Html.LabelFor(m => @Model.SiteConfig.FrontPageCategory, null, new { @class = "form-label", @for = "frontPageCategory" })
@@ -62,7 +60,7 @@
 <div class="d-flex flex-wrap">
     @Html.CheckBoxFor(m => @Model.SiteConfig.EnableStartPageCaching, new { @class = "form-check-input me-1" })
     @Html.LabelFor(m => @Model.SiteConfig.EnableStartPageCaching, null, new { @class = "form-check-label me-3" })
-    
+
     @Html.CheckBoxFor(m => @Model.SiteConfig.ShowItemSummaryInAggregatedViews, new { @class = "form-check-input me-1" })
     @Html.LabelFor(m => @Model.SiteConfig.ShowItemSummaryInAggregatedViews, null, new { @class = "form-check-label me-3" })
 </div>


### PR DESCRIPTION
Populate categories in settings view model

AdminController now sets Categories on DasBlogSettingsViewModel for both GET and POST actions. The front page category dropdown in _Admin_FrontPage.cshtml now uses Model.Categories instead of querying blogManager directly. Added Categories property to DasBlogSettingsViewModel. Minor whitespace cleanup in the view.