### PR TITLE
Improve comment HTML filtering and allowlist support

### DIFF
--- a/source/DasBlog.Tests/UnitTests/Settings/DasBlogSettingsTests.cs
+++ b/source/DasBlog.Tests/UnitTests/Settings/DasBlogSettingsTests.cs
@@ -8,6 +8,7 @@ using DasBlog.Services.ConfigFile;
 using DasBlog.Services.ConfigFile.Interfaces;
 using DasBlog.Core.Security;
 using System.Collections.Generic;
+using DasBlog.Core.Common.Comments;
 using DasBlog.Services.FileManagement;
 using System.Net.Mail;
 using newtelligence.DasBlog.Runtime;
@@ -281,18 +282,70 @@ namespace DasBlog.Tests.UnitTests.Settings
             Assert.True(Math.Abs((lookahead - localNow.AddDays(dasBlogSettings.SiteConfiguration.ContentLookaheadDays)).TotalMinutes) < 1);
         }
 
-        [Fact]
-        public void FilterHtml_EncodesIfNoValidTags()
-        {
-            var dasBlogSettings = dasBlogSettingsMock.CreateSettings();
+		[Fact]
+		public void FilterHtml_EncodesIfNoValidTags()
+		{
+			var dasBlogSettings = dasBlogSettingsMock.CreateSettings();
 			dasBlogSettings.SiteConfiguration.ValidCommentTags = null; // Simulate no valid tags
-            var input = "<b>hello</b> & <script>alert('x')</script>";
-            var result = dasBlogSettings.FilterHtml(input);
-            Assert.Contains("&lt;b&gt;hello&lt;/b&gt;", result);
-        }
+			var input = "<b>hello</b> & <script>alert('x')</script>";
+			var result = dasBlogSettings.FilterHtml(input);
+			Assert.Contains("&lt;b&gt;hello&lt;/b&gt;", result);
+		}
 
