### PR TITLE
Add two-factor authentication (2FA) support

### DIFF
--- a/source/DasBlog.Core/Security/RecoveryCode.cs
+++ b/source/DasBlog.Core/Security/RecoveryCode.cs
@@ -1,0 +1,23 @@
+﻿#region Copyright (c) 2003, newtelligence AG. All rights reserved.
+/*
+// Copyright (c) 2003, newtelligence AG. (http://www.newtelligence.com)
+// Original BlogX Source Code: Copyright (c) 2003, Chris Anderson (http://simplegeek.com)
+// All rights reserved.
+*/
+#endregion
+
+using System;
+using System.Xml.Serialization;
+
+namespace DasBlog.Core.Security
+{
+	[Serializable]
+	public class RecoveryCode
+	{
+		[XmlAttribute("hash")]
+		public string Hash { get; set; }
+
+		[XmlAttribute("used")]
+		public bool Used { get; set; }
+	}
+}

--- a/source/DasBlog.Core/Security/TwoFactorSettings.cs
+++ b/source/DasBlog.Core/Security/TwoFactorSettings.cs
@@ -1,0 +1,40 @@
+﻿#region Copyright (c) 2003, newtelligence AG. All rights reserved.
+/*
+// Copyright (c) 2003, newtelligence AG. (http://www.newtelligence.com)
+// Original BlogX Source Code: Copyright (c) 2003, Chris Anderson (http://simplegeek.com)
+// All rights reserved.
+*/
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Serialization;
+
+namespace DasBlog.Core.Security
+{
+	[Serializable]
+	[XmlType("TwoFactor")]
+	public class TwoFactorSettings
+	{
+		[XmlAttribute("enabled")]
+		public bool Enabled { get; set; }
+
+		[XmlElement("AuthenticatorSecret")]
+		public string AuthenticatorSecret { get; set; }
+
+		[XmlArray("RecoveryCodes")]
+		[XmlArrayItem("Code")]
+		public List<RecoveryCode> RecoveryCodes { get; set; } = new List<RecoveryCode>();
+
+		public bool ShouldSerializeAuthenticatorSecret()
+		{
+			return !string.IsNullOrEmpty(AuthenticatorSecret);
+		}
+
+		public bool ShouldSerializeRecoveryCodes()
+		{
+			return RecoveryCodes?.Any() == true;
+		}
+	}
+}

--- a/source/DasBlog.Core/Security/User.cs
+++ b/source/DasBlog.Core/Security/User.cs
@@ -38,6 +38,7 @@
 #endregion
 
 using System;
+using System.Linq;
 using System.Xml.Serialization;
 
 namespace DasBlog.Core.Security
@@ -81,9 +82,17 @@ namespace DasBlog.Core.Security
 		[XmlElement("Password")]
 		public string Password { get; set; }
 
+		[XmlElement("TwoFactor")]
+		public TwoFactorSettings TwoFactor { get; set; } = new TwoFactorSettings();
+
 		public string XmlPassword { get; set; }
 
 		public UserToken ToToken() => new UserToken(Name, Role.ToString());
