### PR TITLE
Bump version to 10.5.0 in all main projects

### DIFF
--- a/source/DasBlog.CLI/DasBlog.CLI.csproj
+++ b/source/DasBlog.CLI/DasBlog.CLI.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <AssemblyName>dasblog-core</AssemblyName>
-    <Version>10.2.0</Version>
+    <Version>10.5.0</Version>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>

--- a/source/DasBlog.Core/DasBlog.Core.csproj
+++ b/source/DasBlog.Core/DasBlog.Core.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>
-    <Version>10.2.0</Version>
+    <Version>10.5.0</Version>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>

--- a/source/DasBlog.Managers/DasBlog.Managers.csproj
+++ b/source/DasBlog.Managers/DasBlog.Managers.csproj
@@ -3,7 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <Configurations>Debug;Release</Configurations>
     <Platforms>AnyCPU</Platforms>
-    <Version>10.2.0</Version>
+    <Version>10.5.0</Version>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>

--- a/source/DasBlog.Services/DasBlog.Services.csproj
+++ b/source/DasBlog.Services/DasBlog.Services.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>10.2.0</Version>
+    <Version>10.5.0</Version>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>

--- a/source/DasBlog.Template.csproj
+++ b/source/DasBlog.Template.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>10.2.0</PackageVersion>
+    <PackageVersion>10.5.0</PackageVersion>
     <PackageId>DasBlog.Template</PackageId>
     <Title>DasBlog Core Blog Template</Title>
     <Authors>Mark Downie</Authors>

--- a/source/DasBlog.Web/DasBlog.Web.csproj
+++ b/source/DasBlog.Web/DasBlog.Web.csproj
@@ -14,7 +14,7 @@
     <Platforms>AnyCPU</Platforms>
     <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
     <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
-    <Version>10.2.0</Version>
+    <Version>10.5.0</Version>
     <PackageReleaseNotes>Platform and security: Upgraded to .NET 10, added Akismet spam protection with async checks/reporting and admin Mark as Spam, tightened CSP script/style sources, improved SEO metadata/sitemap/robots support, and added SEO plus spam unit tests. UI and UX: aligned Bootstrap to 5.3.3, improved blog layout/theme mapping, fixed site.css path resolution, improved modal accessibility, added autocomplete for login/comment forms, enabled lowercase URLs/query strings, and fixed sitemap/robots routing and pathBase handling. Security hardening: added HTML sanitization for static pages and activity log output, and tightened comment HTML allowlist filtering to reduce XSS exposure. Breaking/config changes: removed Google Analytics and CAPTCHA/reCAPTCHA support, removed FaceBookAdmins and FaceBookAppID meta fields, and migrated Mastodon settings to meta.config with resolver support. Additional fixes: improved X (Twitter) card metadata output, refactored delete modal rendering, and fixed category population in settings.</PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/source/newtelligence.DasBlog.Runtime/newtelligence.DasBlog.Runtime.csproj
+++ b/source/newtelligence.DasBlog.Runtime/newtelligence.DasBlog.Runtime.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>10.2.0</Version>
+    <Version>10.5.0</Version>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>


### PR DESCRIPTION
Bump version to 10.5.0 in all main projects

Updated Version/PackageVersion from 10.2.0 to 10.5.0 in DasBlog.Web, DasBlog.Core, DasBlog.Managers, DasBlog.Services, DasBlog.CLI, newtelligence.DasBlog.Runtime, and DasBlog.Template.csproj. No other changes made.