### PR TITLE
Sanitize activity log HTML to prevent XSS

### DIFF
--- a/source/DasBlog.Tests/UnitTests/Services/StaticPageContentSanitizerTest.cs
+++ b/source/DasBlog.Tests/UnitTests/Services/StaticPageContentSanitizerTest.cs
@@ -53,5 +53,22 @@ namespace DasBlog.Tests.UnitTests.Services
 			Assert.Contains("world", result);
 			Assert.Contains("link", result);
 		}
+
+		[Fact]
+		[Trait("Category", "UnitTest")]
+		public void Sanitize_ActivityLogHtml_RemovesMaliciousContent()
+		{
+			var sanitizer = new StaticPageContentSanitizer();
+			var html = "<span><strong>Audit:</strong> Login from <a href=\"https://example.com\">example</a></span><script>alert('xss')</script><img src=\"x\" onerror=\"alert('xss')\" />";
+
+			var result = sanitizer.Sanitize(html);
+
+			Assert.Contains("Audit:", result);
+			Assert.Contains("<span", result, System.StringComparison.OrdinalIgnoreCase);
+			Assert.Contains("<strong", result, System.StringComparison.OrdinalIgnoreCase);
+			Assert.Contains("<a", result, System.StringComparison.OrdinalIgnoreCase);
+			Assert.DoesNotContain("<script", result, System.StringComparison.OrdinalIgnoreCase);
+			Assert.DoesNotContain("onerror", result, System.StringComparison.OrdinalIgnoreCase);
+		}
 	}
 }

--- a/source/DasBlog.Web/Views/Activity/ActivityList.cshtml
+++ b/source/DasBlog.Web/Views/Activity/ActivityList.cshtml
@@ -1,7 +1,9 @@
 ﻿@using DasBlog.Services.ActivityLogs
 @using DasBlog.Core.Common;
+@using DasBlog.Web.Services.Interfaces
 
 @model System.Collections.Generic.List<EventDataDisplayItem>
+@inject IStaticPageContentSanitizer HtmlSanitizer
 
 @{
     ViewBag.Title = "Activity Report";
@@ -87,7 +89,7 @@
                                 @eddi.EventCode
                             </td>
                             <td class="dbc-activity-table-column">
-                                @Html.Raw(eddi.HtmlMessage)
+                                @Html.Raw(HtmlSanitizer.Sanitize(eddi.HtmlMessage))
                             </td>
                         </tr>
                     }


### PR DESCRIPTION
Sanitize activity log HTML to prevent XSS

Added sanitizer to ActivityList.cshtml for activity log messages using IStaticPageContentSanitizer. Added unit test to ensure malicious HTML is removed while preserving safe formatting.