+
+		public bool ShouldSerializeTwoFactor()
+		{
+			return TwoFactor != null && (TwoFactor.Enabled || !string.IsNullOrEmpty(TwoFactor.AuthenticatorSecret) || TwoFactor.RecoveryCodes?.Any() == true);
+		}
 
 		public bool Equals(User other)
 		{

--- a/source/DasBlog.Tests/UnitTests/Config/SiteSecurityTwoFactorConfigTests.cs
+++ b/source/DasBlog.Tests/UnitTests/Config/SiteSecurityTwoFactorConfigTests.cs
@@ -1,0 +1,108 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Xml.Serialization;
+using DasBlog.Core.Security;
+using DasBlog.Services.ConfigFile;
+using Xunit;
+
+namespace DasBlog.Tests.UnitTests.Config
+{
+	public class SiteSecurityTwoFactorConfigTests
+	{
+		[Fact]
+		public void Serialize_UserWithoutTwoFactor_OmitsTwoFactorElement()
+		{
+			var config = new SiteSecurityConfigData
+			{
+				Users = new List<User>
+				{
+					new User
+					{
+						Role = Role.Admin,
+						EmailAddress = "admin@example.com",
+						DisplayName = "Admin",
+						Active = true,
+						Password = "HASH"
+					}
+				}
+			};
+
+			var xml = Serialize(config);
+
+			Assert.DoesNotContain("<TwoFactor", xml);
+		}
+
+		[Fact]
+		public void Deserialize_OldConfigWithoutTwoFactor_LoadsWithDisabledTwoFactor()
+		{
+			const string xml = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<SiteSecurityConfig>
+  <Users>
+	<User>
+	  <Role>Admin</Role>
+	  <EmailAddress>admin@example.com</EmailAddress>
+	  <DisplayName>Admin</DisplayName>
+	  <Active>true</Active>
+	  <Password>HASH</Password>
+	</User>
+  </Users>
+</SiteSecurityConfig>";
+
+			var config = Deserialize(xml);
+
+			Assert.Single(config.Users);
+			Assert.False(config.Users[0].TwoFactor.Enabled);
+			Assert.Null(config.Users[0].TwoFactor.AuthenticatorSecret);
+			Assert.Empty(config.Users[0].TwoFactor.RecoveryCodes);
+		}
+
+		[Fact]
+		public void Deserialize_TwoFactorConfig_LoadsSecretAndRecoveryCodes()
+		{
+			const string xml = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<SiteSecurityConfig>
+  <Users>
+	<User>
+	  <Role>Admin</Role>
+	  <EmailAddress>admin@example.com</EmailAddress>
+	  <DisplayName>Admin</DisplayName>
+	  <Active>true</Active>
+	  <Password>HASH</Password>
+	  <TwoFactor enabled=""true"">
+		<AuthenticatorSecret>SECRET</AuthenticatorSecret>
+		<RecoveryCodes>
+		  <Code hash=""SHA256:ONE"" used=""false"" />
+		  <Code hash=""SHA256:TWO"" used=""true"" />
+		</RecoveryCodes>
+	  </TwoFactor>
+	</User>
+  </Users>
+</SiteSecurityConfig>";
+
+			var config = Deserialize(xml);
+			var twoFactor = config.Users[0].TwoFactor;
+
+			Assert.True(twoFactor.Enabled);
+			Assert.Equal("SECRET", twoFactor.AuthenticatorSecret);
+			Assert.Equal(2, twoFactor.RecoveryCodes.Count);
+			Assert.Equal("SHA256:ONE", twoFactor.RecoveryCodes[0].Hash);
+			Assert.False(twoFactor.RecoveryCodes[0].Used);
+			Assert.True(twoFactor.RecoveryCodes[1].Used);
+		}
+
+		private static string Serialize(SiteSecurityConfigData config)
+		{
+			var serializer = new XmlSerializer(typeof(SiteSecurityConfigData));
+			using var writer = new StringWriter();
+			serializer.Serialize(writer, config);
+			return writer.ToString();
+		}
+
+		private static SiteSecurityConfigData Deserialize(string xml)
+		{
+			var serializer = new XmlSerializer(typeof(SiteSecurityConfigData));
+			using var reader = new StringReader(xml);
+			return (SiteSecurityConfigData)serializer.Deserialize(reader);
+		}
+	}
+}

--- a/source/DasBlog.Tests/UnitTests/Web/Controllers/AccountControllerTwoFactorTests.cs
+++ b/source/DasBlog.Tests/UnitTests/Web/Controllers/AccountControllerTwoFactorTests.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using DasBlog.Managers.Interfaces;
+using DasBlog.Services;
+using DasBlog.Services.ConfigFile.Interfaces;
+using DasBlog.Services.Users;
+using DasBlog.Web.Controllers;
+using DasBlog.Web.Identity;
+using DasBlog.Web.Models.AccountViewModels;
+using DasBlog.Web.Services;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace DasBlog.Tests.UnitTests.Web.Controllers
+{
+	public class AccountControllerTwoFactorTests
+	{
+		[Fact]
+		public async Task Login_Post_RedirectsToTwoFactorChallengeWhenPasswordRequiresTwoFactor()
+		{
+			var signInManager = BuildSignInManager();
+			signInManager
+				.Setup(s => s.PasswordSignInAsync("admin@example.com", "password", true, false))
+				.ReturnsAsync(Microsoft.AspNetCore.Identity.SignInResult.TwoFactorRequired);
+
+			var controller = new AccountController(
+				userManager: null,
+				signInManager: signInManager.Object,
+				mapper: null,
+				logger: Mock.Of<ILogger<AccountController>>(),
+				settings: Mock.Of<IDasBlogSettings>(),
+				firstRunService: Mock.Of<IFirstRunService>(),
+				userService: Mock.Of<IUserService>(),
+				siteSecurityManager: Mock.Of<ISiteSecurityManager>(),
+				siteSecurityConfig: Mock.Of<ISiteSecurityConfig>());
+
+			var result = await controller.Login(new LoginViewModel
+			{
+				Email = "admin@example.com",
+				Password = "password",
+				RememberMe = true
+			}, "/admin/settings");
+
+			var redirect = Assert.IsType<RedirectToActionResult>(result);
+			Assert.Equal("LoginWith2fa", redirect.ActionName);
+			Assert.Equal("/admin/settings", redirect.RouteValues["returnUrl"]);
+			Assert.Equal(true, redirect.RouteValues["rememberMe"]);
+		}
+
+		private static Mock<SignInManager<DasBlogUser>> BuildSignInManager()
+		{
+			var userManager = new Mock<UserManager<DasBlogUser>>(
+				Mock.Of<IUserStore<DasBlogUser>>(),
+				Mock.Of<IOptions<IdentityOptions>>(),
+				Mock.Of<IPasswordHasher<DasBlogUser>>(),
+				new List<IUserValidator<DasBlogUser>>(),
+				new List<IPasswordValidator<DasBlogUser>>(),
+				Mock.Of<ILookupNormalizer>(),
+				new IdentityErrorDescriber(),
+				Mock.Of<IServiceProvider>(),
+				Mock.Of<ILogger<UserManager<DasBlogUser>>>());
+
+			return new Mock<SignInManager<DasBlogUser>>(
+				userManager.Object,
+				Mock.Of<IHttpContextAccessor>(),
+				Mock.Of<IUserClaimsPrincipalFactory<DasBlogUser>>(),
+				Options.Create(new IdentityOptions()),
+				Mock.Of<ILogger<SignInManager<DasBlogUser>>>(),
+				Mock.Of<IAuthenticationSchemeProvider>(),
+				Mock.Of<IUserConfirmation<DasBlogUser>>());
+		}
+	}
+}

--- a/source/DasBlog.Tests/UnitTests/Web/Identity/DasBlogUserStoreTwoFactorTests.cs
+++ b/source/DasBlog.Tests/UnitTests/Web/Identity/DasBlogUserStoreTwoFactorTests.cs
@@ -1,0 +1,86 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DasBlog.Core.Security;
+using DasBlog.Services;
+using DasBlog.Services.ConfigFile.Interfaces;
+using DasBlog.Services.Users;
+using DasBlog.Web.Identity;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace DasBlog.Tests.UnitTests.Web.Identity
+{
+	public class DasBlogUserStoreTwoFactorTests
+	{
+		[Fact]
+		public async Task ReplaceCodesAsync_StoresHashedCodesAndRedeemIsSingleUse()
+		{
+			var store = BuildStore(out _, out _);
+			var user = new DasBlogUser { Email = "admin@example.com" };
+
+			await store.ReplaceCodesAsync(user, new[] { "alpha-code", "bravo-code" }, CancellationToken.None);
+
+			Assert.Equal(2, await store.CountCodesAsync(user, CancellationToken.None));
+			Assert.DoesNotContain(user.RecoveryCodes, code => code.Hash == "alpha-code" || code.Hash == "bravo-code");
+			Assert.All(user.RecoveryCodes, code => Assert.StartsWith("SHA256:", code.Hash));
+
+			Assert.True(await store.RedeemCodeAsync(user, "alpha-code", CancellationToken.None));
+			Assert.False(await store.RedeemCodeAsync(user, "alpha-code", CancellationToken.None));
+			Assert.Equal(1, await store.CountCodesAsync(user, CancellationToken.None));
+		}
+
+		[Fact]
+		public async Task SetTwoFactorEnabledAsync_DisableClearsSecretAndRecoveryCodes()
+		{
+			var store = BuildStore(out var users, out _);
+			var user = new DasBlogUser
+			{
+				Email = "admin@example.com",
+				TwoFactorEnabled = true,
+				AuthenticatorSecret = "SECRET",
+				RecoveryCodes = new List<RecoveryCode> { new RecoveryCode { Hash = "SHA256:HASH", Used = false } }
+			};
+
+			await store.SetTwoFactorEnabledAsync(user, false, CancellationToken.None);
+
+			Assert.False(users[0].TwoFactor.Enabled);
+			Assert.Null(users[0].TwoFactor.AuthenticatorSecret);
+			Assert.Empty(users[0].TwoFactor.RecoveryCodes);
+		}
+
+		private static DasBlogUserStore BuildStore(out List<User> users, out Mock<ISiteSecurityConfig> securityConfig)
+		{
+			users = new List<User>
+			{
+				new User
+				{
+					EmailAddress = "admin@example.com",
+					DisplayName = "Admin",
+					Password = "HASH",
+					TwoFactor = new TwoFactorSettings()
+				}
+			};
+
+			var currentUsers = users;
+			var userService = new Mock<IUserService>();
+			userService.Setup(s => s.GetAllUsers()).Returns(() => currentUsers);
+			userService.Setup(s => s.SaveUsers(It.IsAny<List<User>>()))
+				.Callback<List<User>>(saved => currentUsers = saved);
+
+			securityConfig = new Mock<ISiteSecurityConfig>();
+			securityConfig.SetupProperty(c => c.Users, currentUsers);
+
+			var settings = new Mock<IDasBlogSettings>();
+			settings.Setup(s => s.SecurityConfiguration).Returns(securityConfig.Object);
+
+			return new DasBlogUserStore(
+				settings.Object,
+				mapper: null,
+				userService.Object,
+				Mock.Of<ILogger<DasBlogUserStore>>());
+		}
+	}
+}

--- a/source/DasBlog.Web/Controllers/AccountController.cs
+++ b/source/DasBlog.Web/Controllers/AccountController.cs
@@ -15,6 +15,8 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.Extensions.Logging;
+using QRCoder;
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -26,6 +28,7 @@ namespace DasBlog.Web.Controllers
 		private const string KEY_RETURNURL = "ReturnUrl";
 		private readonly ILogger<AccountController> logger;
 		private readonly IMapper mapper;
+		private readonly IDasBlogSettings settings;
 		private readonly SignInManager<DasBlogUser> signInManager;
 		private readonly UserManager<DasBlogUser> userManager;
 		private readonly IFirstRunService firstRunService;
@@ -42,6 +45,7 @@ namespace DasBlog.Web.Controllers
 		{
 			this.signInManager = signInManager;
 			this.userManager = userManager;
+			this.settings = settings;
 			this.logger = logger;
 			this.mapper = mapper;
 			this.firstRunService = firstRunService;
@@ -84,6 +88,12 @@ namespace DasBlog.Web.Controllers
 
 					return LocalRedirect(returnUrl ?? Url.Action("Index", "Home"));
 				}
+
+				if (result.RequiresTwoFactor)
+				{
+					return RedirectToAction(nameof(LoginWith2fa), new { returnUrl, rememberMe = model.RememberMe });
+				}
+
 				logger.LogInformation(new EventDataItem(EventCodes.SecurityFailure, null, 
 												"{email} failed to log in", model.Email));
 
@@ -91,6 +101,227 @@ namespace DasBlog.Web.Controllers
 			}
 
 			return View(model);