-        [Fact]
-        public void IsAdmin_ReturnsTrueForAdminHash()
+		[Fact]
+		public void FilterHtml_RespectsConfiguredCommentAllowlist()
+		{
+			var dasBlogSettings = dasBlogSettingsMock.CreateSettings();
+			dasBlogSettings.SiteConfiguration.ValidCommentTags = new[]
+			{
+				new ValidCommentTags
+				{
+					Tag = new List<Tag>
+					{
+						new Tag { Name = "p", Allowed = true },
+						new Tag { Name = "strong", Allowed = true },
+						new Tag { Name = "a", Allowed = true, Attributes = "href,title" }
+					}
+				}
+			};
+
+			var input = "<p>Hello <strong>world</strong> <a href=\"https://example.com\" title=\"Example\">link</a><script>alert('x')</script><img src=\"x\" onerror=\"alert('x')\" /></p>";
+			var result = dasBlogSettings.FilterHtml(input);
+
+			Assert.Contains("<p", result, StringComparison.OrdinalIgnoreCase);
+			Assert.Contains("<strong", result, StringComparison.OrdinalIgnoreCase);
+			Assert.Contains("<a", result, StringComparison.OrdinalIgnoreCase);
+			Assert.Contains("https://example.com", result, StringComparison.OrdinalIgnoreCase);
+			Assert.DoesNotContain("<script", result, StringComparison.OrdinalIgnoreCase);
+			Assert.DoesNotContain("<img", result, StringComparison.OrdinalIgnoreCase);
+			Assert.DoesNotContain("onerror", result, StringComparison.OrdinalIgnoreCase);
+		}
+
+		[Fact]
+		public void FilterHtml_DisallowedWrapperTag_PreservesInnerText()
+		{
+			var dasBlogSettings = dasBlogSettingsMock.CreateSettings();
+			dasBlogSettings.SiteConfiguration.ValidCommentTags = new[]
+			{
+				new ValidCommentTags
+				{
+					Tag = new List<Tag>
+					{
+						new Tag { Name = "p", Allowed = true }
+					}
+				}
+			};
+
+			var input = "<h2>The title</h2><p>Body</p>";
+			var result = dasBlogSettings.FilterHtml(input);
+
+			Assert.DoesNotContain("<h2", result, StringComparison.OrdinalIgnoreCase);
+			Assert.Contains("The title", result, StringComparison.Ordinal);
+			Assert.Contains("<p>Body</p>", result, StringComparison.OrdinalIgnoreCase);
+		}
+
+		[Fact]
+		public void IsAdmin_ReturnsTrueForAdminHash()
         {
             var dasBlogSettings = dasBlogSettingsMock.CreateSettings();
             var admin = dasBlogSettings.SecurityConfiguration.Users[0];

--- a/source/DasBlog.Tests/UnitTests/UI/TagHelperTest.cs
+++ b/source/DasBlog.Tests/UnitTests/UI/TagHelperTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
+using DasBlog.Core.Common.Comments;
 using DasBlog.Web.Models.BlogViewModels;
 using DasBlog.Web.Settings;
 using DasBlog.Web.TagHelpers;
@@ -187,6 +188,61 @@ namespace DasBlog.Tests.UnitTests.UI
 			Assert.Same("div", output.TagName);
 			Assert.Equal("dbc-comment-content", output.Attributes[0].Value.ToString());
 			Assert.Equal("", output.Content.GetContent().Trim());
+		}
+
+		[Fact]
+		[Trait("Category", "UnitTest")]
+		public void CommentContentTagHelper_WhenCommentContainsHtml_DoesNotInjectLineBreakTags()
+		{
+			var dasBlogSettings = new DasBlogSettingsMock().CreateSettings();
+			dasBlogSettings.SiteConfiguration.ValidCommentTags = new[]
+			{
+				new ValidCommentTags
+				{
+					Tag = new List<Tag>
+					{
+						new Tag { Name = "p", Allowed = true }
+					}
+				}
+			};
+			var helper = new CommentContentTagHelper((DasBlog.Services.IContentProcessor)dasBlogSettings)
+			{
+				Comment = new CommentViewModel
+				{
+					Text = "<p>One</p>\n<p>Two</p>"
+				}
+			};
+
+			var context = new TagHelperContext(new TagHelperAttributeList(), new Dictionary<object, object>(), Guid.NewGuid().ToString("N"));
+			var output = new TagHelperOutput(string.Empty, new TagHelperAttributeList(), (_, _) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
+
+			helper.Process(context, output);
+
+			var rendered = output.Content.GetContent();
+			Assert.DoesNotContain("<br />", rendered, StringComparison.OrdinalIgnoreCase);
+			Assert.Contains("<p>One</p>", rendered, StringComparison.OrdinalIgnoreCase);
+			Assert.Contains("<p>Two</p>", rendered, StringComparison.OrdinalIgnoreCase);
+		}
+
+		[Fact]
+		[Trait("Category", "UnitTest")]
+		public void CommentContentTagHelper_WhenCommentIsPlainText_ReplacesLineBreaksWithBrTags()
+		{
+			var dasBlogSettings = new DasBlogSettingsMock().CreateSettings();
+			var helper = new CommentContentTagHelper((DasBlog.Services.IContentProcessor)dasBlogSettings)
+			{
+				Comment = new CommentViewModel
+				{
+					Text = "One\nTwo"
+				}
+			};
+
+			var context = new TagHelperContext(new TagHelperAttributeList(), new Dictionary<object, object>(), Guid.NewGuid().ToString("N"));
+			var output = new TagHelperOutput(string.Empty, new TagHelperAttributeList(), (_, _) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
+
+			helper.Process(context, output);
+
+			Assert.Contains("One<br />Two", output.Content.GetContent(), StringComparison.OrdinalIgnoreCase);
 		}
 
 		[Fact]

--- a/source/DasBlog.Web/Settings/DasBlogSettings.cs
+++ b/source/DasBlog.Web/Settings/DasBlogSettings.cs
@@ -1,23 +1,22 @@
 ﻿using DasBlog.Core.Common;
 using DasBlog.Core.Common.Comments;
 using DasBlog.Core.Security;
+using DasBlog.Services;
+using DasBlog.Services.ConfigFile;
+using DasBlog.Services.ConfigFile.Interfaces;
+using DasBlog.Services.FileManagement;
+using DasBlog.Services.Site;
+using Ganss.Xss;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Options;
+using newtelligence.DasBlog.Runtime;
 using NodaTime;
 using System;
+using System.Collections.Generic;
 using System.IO;
-using System.Net;
-using System.Text.RegularExpressions;
-using System.Text;
-using System.Xml.Serialization;
-using DasBlog.Services.ConfigFile.Interfaces;
-using DasBlog.Services.ConfigFile;
-using DasBlog.Services;
-using DasBlog.Services.Site;
 using System.Linq;
-using newtelligence.DasBlog.Runtime;
-using DasBlog.Services.FileManagement;
 using System.Net.Mail;
+using System.Xml.Serialization;
 
 namespace DasBlog.Web.Settings
 {
@@ -70,9 +69,6 @@ namespace DasBlog.Web.Settings
 
 		public ISiteSecurityConfig SecurityConfiguration { get; }
 		public IOEmbedProviders OEmbedProviders => embedProvidersMonitor.CurrentValue;
-
-		private static Regex htmlFilterRegex = new Regex("<(?<end>/)?(?<name>\\w+)((\\s+(?<attNameValue>(?<attName>\\w+)(\\s*=\\s*(?:\"(?<attVal>[^\"]*)\"|'(?<attVal>[^']*)'|(?<attVal>[^'\">\\s]+)))?))+\\s*|\\s*)(?<self>/)?>",
-			RegexOptions.CultureInvariant | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Compiled);
 
 		public string GetBaseUrl()
 		{
@@ -203,50 +199,69 @@ namespace DasBlog.Web.Settings
 				return string.Empty;
 			}
 
-			if (SiteConfiguration.ValidCommentTags == null || SiteConfiguration.ValidCommentTags[0].Tag.Count(s => s.Allowed == true) == 0)
+			var sanitizer = CreateCommentSanitizer();
+			if (sanitizer == null)
 			{
-				return WebUtility.HtmlEncode(input);
+				return System.Net.WebUtility.HtmlEncode(input);
 			}
 
-			// check for matches
-			var matches = htmlFilterRegex.Matches(input);
+			return sanitizer.Sanitize(input);
+		}
 
-			// no matches, normal encoding
-			if (matches.Count == 0)
+		private HtmlSanitizer CreateCommentSanitizer()
+		{
+			if (SiteConfiguration.ValidCommentTags == null || SiteConfiguration.ValidCommentTags.Length == 0)
 			{
-				return WebUtility.HtmlEncode(input);
+				return null;
 			}
 
-			var sb = new StringBuilder();
+			var configuredTags = SiteConfiguration.ValidCommentTags[0]?.Tag
+				?.Where(tag => tag?.Allowed == true && !string.IsNullOrWhiteSpace(tag.Name))
+				.ToList();
 
-
-			var collection = new MatchedTagCollection(SiteConfiguration.ValidCommentTags);
-			collection.Init(matches);
-
-			int inputIndex = 0;
-
-			foreach (MatchedTag tag in collection)
+			if (configuredTags == null || configuredTags.Count == 0)
 			{
-				// add the normal text between the current index and the index of the current tag
-				if (inputIndex < tag.Index)
+				return null;
+			}
+
+			var sanitizer = new HtmlSanitizer();
+			sanitizer.KeepChildNodes = true;
+			sanitizer.AllowedTags.Clear();
+			sanitizer.AllowedAttributes.Clear();
+			sanitizer.AllowedSchemes.Clear();
+			sanitizer.AllowedSchemes.Add("http");
+			sanitizer.AllowedSchemes.Add("https");
+			sanitizer.AllowedSchemes.Add("mailto");
+			sanitizer.UriAttributes.Add("cite");
+
+			foreach (var tag in configuredTags)
+			{
+				sanitizer.AllowedTags.Add(tag.Name.Trim().ToLowerInvariant());
+
+				foreach (var attribute in SplitAttributes(tag.Attributes))
 				{
-					sb.Append(WebUtility.HtmlEncode(input.Substring(inputIndex, tag.Index - inputIndex)));
+					sanitizer.AllowedAttributes.Add(attribute);
 				}
-
-				// add the filtered value
-				sb.Append(tag.FilteredValue);
-
-				// move the current index past the tag
-				inputIndex = tag.Index + tag.Length;
 			}
 
-			// add remainder
-			if (inputIndex < input.Length)
+			return sanitizer;
+		}
+
+		private static IEnumerable<string> SplitAttributes(string attributes)
+		{
+			if (string.IsNullOrWhiteSpace(attributes))
 			{
-				sb.Append(WebUtility.HtmlEncode(input.Substring(inputIndex)));
+				yield break;
 			}
 
-			return sb.ToString();
+			foreach (var attribute in attributes.Split(',', StringSplitOptions.RemoveEmptyEntries))
+			{
+				var trimmed = attribute.Trim().ToLowerInvariant();
+				if (!string.IsNullOrWhiteSpace(trimmed))
+				{
+					yield return trimmed;
+				}
+			}
 		}
 
 		public bool AreCommentsPermitted(DateTime blogpostdate)

--- a/source/DasBlog.Web/TagHelpers/Comments/CommentContentTagHelper.cs
+++ b/source/DasBlog.Web/TagHelpers/Comments/CommentContentTagHelper.cs
@@ -27,9 +27,22 @@ namespace DasBlog.Web.TagHelpers.Comments
 
 			output.Attributes.SetAttribute("class", Css);
 			Comment ??= new CommentViewModel();
-			Comment.Text = contentProcessor.FilterHtml(Comment.Text ?? string.Empty);
-			Comment.Text = Regex.Replace(Comment.Text, "\n", "<br />");
-			output.Content.SetHtmlContent(HttpUtility.HtmlDecode(Comment.Text));
+			var sanitizedComment = contentProcessor.FilterHtml(Comment.Text ?? string.Empty);
+			if (!ContainsHtmlTag(sanitizedComment))
+			{
+				sanitizedComment = Regex.Replace(sanitizedComment, "\n", "<br />");
+			}
+			output.Content.SetHtmlContent(HttpUtility.HtmlDecode(sanitizedComment));
+		}
+
+		private static bool ContainsHtmlTag(string content)
+		{
+			if (string.IsNullOrWhiteSpace(content))
+			{
+				return false;
+			}
+
+			return Regex.IsMatch(content, @"<\/?[a-zA-Z][^>]*>");
 		}
 
 		public override Task ProcessAsync(TagHelperContext context, TagHelperOutput output)


### PR DESCRIPTION
Improve comment HTML filtering and allowlist support

Replaced legacy regex HTML filter with Ganss.Xss HtmlSanitizer, honoring ValidCommentTags for allowed tags and attributes. Falls back to HTML-encoding if no tags are allowed. Updated CommentContentTagHelper to only insert <br /> for plain text comments. Added unit tests for allowlist enforcement, wrapper tag handling, and plain text encoding. Refactored for clarity and maintainability.