+		}
+
+		[HttpGet("account/login-with-2fa")]
+		[AllowAnonymous]
+		public async Task<IActionResult> LoginWith2fa(bool rememberMe, string returnUrl = null)
+		{
+			SetNoStoreHeaders();
+
+			var user = await signInManager.GetTwoFactorAuthenticationUserAsync();
+			if (user == null)
+			{
+				return NotFound();
+			}
+
+			DefaultPage("Two-factor authentication");
+			return View(new LoginWith2faViewModel { RememberMe = rememberMe, ReturnUrl = returnUrl });
+		}
+
+		[HttpPost("account/login-with-2fa")]
+		[AllowAnonymous]
+		[ValidateAntiForgeryToken]
+		[EnableRateLimiting("login")]
+		public async Task<IActionResult> LoginWith2fa(LoginWith2faViewModel model)
+		{
+			SetNoStoreHeaders();
+
+			var user = await signInManager.GetTwoFactorAuthenticationUserAsync();
+			if (user == null)
+			{
+				return NotFound();
+			}
+
+			if (!ModelState.IsValid)
+			{
+				DefaultPage("Two-factor authentication");
+				return View(model);
+			}
+
+			var code = StripAuthenticatorCode(model.TwoFactorCode);
+			var result = await signInManager.TwoFactorAuthenticatorSignInAsync(code, model.RememberMe, model.RememberMachine);
+
+			if (result.Succeeded)
+			{
+				logger.LogInformation(new EventDataItem(EventCodes.SecuritySuccess, null,
+					"{email} completed two-factor authentication", user.Email));
+
+				return LocalRedirect(model.ReturnUrl ?? Url.Action("Index", "Home"));
+			}
+
+			logger.LogInformation(new EventDataItem(EventCodes.SecurityFailure, null,
+				"{email} failed two-factor authentication", user.Email));
+
+			ModelState.AddModelError(string.Empty, "The authenticator code is invalid.");
+			DefaultPage("Two-factor authentication");
+			return View(model);
+		}
+
+		[HttpGet("account/login-with-recovery-code")]
+		[AllowAnonymous]
+		public async Task<IActionResult> LoginWithRecoveryCode(string returnUrl = null)
+		{
+			SetNoStoreHeaders();
+
+			var user = await signInManager.GetTwoFactorAuthenticationUserAsync();
+			if (user == null)
+			{
+				return NotFound();
+			}
+
+			DefaultPage("Recovery code");
+			return View(new LoginWithRecoveryCodeViewModel { ReturnUrl = returnUrl });
+		}
+
+		[HttpPost("account/login-with-recovery-code")]
+		[AllowAnonymous]
+		[ValidateAntiForgeryToken]
+		[EnableRateLimiting("login")]
+		public async Task<IActionResult> LoginWithRecoveryCode(LoginWithRecoveryCodeViewModel model)
+		{
+			SetNoStoreHeaders();
+
+			var user = await signInManager.GetTwoFactorAuthenticationUserAsync();
+			if (user == null)
+			{
+				return NotFound();
+			}
+
+			if (!ModelState.IsValid)
+			{
+				DefaultPage("Recovery code");
+				return View(model);
+			}
+
+			var result = await signInManager.TwoFactorRecoveryCodeSignInAsync(model.RecoveryCode.Trim());
+			if (result.Succeeded)
+			{
+				logger.LogInformation(new EventDataItem(EventCodes.SecuritySuccess, null,
+					"{email} logged in with a recovery code", user.Email));
+
+				return LocalRedirect(model.ReturnUrl ?? Url.Action("Index", "Home"));
+			}
+
+			logger.LogInformation(new EventDataItem(EventCodes.SecurityFailure, null,
+				"{email} failed recovery code login", user.Email));
+
+			ModelState.AddModelError(string.Empty, "The recovery code is invalid or has already been used.");
+			DefaultPage("Recovery code");
+			return View(model);
+		}
+
+		[HttpGet("account/security/enable-authenticator")]
+		[RequireHttps]
+		public async Task<IActionResult> EnableAuthenticator()
+		{
+			SetNoStoreHeaders();
+
+			var user = await userManager.GetUserAsync(User);
+			if (user == null)
+			{
+				return NotFound();
+			}
+
+			DefaultPage("Enable authenticator");
+			return View(await BuildEnableAuthenticatorViewModel(user));
+		}
+
+		[HttpPost("account/security/enable-authenticator")]
+		[RequireHttps]
+		[ValidateAntiForgeryToken]
+		public async Task<IActionResult> EnableAuthenticator(EnableAuthenticatorViewModel model)
+		{
+			SetNoStoreHeaders();
+
+			var user = await userManager.GetUserAsync(User);
+			if (user == null)
+			{
+				return NotFound();
+			}
+
+			if (!ModelState.IsValid)
+			{
+				DefaultPage("Enable authenticator");
+				return View(await BuildEnableAuthenticatorViewModel(user));
+			}
+
+			var code = StripAuthenticatorCode(model.Code);
+			var isValid = await userManager.VerifyTwoFactorTokenAsync(user, TokenOptions.DefaultAuthenticatorProvider, code);
+			if (!isValid)
+			{
+				ModelState.AddModelError(nameof(model.Code), "The verification code is invalid.");
+				DefaultPage("Enable authenticator");
+				return View(await BuildEnableAuthenticatorViewModel(user));
+			}
+
+			await userManager.SetTwoFactorEnabledAsync(user, true);
+			var recoveryCodes = (await userManager.GenerateNewTwoFactorRecoveryCodesAsync(user, 10)).ToList();
+			await signInManager.RefreshSignInAsync(user);
+
+			logger.LogInformation(new EventDataItem(EventCodes.SecuritySuccess, null,
+				"{email} enabled two-factor authentication", user.Email));
+
+			DefaultPage("Recovery codes");
+			return View("ShowRecoveryCodes", new RecoveryCodesViewModel { RecoveryCodes = recoveryCodes });
+		}
+
+		[HttpGet("account/security/disable-2fa")]
+		public IActionResult Disable2fa()
+		{
+			DefaultPage("Disable two-factor authentication");
+			return View();
+		}
+
+		[HttpPost("account/security/disable-2fa")]
+		[ValidateAntiForgeryToken]
+		public async Task<IActionResult> Disable2faConfirmed()
+		{
+			var user = await userManager.GetUserAsync(User);
+			if (user == null)
+			{
+				return NotFound();
+			}
+
+			await userManager.SetTwoFactorEnabledAsync(user, false);
+			await signInManager.RefreshSignInAsync(user);
+
+			logger.LogInformation(new EventDataItem(EventCodes.SecuritySuccess, null,
+				"{email} disabled two-factor authentication", user.Email));
+
+			TempData["SuccessMessage"] = "Two-factor authentication has been disabled.";
+			return RedirectToAction(nameof(EnableAuthenticator));
+		}
+
+		[HttpGet("account/security/reset-recovery-codes")]
+		public IActionResult ResetRecoveryCodes()
+		{
+			DefaultPage("Reset recovery codes");
+			return View();
+		}
+
+		[HttpPost("account/security/reset-recovery-codes")]
+		[ValidateAntiForgeryToken]
+		public async Task<IActionResult> ResetRecoveryCodesConfirmed()
+		{
+			var user = await userManager.GetUserAsync(User);
+			if (user == null)
+			{
+				return NotFound();
+			}
+
+			if (!await userManager.GetTwoFactorEnabledAsync(user))
+			{
+				return RedirectToAction(nameof(EnableAuthenticator));
+			}
+
+			var recoveryCodes = (await userManager.GenerateNewTwoFactorRecoveryCodesAsync(user, 10)).ToList();
+
+			logger.LogInformation(new EventDataItem(EventCodes.SecuritySuccess, null,
+				"{email} reset two-factor recovery codes", user.Email));
+
+			DefaultPage("Recovery codes");
+			return View("ShowRecoveryCodes", new RecoveryCodesViewModel { RecoveryCodes = recoveryCodes });
 		}
 
 		[HttpGet]
@@ -185,6 +416,68 @@ namespace DasBlog.Web.Controllers
 				"First-run setup completed for {email}", admin.EmailAddress));
 
 			return RedirectToAction(nameof(Login));
+		}
+
+		private async Task<EnableAuthenticatorViewModel> BuildEnableAuthenticatorViewModel(DasBlogUser user)
+		{
+			var key = await userManager.GetAuthenticatorKeyAsync(user);
+			if (string.IsNullOrEmpty(key))
+			{
+				await userManager.ResetAuthenticatorKeyAsync(user);
+				key = await userManager.GetAuthenticatorKeyAsync(user);
+			}
+
+			var issuer = settings.SiteConfiguration?.Title ?? "DasBlog";
+			var authenticatorUri = GenerateQrCodeUri(user.Email, key, issuer);
+
+			return new EnableAuthenticatorViewModel
+			{
+				SharedKey = FormatKey(key),
+				AuthenticatorUri = authenticatorUri,
+				QrCodeSvg = GenerateQrCodeSvg(authenticatorUri),
+				IsTwoFactorEnabled = await userManager.GetTwoFactorEnabledAsync(user)
+			};
+		}
+
+		private static string GenerateQrCodeUri(string email, string unformattedKey, string issuer)
+		{
+			return string.Format(
+				"otpauth://totp/{0}:{1}?secret={2}&issuer={0}&digits=6",
+				Uri.EscapeDataString(issuer),
+				Uri.EscapeDataString(email),
+				Uri.EscapeDataString(unformattedKey));
+		}
+
+		private static string GenerateQrCodeSvg(string authenticatorUri)
+		{
+			using var generator = new QRCodeGenerator();
+			using var data = generator.CreateQrCode(authenticatorUri, QRCodeGenerator.ECCLevel.Q);
+			var qrCode = new SvgQRCode(data);
+			return qrCode.GetGraphic(4);
+		}
+
+		private static string FormatKey(string unformattedKey)
+		{
+			if (string.IsNullOrEmpty(unformattedKey))
+			{
+				return string.Empty;
+			}
+
+			var result = string.Join(" ", Enumerable.Range(0, (unformattedKey.Length + 3) / 4)
+				.Select(i => unformattedKey.Substring(i * 4, Math.Min(4, unformattedKey.Length - i * 4))));
+			return result.ToLowerInvariant();
+		}
+
+		private static string StripAuthenticatorCode(string code)
+		{
+			return code?.Replace(" ", string.Empty).Replace("-", string.Empty);
+		}
+
+		private void SetNoStoreHeaders()
+		{
+			Response.Headers["Cache-Control"] = "no-store, no-cache, max-age=0";
+			Response.Headers["Pragma"] = "no-cache";
+			Response.Headers["Expires"] = "0";
 		}
 	}
 }

--- a/source/DasBlog.Web/DasBlog.Web.csproj
+++ b/source/DasBlog.Web/DasBlog.Web.csproj
@@ -34,6 +34,7 @@
     <PackageReference Include="NWebsec.AspNetCore.Middleware" />
     <PackageReference Include="HtmlSanitizer" />
     <PackageReference Include="Quartz.AspNetCore" />
+    <PackageReference Include="QRCoder" />
     <PackageReference Include="NuGet.Protocol" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>

--- a/source/DasBlog.Web/DasBlogServiceCollectionExtensions.cs
+++ b/source/DasBlog.Web/DasBlogServiceCollectionExtensions.cs
@@ -175,11 +175,20 @@ namespace DasBlog.Web
 			services.AddSingleton<IPasswordHasher<object>, PasswordHasher<object>>();
 			services.AddScoped<IPasswordHasher<DasBlogUser>, DasBlogPasswordHasher>();
 
-			services.Configure<IdentityOptions>(configuration.GetSection("IdentityOptions"));
+			services.Configure<IdentityOptions>(options =>
+			{
+				configuration.GetSection("IdentityOptions").Bind(options);
+				options.Tokens.AuthenticatorTokenProvider = TokenOptions.DefaultAuthenticatorProvider;
+			});
 
 			services.ConfigureApplicationCookie(options =>
 			{
 				options.ExpireTimeSpan = TimeSpan.FromSeconds(10000);
+			});
+
+			services.Configure<CookieAuthenticationOptions>(IdentityConstants.TwoFactorRememberMeScheme, options =>
+			{
+				options.ExpireTimeSpan = TimeSpan.FromDays(30);
 			});
 
 			services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)

--- a/source/DasBlog.Web/Identity/DasBlogUser.cs
+++ b/source/DasBlog.Web/Identity/DasBlogUser.cs
@@ -1,5 +1,6 @@
 ﻿using DasBlog.Core.Security;
 using Microsoft.AspNetCore.Identity;
+using System.Collections.Generic;
 
 namespace DasBlog.Web.Identity
 {
@@ -14,5 +15,11 @@ namespace DasBlog.Web.Identity
 		public bool NotifyOnAllComment { get; set; }
 
 		public bool NotifyOnOwnComment { get; set; }
+
+		public bool TwoFactorEnabled { get; set; }
+
+		public string AuthenticatorSecret { get; set; }
+
+		public IList<RecoveryCode> RecoveryCodes { get; set; } = new List<RecoveryCode>();
 	}
 }

--- a/source/DasBlog.Web/Identity/DasBlogUserStore.cs
+++ b/source/DasBlog.Web/Identity/DasBlogUserStore.cs
@@ -6,15 +6,18 @@ using Microsoft.AspNetCore.Identity;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Security.Claims;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 
 namespace DasBlog.Web.Identity
 {
-	public class DasBlogUserStore : IUserStore<DasBlogUser>, IUserPasswordStore<DasBlogUser>, IUserEmailStore<DasBlogUser>, IUserClaimStore<DasBlogUser>
+	public class DasBlogUserStore : IUserStore<DasBlogUser>, IUserPasswordStore<DasBlogUser>, IUserEmailStore<DasBlogUser>, IUserClaimStore<DasBlogUser>, IUserAuthenticatorKeyStore<DasBlogUser>, IUserTwoFactorStore<DasBlogUser>, IUserTwoFactorRecoveryCodeStore<DasBlogUser>
 	{
+		private const string RecoveryCodeHashPrefix = "SHA256:";
 		private readonly IDasBlogSettings dasBlogSettings;
 		private readonly IMapper mapper;
 		private readonly IUserService userService;
@@ -102,20 +105,10 @@ namespace DasBlog.Web.Identity
 
 			try
 			{
-				var users = userService.GetAllUsers().ToList();
-				var index = users.FindIndex(u => !string.IsNullOrEmpty(u.EmailAddress)
-					&& u.EmailAddress.Equals(user.Email, StringComparison.OrdinalIgnoreCase));
-
-				if (index < 0)
+				if (!SaveUser(user, includePassword: true))
 				{
 					return Task.FromResult(IdentityResult.Failed(new IdentityError { Description = "User not found." }));
 				}
-
-				users[index].Password = user.PasswordHash;
-				userService.SaveUsers(users);
-
-				// Keep the cached SecurityConfiguration.Users list in sync so subsequent reads see the new hash.
-				dasBlogSettings.SecurityConfiguration.Users = users;
 			}
 			catch (Exception e)
 			{
@@ -294,6 +287,190 @@ namespace DasBlog.Web.Identity
 			throw new NotImplementedException();
 		}
 
+		#endregion IUserPasswordStore
+
+		#region IUserAuthenticatorKeyStore
+
+		public Task SetAuthenticatorKeyAsync(DasBlogUser user, string key, CancellationToken cancellationToken)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			if (user == null)
+			{
+				throw new ArgumentNullException(nameof(user));
+			}
+
+			user.AuthenticatorSecret = key;
+			SaveUser(user, includePassword: false);
+			return Task.CompletedTask;
+		}
+
+		public Task<string> GetAuthenticatorKeyAsync(DasBlogUser user, CancellationToken cancellationToken)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			if (user == null)
+			{
+				throw new ArgumentNullException(nameof(user));
+			}
+
+			return Task.FromResult(user.AuthenticatorSecret);
+		}
+
+		#endregion IUserAuthenticatorKeyStore
+
+		#region IUserTwoFactorStore
+
+		public Task SetTwoFactorEnabledAsync(DasBlogUser user, bool enabled, CancellationToken cancellationToken)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			if (user == null)
+			{
+				throw new ArgumentNullException(nameof(user));
+			}
+
+			user.TwoFactorEnabled = enabled;
+			if (!enabled)
+			{
+				user.AuthenticatorSecret = null;
+				user.RecoveryCodes = new List<RecoveryCode>();
+			}
+
+			SaveUser(user, includePassword: false);
+			return Task.CompletedTask;
+		}
+
+		public Task<bool> GetTwoFactorEnabledAsync(DasBlogUser user, CancellationToken cancellationToken)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			if (user == null)
+			{
+				throw new ArgumentNullException(nameof(user));
+			}
+
+			return Task.FromResult(user.TwoFactorEnabled);
+		}
+
+		#endregion IUserTwoFactorStore
+
+		#region IUserTwoFactorRecoveryCodeStore
+
+		public Task ReplaceCodesAsync(DasBlogUser user, IEnumerable<string> recoveryCodes, CancellationToken cancellationToken)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			if (user == null)
+			{
+				throw new ArgumentNullException(nameof(user));
+			}
+
+			user.RecoveryCodes = recoveryCodes
+				.Select(code => new RecoveryCode { Hash = HashRecoveryCode(code), Used = false })
+				.ToList();
+
+			SaveUser(user, includePassword: false);
+			return Task.CompletedTask;
+		}
+
+		public Task<bool> RedeemCodeAsync(DasBlogUser user, string code, CancellationToken cancellationToken)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			if (user == null)
+			{
+				throw new ArgumentNullException(nameof(user));
+			}
+
+			var matchingCode = user.RecoveryCodes?.FirstOrDefault(recoveryCode => !recoveryCode.Used && RecoveryCodeMatches(recoveryCode.Hash, code));
+			if (matchingCode == null)
+			{
+				return Task.FromResult(false);
+			}
+
+			matchingCode.Used = true;
+			SaveUser(user, includePassword: false);
+			return Task.FromResult(true);
+		}
+
+		public Task<int> CountCodesAsync(DasBlogUser user, CancellationToken cancellationToken)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			if (user == null)
+			{
+				throw new ArgumentNullException(nameof(user));
+			}
+
+			return Task.FromResult(user.RecoveryCodes?.Count(code => !code.Used) ?? 0);
+		}
+
+		#endregion IUserTwoFactorRecoveryCodeStore
+
+		private bool SaveUser(DasBlogUser user, bool includePassword)
+		{
+			var users = userService.GetAllUsers().ToList();
+			var index = users.FindIndex(u => UserMatches(u, user));
+
+			if (index < 0)
+			{
+				return false;
+			}
+
+			ApplyIdentityState(users[index], user, includePassword);
+			userService.SaveUsers(users);
+
+			// Keep the cached SecurityConfiguration.Users list in sync so subsequent reads see changes.
+			dasBlogSettings.SecurityConfiguration.Users = users;
+			return true;
+		}
+
+		private static bool UserMatches(User persistedUser, DasBlogUser identityUser)
+		{
+			return (!string.IsNullOrEmpty(persistedUser.EmailAddress) && !string.IsNullOrEmpty(identityUser.Email)
+					&& persistedUser.EmailAddress.Equals(identityUser.Email, StringComparison.OrdinalIgnoreCase))
+				|| (!string.IsNullOrEmpty(persistedUser.Name) && !string.IsNullOrEmpty(identityUser.UserName)
+					&& persistedUser.Name.Equals(identityUser.UserName, StringComparison.OrdinalIgnoreCase));
+		}
+
+		private static void ApplyIdentityState(User persistedUser, DasBlogUser identityUser, bool includePassword)
+		{
+			if (!string.IsNullOrEmpty(identityUser.Email))
+			{
+				persistedUser.EmailAddress = identityUser.Email;
+			}
+
+			if (!string.IsNullOrEmpty(identityUser.DisplayName))
+			{
+				persistedUser.DisplayName = identityUser.DisplayName;
+			}
+
+			if (includePassword && !string.IsNullOrEmpty(identityUser.PasswordHash))
+			{
+				persistedUser.Password = identityUser.PasswordHash;
+			}
+
+			persistedUser.TwoFactor = new TwoFactorSettings
+			{
+				Enabled = identityUser.TwoFactorEnabled,
+				AuthenticatorSecret = identityUser.AuthenticatorSecret,
+				RecoveryCodes = identityUser.RecoveryCodes?.ToList() ?? new List<RecoveryCode>()
+			};
+		}
+
+		private static string HashRecoveryCode(string code)
+		{
+			var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(code ?? string.Empty));
+			return RecoveryCodeHashPrefix + Convert.ToBase64String(bytes);
+		}
+
+		private static bool RecoveryCodeMatches(string storedHash, string code)
+		{
+			if (string.IsNullOrEmpty(storedHash))
+			{
+				return false;
+			}
+
+			var candidateHash = HashRecoveryCode(code);
+			var storedBytes = Encoding.UTF8.GetBytes(storedHash);
+			var candidateBytes = Encoding.UTF8.GetBytes(candidateHash);
+			return storedBytes.Length == candidateBytes.Length && CryptographicOperations.FixedTimeEquals(storedBytes, candidateBytes);
+		}
+
 		#region IDisposable Support
 
 		private bool disposedValue = false; // To detect redundant calls
@@ -330,7 +507,5 @@ namespace DasBlog.Web.Identity
 		}
 
 		#endregion IDisposable Support
-
-		#endregion IUserPasswordStore
 	}
 }

--- a/source/DasBlog.Web/Mappers/ProfileDasBlogUser.cs
+++ b/source/DasBlog.Web/Mappers/ProfileDasBlogUser.cs
@@ -5,6 +5,8 @@ using DasBlog.Web.Identity;
 using System.Text.RegularExpressions;
 using DasBlog.Managers.Interfaces;
 using DasBlog.Web.Models;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace DasBlog.Web.Mappers
 {
@@ -27,6 +29,12 @@ namespace DasBlog.Web.Mappers
 				.ForMember(dest => dest.EmailAddress, opt => opt.MapFrom(src => src.Email))
 				.ForMember(dest => dest.DisplayName, opt => opt.MapFrom(src => src.DisplayName))
 				.ForMember(dest => dest.Password, opt => opt.MapFrom(src => src.PasswordHash))
+				.ForMember(dest => dest.TwoFactor, opt => opt.MapFrom(src => new TwoFactorSettings
+				{
+					Enabled = src.TwoFactorEnabled,
+					AuthenticatorSecret = src.AuthenticatorSecret,
+					RecoveryCodes = src.RecoveryCodes == null ? new List<RecoveryCode>() : src.RecoveryCodes.ToList()
+				}))
 				.ForMember(dest => dest.Name, opt => opt.MapFrom(src => src.DisplayName));
 
 			CreateMap<User, DasBlogUser>()
@@ -34,6 +42,9 @@ namespace DasBlog.Web.Mappers
 				.ForMember(dest => dest.Email, opt => opt.MapFrom(src => src.EmailAddress))
 				.ForMember(dest => dest.DisplayName, opt => opt.MapFrom(src => src.DisplayName))
 				.ForMember(dest => dest.PasswordHash, opt => opt.MapFrom(src => src.Password))
+				.ForMember(dest => dest.TwoFactorEnabled, opt => opt.MapFrom(src => src.TwoFactor != null && src.TwoFactor.Enabled))
+				.ForMember(dest => dest.AuthenticatorSecret, opt => opt.MapFrom(src => src.TwoFactor == null ? null : src.TwoFactor.AuthenticatorSecret))
+				.ForMember(dest => dest.RecoveryCodes, opt => opt.MapFrom(src => src.TwoFactor == null || src.TwoFactor.RecoveryCodes == null ? new List<RecoveryCode>() : src.TwoFactor.RecoveryCodes.ToList()))
 				.ForMember(dest => dest.SecurityStamp, opt => opt.MapFrom(src => src.Name));
 			
 			CreateMap<AuthorViewModel, User>()

--- a/source/DasBlog.Web/Models/AccountViewModels/EnableAuthenticatorViewModel.cs
+++ b/source/DasBlog.Web/Models/AccountViewModels/EnableAuthenticatorViewModel.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace DasBlog.Web.Models.AccountViewModels
+{
+	public class EnableAuthenticatorViewModel
+	{
+		public string SharedKey { get; set; }
+
+		public string AuthenticatorUri { get; set; }
+
+		public string QrCodeSvg { get; set; }
+
+		public bool IsTwoFactorEnabled { get; set; }
+
+		[Required]
+		[Display(Name = "Verification code")]
+		[StringLength(7, ErrorMessage = "The verification code must be 6 digits.", MinimumLength = 6)]
+		[DataType(DataType.Text)]
+		public string Code { get; set; }
+
+		public IList<string> RecoveryCodes { get; set; } = new List<string>();
+	}
+}

--- a/source/DasBlog.Web/Models/AccountViewModels/LoginWith2faViewModel.cs
+++ b/source/DasBlog.Web/Models/AccountViewModels/LoginWith2faViewModel.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+
+namespace DasBlog.Web.Models.AccountViewModels
+{
+	public class LoginWith2faViewModel
+	{
+		[Required]
+		[Display(Name = "Authenticator code")]
+		[StringLength(7, ErrorMessage = "The authenticator code must be 6 digits.", MinimumLength = 6)]
+		[DataType(DataType.Text)]
+		public string TwoFactorCode { get; set; }
+
+		[DisplayName("Remember this browser?")]
+		public bool RememberMachine { get; set; }
+
+		public bool RememberMe { get; set; }
+
+		public string ReturnUrl { get; set; }
+	}
+}

--- a/source/DasBlog.Web/Models/AccountViewModels/LoginWithRecoveryCodeViewModel.cs
+++ b/source/DasBlog.Web/Models/AccountViewModels/LoginWithRecoveryCodeViewModel.cs
@@ -1,0 +1,14 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace DasBlog.Web.Models.AccountViewModels
+{
+	public class LoginWithRecoveryCodeViewModel
+	{
+		[Required]
+		[DataType(DataType.Text)]
+		[Display(Name = "Recovery code")]
+		public string RecoveryCode { get; set; }
+
+		public string ReturnUrl { get; set; }
+	}
+}

--- a/source/DasBlog.Web/Models/AccountViewModels/RecoveryCodesViewModel.cs
+++ b/source/DasBlog.Web/Models/AccountViewModels/RecoveryCodesViewModel.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace DasBlog.Web.Models.AccountViewModels
+{
+	public class RecoveryCodesViewModel
+	{
+		public IList<string> RecoveryCodes { get; set; } = new List<string>();
+	}
+}

--- a/source/DasBlog.Web/Views/Account/Disable2fa.cshtml
+++ b/source/DasBlog.Web/Views/Account/Disable2fa.cshtml
@@ -1,0 +1,15 @@
+@{
+    ViewBag.Title = "Disable two-factor authentication";
+    Layout = "../../Themes/dasblog/_Layout.cshtml";
+}
+
+<h2>@ViewBag.Title</h2>
+<hr />
+<div class="alert alert-warning" role="alert">
+    Disabling two-factor authentication clears the authenticator secret and all recovery codes for this account.
+</div>
+
+<form asp-controller="Account" asp-action="Disable2faConfirmed" method="post">
+    <button type="submit" class="btn btn-danger me-2">Disable 2FA</button>
+    <a asp-controller="Account" asp-action="EnableAuthenticator" class="btn btn-secondary">Cancel</a>
+</form>

--- a/source/DasBlog.Web/Views/Account/EnableAuthenticator.cshtml
+++ b/source/DasBlog.Web/Views/Account/EnableAuthenticator.cshtml
@@ -1,0 +1,59 @@
+@model DasBlog.Web.Models.AccountViewModels.EnableAuthenticatorViewModel
+
+@{
+    ViewBag.Title = "Authenticator app";
+    Layout = "../../Themes/dasblog/_Layout.cshtml";
+}
+
+<h2>@ViewBag.Title</h2>
+<hr />
+<success-alert alert-id="twoFactorSuccess" message-key="SuccessMessage" />
+
+@if (Model.IsTwoFactorEnabled)
+{
+    <div class="alert alert-success" role="alert">
+        Two-factor authentication is enabled for this account.
+    </div>
+    <div class="d-flex flex-wrap mb-4">
+        <a asp-controller="Account" asp-action="ResetRecoveryCodes" class="btn btn-warning me-2">Reset recovery codes</a>
+        <a asp-controller="Account" asp-action="Disable2fa" class="btn btn-danger">Disable 2FA</a>
+    </div>
+}
+else
+{
+    <p>Scan this QR code with an authenticator app, or enter the setup key manually. Then enter the 6-digit verification code to finish enrollment.</p>
+
+    <div class="row gy-2 gx-3 align-items-md-start mb-3">
+        <div class="col-sm-4 text-center">
+            @Html.Raw(Model.QrCodeSvg)
+        </div>
+        <div class="col-sm-8">
+            <p><strong>Setup key:</strong></p>
+            <code>@Model.SharedKey</code>
+        </div>
+    </div>
+
+    <form asp-controller="Account" asp-action="EnableAuthenticator" method="post" class="form-horizontal">
+        <div class="row gy-2 gx-3 align-items-md-start mb-3">
+            <div class="col-sm-4">
+                <div class="form-floating">
+                    @Html.TextBoxFor(m => m.Code, null, new { @class = "form-control", id = "Code", autocomplete = "one-time-code", inputmode = "numeric" })
+                    @Html.LabelFor(m => m.Code, null, new { @class = "form-label", @for = "Code" })
+                </div>
+                @Html.ValidationMessageFor(m => m.Code, null, new { @class = "text-danger" })
+            </div>
+        </div>
+
+        <div class="d-flex flex-wrap">
+            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+        </div>
+
+        <hr />
+        <button type="submit" class="btn btn-primary me-2">Verify and enable</button>
+        <a href="~/admin/settings" class="btn btn-secondary">Cancel</a>
+    </form>
+}
+
+@section Scripts {
+    @{ await Html.RenderPartialAsync("_ValidationScriptsPartial"); }
+}

--- a/source/DasBlog.Web/Views/Account/LoginWith2fa.cshtml
+++ b/source/DasBlog.Web/Views/Account/LoginWith2fa.cshtml
@@ -1,0 +1,44 @@
+@model DasBlog.Web.Models.AccountViewModels.LoginWith2faViewModel
+
+@{
+    ViewBag.Title = "Two-factor authentication";
+    Layout = "../../Themes/dasblog/_Layout.cshtml";
+}
+
+<h2>@ViewBag.Title</h2>
+<hr />
+<p>Enter the 6-digit code from your authenticator app.</p>
+
+<form asp-controller="Account" asp-action="LoginWith2fa" method="post" class="form-horizontal">
+    @Html.HiddenFor(m => m.RememberMe)
+    @Html.HiddenFor(m => m.ReturnUrl)
+
+    <div class="row gy-2 gx-3 justify-content-md-center mb-3">
+        <div class="col-sm-4">
+            <div class="form-floating">
+                @Html.TextBoxFor(m => m.TwoFactorCode, null, new { @class = "form-control", id = "TwoFactorCode", autocomplete = "one-time-code", inputmode = "numeric" })
+                @Html.LabelFor(m => m.TwoFactorCode, null, new { @class = "form-label", @for = "TwoFactorCode" })
+            </div>
+            @Html.ValidationMessageFor(m => m.TwoFactorCode, null, new { @class = "text-danger" })
+        </div>
+    </div>
+
+    <div class="d-flex flex-wrap justify-content-md-center mb-3">
+        @Html.CheckBoxFor(m => m.RememberMachine, new { @class = "form-check-input me-1" })
+        @Html.LabelFor(m => m.RememberMachine, null, new { @class = "form-check-label me-3" })
+    </div>
+
+    <div class="d-flex flex-wrap justify-content-md-center">
+        <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+    </div>
+
+    <hr />
+    <div class="d-flex flex-wrap justify-content-md-center">
+        <button type="submit" class="btn btn-primary me-2">Verify</button>
+        <a asp-controller="Account" asp-action="LoginWithRecoveryCode" asp-route-returnUrl="@Model.ReturnUrl" class="btn btn-link">Use a recovery code</a>
+    </div>
+</form>
+
+@section Scripts {
+    @{ await Html.RenderPartialAsync("_ValidationScriptsPartial"); }
+}

--- a/source/DasBlog.Web/Views/Account/LoginWithRecoveryCode.cshtml
+++ b/source/DasBlog.Web/Views/Account/LoginWithRecoveryCode.cshtml
@@ -1,0 +1,38 @@
+@model DasBlog.Web.Models.AccountViewModels.LoginWithRecoveryCodeViewModel
+
+@{
+    ViewBag.Title = "Recovery code";
+    Layout = "../../Themes/dasblog/_Layout.cshtml";
+}
+
+<h2>@ViewBag.Title</h2>
+<hr />
+<p>Enter one of your saved recovery codes. Each recovery code can only be used once.</p>
+
+<form asp-controller="Account" asp-action="LoginWithRecoveryCode" method="post" class="form-horizontal">
+    @Html.HiddenFor(m => m.ReturnUrl)
+
+    <div class="row gy-2 gx-3 justify-content-md-center mb-3">
+        <div class="col-sm-4">
+            <div class="form-floating">
+                @Html.TextBoxFor(m => m.RecoveryCode, null, new { @class = "form-control", id = "RecoveryCode", autocomplete = "one-time-code" })
+                @Html.LabelFor(m => m.RecoveryCode, null, new { @class = "form-label", @for = "RecoveryCode" })
+            </div>
+            @Html.ValidationMessageFor(m => m.RecoveryCode, null, new { @class = "text-danger" })
+        </div>
+    </div>
+
+    <div class="d-flex flex-wrap justify-content-md-center">
+        <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+    </div>
+
+    <hr />
+    <div class="d-flex flex-wrap justify-content-md-center">
+        <button type="submit" class="btn btn-primary me-2">Log in</button>
+        <a asp-controller="Account" asp-action="LoginWith2fa" asp-route-returnUrl="@Model.ReturnUrl" class="btn btn-link">Use an authenticator code</a>
+    </div>
+</form>
+
+@section Scripts {
+    @{ await Html.RenderPartialAsync("_ValidationScriptsPartial"); }
+}

--- a/source/DasBlog.Web/Views/Account/ResetRecoveryCodes.cshtml
+++ b/source/DasBlog.Web/Views/Account/ResetRecoveryCodes.cshtml
@@ -1,0 +1,15 @@
+@{
+    ViewBag.Title = "Reset recovery codes";
+    Layout = "../../Themes/dasblog/_Layout.cshtml";
+}
+
+<h2>@ViewBag.Title</h2>
+<hr />
+<div class="alert alert-warning" role="alert">
+    Resetting recovery codes invalidates all previous recovery codes for this account.
+</div>
+
+<form asp-controller="Account" asp-action="ResetRecoveryCodesConfirmed" method="post">
+    <button type="submit" class="btn btn-warning me-2">Reset recovery codes</button>
+    <a asp-controller="Account" asp-action="EnableAuthenticator" class="btn btn-secondary">Cancel</a>
+</form>

--- a/source/DasBlog.Web/Views/Account/ShowRecoveryCodes.cshtml
+++ b/source/DasBlog.Web/Views/Account/ShowRecoveryCodes.cshtml
@@ -1,0 +1,23 @@
+@model DasBlog.Web.Models.AccountViewModels.RecoveryCodesViewModel
+
+@{
+    ViewBag.Title = "Recovery codes";
+    Layout = "../../Themes/dasblog/_Layout.cshtml";
+}
+
+<h2>@ViewBag.Title</h2>
+<hr />
+<div class="alert alert-warning" role="alert">
+    Save these recovery codes now. They are shown only once, and each code can only be used one time.
+</div>
+
+<div class="row gy-2 gx-3 mb-3">
+    @foreach (var code in Model.RecoveryCodes)
+    {
+        <div class="col-sm-3">
+            <code>@code</code>
+        </div>
+    }
+</div>
+
+<a asp-controller="Account" asp-action="EnableAuthenticator" class="btn btn-primary">Done</a>

--- a/source/DasBlog.Web/Views/Shared/_Admin_Security.cshtml
+++ b/source/DasBlog.Web/Views/Shared/_Admin_Security.cshtml
@@ -5,6 +5,12 @@
 
 <div class="row gy-2 gx-3 align-items-md-start mb-3">
     <div class="col-sm-12">
+        <a asp-controller="Account" asp-action="EnableAuthenticator" class="btn btn-outline-primary">Manage two-factor authentication</a>
+    </div>
+</div>
+
+<div class="row gy-2 gx-3 align-items-md-start mb-3">
+    <div class="col-sm-12">
         <div class="form-floating">
             @Html.TextBoxFor(m => @Model.SiteConfig.SecurityStyleSources, null, new { @class = "form-control", id = "securityStyleSources" })
             @Html.LabelFor(m => @Model.SiteConfig.SecurityStyleSources, null, new { @class = "form-label", @for = "securityStyleSources" })

--- a/source/Directory.Packages.props
+++ b/source/Directory.Packages.props
@@ -36,6 +36,7 @@
     <PackageVersion Include="HtmlAgilityPack" Version="1.11.71" />
     <PackageVersion Include="HtmlSanitizer" Version="9.0.892" />
     <PackageVersion Include="Quartz.AspNetCore" Version="3.13.1" />
+    <PackageVersion Include="QRCoder" Version="1.6.0" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.48.0" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.4.13" />
 


### PR DESCRIPTION
Add two-factor authentication (2FA) support

Implemented TOTP authenticator app and recovery code support for user accounts. Added TwoFactorSettings and RecoveryCode types, updated User and DasBlogUser models, and extended DasBlogUserStore for 2FA persistence and validation. Integrated 2FA flows in AccountController, including QR code setup (QRCoder), code verification, and recovery code management. Updated AutoMapper profiles, admin UI, and added new Razor views for 2FA. Registered QRCoder package and added unit tests for 2FA logic and serialization.