### PR TITLE
Enable progressive front page loading with "Load more"

### DIFF
--- a/source/DasBlog.Core/Common/Constants.cs
+++ b/source/DasBlog.Core/Common/Constants.cs
@@ -20,6 +20,7 @@
 		public const string ShowPageControl = "show-page-control";
 		public const string PageNumber = "page-number";
 		public const string PostCount = "post-count";
+		public const string EnableProgressiveFrontPageLoading = "enable-progressive-front-page-loading";
 		public const string ArchivePageTitle = "Archive";
 		public const string ArchiveAllPageTitle = "Complete Archive";
 		public const string CommentShowPageControl = "comment-show-page-control";

--- a/source/DasBlog.Services/ConfigFile/Interfaces/ISiteConfig.cs
+++ b/source/DasBlog.Services/ConfigFile/Interfaces/ISiteConfig.cs
@@ -106,6 +106,8 @@ namespace DasBlog.Services.ConfigFile.Interfaces
 
 		bool EnableStartPageCaching { get; set; }
 
+        bool EnableProgressiveFrontPageLoading { get; set; }
+
 		bool ShowItemSummaryInAggregatedViews { get; set; }
 
         decimal DisplayTimeZoneIndex { get; set; }

--- a/source/DasBlog.Services/ConfigFile/SiteConfig.cs
+++ b/source/DasBlog.Services/ConfigFile/SiteConfig.cs
@@ -102,6 +102,7 @@ namespace DasBlog.Services.ConfigFile
         public bool AllowMarkdownInComments {get; set;}
         public bool ShowCommentCount { get; set; }
         public bool EnableStartPageCaching { get; set; }
+        public bool EnableProgressiveFrontPageLoading { get; set; }
 		public bool EnableRewritingHashtagsToCategoryLinks { get; set; }
 		public bool EnableRewritingBareLinksToEmbeddings { get; set; }
 		public bool EnableRewritingBareLinksToIcons { get; set; }

--- a/source/DasBlog.Tests/UnitTests/Config/site.config
+++ b/source/DasBlog.Tests/UnitTests/Config/site.config
@@ -45,6 +45,7 @@
   <FrontPageCategory />
   <PostPinnedToHomePage />
   <EnableStartPageCaching>true</EnableStartPageCaching>
+  <EnableProgressiveFrontPageLoading>false</EnableProgressiveFrontPageLoading>
 
   <AlwaysIncludeContentInRSS>true</AlwaysIncludeContentInRSS>
   <EntryTitleAsLink>true</EntryTitleAsLink>

--- a/source/DasBlog.Tests/UnitTests/SiteConfigTest.cs
+++ b/source/DasBlog.Tests/UnitTests/SiteConfigTest.cs
@@ -37,6 +37,7 @@ namespace DasBlog.Tests.UnitTests
 		public string TinyMCEApiKey { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 		public bool EnableComments { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 		public bool EnableStartPageCaching { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+		public bool EnableProgressiveFrontPageLoading { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 		public decimal DisplayTimeZoneIndex { get => 4; set => throw new NotImplementedException(); }
 		public bool AdjustDisplayTimeZone { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 		public string ContentDir { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }

--- a/source/DasBlog.Tests/UnitTests/UI/TagHelperTest.cs
+++ b/source/DasBlog.Tests/UnitTests/UI/TagHelperTest.cs
@@ -278,6 +278,38 @@ namespace DasBlog.Tests.UnitTests.UI
 
 		[Fact]
 		[Trait("Category", "UnitTest")]
+		public async Task SitePageControlTagHelper_RendersLoadMoreForProgressiveFrontPage()
+		{
+			var dasBlogSettingsMock = new DasBlogSettingsMock();
+			var dasBlogSettings = dasBlogSettingsMock.CreateSettings();
+			var viewContext = new Microsoft.AspNetCore.Mvc.Rendering.ViewContext();
+			viewContext.ViewData[DasBlog.Core.Common.Constants.PostCount] = 5;
+			viewContext.ViewData[DasBlog.Core.Common.Constants.PageNumber] = 0;
+			viewContext.ViewData[DasBlog.Core.Common.Constants.EnableProgressiveFrontPageLoading] = true;
+
+			var sut = new DasBlog.Web.TagHelpers.Layout.SitePageControlTagHelper((DasBlog.Services.IUrlResolver)dasBlogSettings)
+			{
+				ViewContext = viewContext
+			};
+
+			var context = new TagHelperContext(new TagHelperAttributeList(), new Dictionary<object, object>(), Guid.NewGuid().ToString("N"));
+			var output = new TagHelperOutput("sitepagecontrol", new TagHelperAttributeList(), (useCachedResult, htmlEncoder) =>
+			{
+				var tagHelperContent = new DefaultTagHelperContent();
+				tagHelperContent.SetContent(string.Empty);
+				return Task.FromResult<TagHelperContent>(tagHelperContent);
+			});
+
+			await sut.ProcessAsync(context, output);
+
+			var content = output.Content.GetContent();
+			Assert.Contains("Load more posts", content);
+			Assert.Contains("data-dbc-load-more-posts='true'", content);
+			Assert.Contains("page/1/posts", content);
+		}
+
+		[Fact]
+		[Trait("Category", "UnitTest")]
 		public async Task PostCategoriesListTagHelper_RendersCategories()
 		{
 			var dasBlogSettingsMock = new DasBlogSettingsMock();

--- a/source/DasBlog.Web/Config/site.Development.config
+++ b/source/DasBlog.Web/Config/site.Development.config
@@ -25,6 +25,7 @@
   <AllowMarkdownInComments>false</AllowMarkdownInComments>
   <ShowCommentCount>true</ShowCommentCount>
   <EnableStartPageCaching>true</EnableStartPageCaching>
+  <EnableProgressiveFrontPageLoading>false</EnableProgressiveFrontPageLoading>
   <EnableRewritingHashtagsToCategoryLinks>false</EnableRewritingHashtagsToCategoryLinks>
   <EnableRewritingBareLinksToEmbeddings>false</EnableRewritingBareLinksToEmbeddings>
   <EnableRewritingBareLinksToIcons>false</EnableRewritingBareLinksToIcons>

--- a/source/DasBlog.Web/Config/site.config
+++ b/source/DasBlog.Web/Config/site.config
@@ -45,6 +45,7 @@
   <FrontPageCategory />
   <PostPinnedToHomePage />
   <EnableStartPageCaching>true</EnableStartPageCaching>
+  <EnableProgressiveFrontPageLoading>false</EnableProgressiveFrontPageLoading>
 
   <AlwaysIncludeContentInRSS>true</AlwaysIncludeContentInRSS>
   <EntryTitleAsLink>true</EntryTitleAsLink>

--- a/source/DasBlog.Web/Controllers/HomeController.cs
+++ b/source/DasBlog.Web/Controllers/HomeController.cs
@@ -67,6 +67,7 @@ namespace DasBlog.Web.Controllers
 			ViewData[Constants.ShowPageControl] = true;			
 			ViewData[Constants.PageNumber] = 0;
 			ViewData[Constants.PostCount] = lpvm.Posts.Count;
+			ViewData[Constants.EnableProgressiveFrontPageLoading] = dasBlogSettings.SiteConfiguration.EnableProgressiveFrontPageLoading;
 
 			return AggregatePostView(lpvm);
 		}
@@ -85,11 +86,7 @@ namespace DasBlog.Web.Controllers
 				return Index();
 			}
 
-			var lpvm = new ListPostsViewModel
-			{
-				Posts = blogManager.GetEntriesForPage(index, Request.Headers["Accept-Language"])
-								.Select(entry => mapper.Map<PostViewModel>(entry)).ToList()
-			};
+			var lpvm = PagePosts(index);
 
 			AddComments(lpvm);
 
@@ -99,6 +96,26 @@ namespace DasBlog.Web.Controllers
 			ViewData[Constants.PostCount] = lpvm.Posts.Count;
 
 			return AggregatePostView(lpvm);
+		}
+
+		[HttpGet("page/{index:int}/posts")]
+		public IActionResult PagePostsPartial(int index)
+		{
+			if (index < 1)
+			{
+				return BadRequest();
+			}
+
+			var lpvm = PagePosts(index);
+
+			if (lpvm.Posts.Count == 0)
+			{
+				return NoContent();
+			}
+
+			AddComments(lpvm);
+
+			return PartialView(dasBlogSettings.SiteConfiguration.ShowItemSummaryInAggregatedViews ? "_BlogItemsSummary" : "_BlogItems", lpvm);
 		}
 
 		public IActionResult Error()
@@ -138,6 +155,15 @@ namespace DasBlog.Web.Controllers
 			}
 
 			return listPostsViewModel;
+		}
+
+		private ListPostsViewModel PagePosts(int index)
+		{
+			return new ListPostsViewModel
+			{
+				Posts = blogManager.GetEntriesForPage(index, Request.Headers["Accept-Language"])
+								.Select(entry => mapper.Map<PostViewModel>(entry)).ToList()
+			};
 		}
 
 		private IList<PostViewModel> HomePagePosts()

--- a/source/DasBlog.Web/Models/AdminViewModels/SiteViewModel.cs
+++ b/source/DasBlog.Web/Models/AdminViewModels/SiteViewModel.cs
@@ -75,6 +75,10 @@ namespace DasBlog.Web.Models.AdminViewModels
 		[Description("Uses standard web based caching on the server side (will increase memory usage).")]
 		public bool EnableStartPageCaching { get; set; }
 
+		[DisplayName("Enable progressive front page loading")]
+		[Description("Adds a Load more posts button to the front page so older posts can be appended without leaving the page.")]
+		public bool EnableProgressiveFrontPageLoading { get; set; }
+
 		[DisplayName("Days to look ahead for content")]
 		[Description("Looks for future posts for this number of days into the future")]
 		[Required(AllowEmptyStrings = false, ErrorMessage = "Enter a value for Content Look ahead Days")]

--- a/source/DasBlog.Web/TagHelpers/Site/SitePageControlTagHelper.cs
+++ b/source/DasBlog.Web/TagHelpers/Site/SitePageControlTagHelper.cs
@@ -19,6 +19,9 @@ namespace DasBlog.Web.TagHelpers.Layout
 		private int PostCount { get; set; }
 		private int PageNumber { get; set; }
 		private const string PAGEANCHOR = "<span class='dbc-span-page-control-{2}'><a href='{0}'>{1}</a></span>";
+		private const string LOADMOREANCHOR = "<span class='dbc-span-page-control-load-more'><a href='{0}' class='btn btn-secondary dbc-load-more-posts' data-dbc-load-more-posts='true' data-dbc-load-more-url='{1}' data-dbc-next-page='{2}'>{3}</a></span>";
+
+		public string LoadMorePostsText { get; set; } = "Load more posts";
 
 		[ViewContext]
 		public ViewContext ViewContext { get; set; }
@@ -34,6 +37,7 @@ namespace DasBlog.Web.TagHelpers.Layout
 		{
 			PostCount = (int?)ViewContext.ViewData[Constants.PostCount] ?? 0;
 			PageNumber = (int?)ViewContext.ViewData[Constants.PageNumber] ?? 0;
+			var progressiveFrontPageLoading = (bool?)ViewContext.ViewData[Constants.EnableProgressiveFrontPageLoading] ?? false;
 
 			var pagecontrol = string.Empty;
 
@@ -47,6 +51,19 @@ namespace DasBlog.Web.TagHelpers.Layout
 			if(!string.IsNullOrEmpty(content.GetContent()))
 			{
 				seperator = content.GetContent();
+			}
+
+			if (progressiveFrontPageLoading && PostCount > 0 && PageNumber == 0)
+			{
+				var nextPage = PageNumber + 1;
+				pagecontrol = string.Format(LOADMOREANCHOR,
+					urlResolver.RelativeToRoot(string.Format("page/{0}", nextPage)),
+					urlResolver.RelativeToRoot(string.Format("page/{0}/posts", nextPage)),
+					nextPage,
+					LoadMorePostsText);
+
+				output.Content.SetHtmlContent(pagecontrol);
+				return;
 			}
 
 			var separatorRequired = PostCount > 0 && PageNumber > 0;

--- a/source/DasBlog.Web/Themes/darkly/_BlogPage.cshtml
+++ b/source/DasBlog.Web/Themes/darkly/_BlogPage.cshtml
@@ -1,7 +1,7 @@
 @model ListPostsViewModel
 
 <div class="row">
-    <div id="contents" class="col-12">
+    <div id="contents" class="col-12" data-dbc-posts-container>
         <partial name="_BlogItems" model="Model" />
     </div>
 </div>

--- a/source/DasBlog.Web/Themes/darkly/_BlogPageSummary.cshtml
+++ b/source/DasBlog.Web/Themes/darkly/_BlogPageSummary.cshtml
@@ -8,6 +8,6 @@
     </div>
 </div>
 
-<div class="row mb-2">
+<div class="row mb-2" data-dbc-posts-container>
     <partial name="_BlogItemsSummary" model="Model" />
 </div>

--- a/source/DasBlog.Web/Themes/dasblog/_BlogPage.cshtml
+++ b/source/DasBlog.Web/Themes/dasblog/_BlogPage.cshtml
@@ -1,7 +1,7 @@
 @model ListPostsViewModel
 
 <div class="row">
-    <div id="contents" class="col-12">
+    <div id="contents" class="col-12" data-dbc-posts-container>
         <partial name="_BlogItems" model="Model" />
     </div>
 </div>

--- a/source/DasBlog.Web/Themes/dasblog/_BlogPageSummary.cshtml
+++ b/source/DasBlog.Web/Themes/dasblog/_BlogPageSummary.cshtml
@@ -8,6 +8,6 @@
     </div>
 </div>
 
-<div class="row mb-2">
+<div class="row mb-2" data-dbc-posts-container>
     <partial name="_BlogItemsSummary" model="Model" />
 </div>

--- a/source/DasBlog.Web/Themes/flamingo/_BlogPage.cshtml
+++ b/source/DasBlog.Web/Themes/flamingo/_BlogPage.cshtml
@@ -1,7 +1,7 @@
 @model ListPostsViewModel
 
 <div class="row">
-    <div id="contents" class="col-12">
+    <div id="contents" class="col-12" data-dbc-posts-container>
         <partial name="_BlogItems" model="Model" />
     </div>
 </div>

--- a/source/DasBlog.Web/Themes/flamingo/_BlogPageSummary.cshtml
+++ b/source/DasBlog.Web/Themes/flamingo/_BlogPageSummary.cshtml
@@ -6,7 +6,7 @@
     <p class="flm-hero-description"><site-description /></p>
 </div>
 
-<div class="flm-post-list">
+<div class="flm-post-list" data-dbc-posts-container>
     <partial name="_BlogItemsSummary" model="Model" />
 </div>
 

--- a/source/DasBlog.Web/Themes/flatly/_BlogPage.cshtml
+++ b/source/DasBlog.Web/Themes/flatly/_BlogPage.cshtml
@@ -1,7 +1,7 @@
 @model ListPostsViewModel
 
 <div class="row">
-    <div id="contents" class="col-12">
+    <div id="contents" class="col-12" data-dbc-posts-container>
         <partial name="_BlogItems" model="Model" />
     </div>
 </div>

--- a/source/DasBlog.Web/Themes/flatly/_BlogPageSummary.cshtml
+++ b/source/DasBlog.Web/Themes/flatly/_BlogPageSummary.cshtml
@@ -8,6 +8,6 @@
     </div>
 </div>
 
-<div class="row mb-2">
+<div class="row mb-2" data-dbc-posts-container>
     <partial name="_BlogItemsSummary" model="Model" />
 </div>

--- a/source/DasBlog.Web/Themes/kindofblue/_BlogPage.cshtml
+++ b/source/DasBlog.Web/Themes/kindofblue/_BlogPage.cshtml
@@ -1,7 +1,7 @@
 @model ListPostsViewModel
 
 <div class="row">
-    <div id="contents" class="col-12">
+    <div id="contents" class="col-12" data-dbc-posts-container>
         <partial name="_BlogItems" model="Model" />
     </div>
 </div>

--- a/source/DasBlog.Web/Themes/kindofblue/_BlogPageSummary.cshtml
+++ b/source/DasBlog.Web/Themes/kindofblue/_BlogPageSummary.cshtml
@@ -6,6 +6,6 @@
     <p class="kob-hero-description"><site-description /></p>
 </div>
 
-<div class="row g-4">
+<div class="row g-4" data-dbc-posts-container>
     <partial name="_BlogItemsSummary" model="Model" />
 </div>

--- a/source/DasBlog.Web/Themes/median/_BlogPage.cshtml
+++ b/source/DasBlog.Web/Themes/median/_BlogPage.cshtml
@@ -1,5 +1,7 @@
 @using DasBlog.Web.Models.BlogViewModels;
 @model ListPostsViewModel
 
-<partial name="_BlogItems" model="Model" />
+<div data-dbc-posts-container>
+    <partial name="_BlogItems" model="Model" />
+</div>
 

--- a/source/DasBlog.Web/Themes/median/_BlogPageSummary.cshtml
+++ b/source/DasBlog.Web/Themes/median/_BlogPageSummary.cshtml
@@ -11,4 +11,6 @@
     </p>
 </div>
 
-<partial name="_BlogItemsSummary" model="Model" />
+<div data-dbc-posts-container>
+    <partial name="_BlogItemsSummary" model="Model" />
+</div>

--- a/source/DasBlog.Web/Views/Shared/_Admin_FrontPage.cshtml
+++ b/source/DasBlog.Web/Views/Shared/_Admin_FrontPage.cshtml
@@ -61,6 +61,9 @@
     @Html.CheckBoxFor(m => @Model.SiteConfig.EnableStartPageCaching, new { @class = "form-check-input me-1" })
     @Html.LabelFor(m => @Model.SiteConfig.EnableStartPageCaching, null, new { @class = "form-check-label me-3" })
 
+    @Html.CheckBoxFor(m => @Model.SiteConfig.EnableProgressiveFrontPageLoading, new { @class = "form-check-input me-1" })
+    @Html.LabelFor(m => @Model.SiteConfig.EnableProgressiveFrontPageLoading, null, new { @class = "form-check-label me-3" })
+
     @Html.CheckBoxFor(m => @Model.SiteConfig.ShowItemSummaryInAggregatedViews, new { @class = "form-check-input me-1" })
     @Html.LabelFor(m => @Model.SiteConfig.ShowItemSummaryInAggregatedViews, null, new { @class = "form-check-label me-3" })
 </div>

--- a/source/DasBlog.Web/wwwroot/js/site.js
+++ b/source/DasBlog.Web/wwwroot/js/site.js
@@ -183,12 +183,13 @@ function showLastUserError(showError) {
                 return;
             }
 
-            var postsContainer = document.querySelector('[data-dbc-posts-container]');
+            event.preventDefault();
+
+            var postsContainer = document.querySelector('[data-dbc-posts-container]') || document.getElementById('contents');
             if (!postsContainer) {
+                window.location.href = loadMoreLink.getAttribute('href');
                 return;
             }
-
-            event.preventDefault();
 
             if (loadMoreLink.getAttribute('aria-busy') === 'true') {
                 return;

--- a/source/DasBlog.Web/wwwroot/js/site.js
+++ b/source/DasBlog.Web/wwwroot/js/site.js
@@ -157,6 +157,93 @@ function showLastUserError(showError) {
 }
 
 (function () {
+    function setNextPage(loadMoreLink) {
+        var nextPage = parseInt(loadMoreLink.getAttribute('data-dbc-next-page'), 10) + 1;
+        var partialUrl = loadMoreLink.getAttribute('data-dbc-load-more-url');
+        var pageUrl = loadMoreLink.getAttribute('href');
+
+        loadMoreLink.setAttribute('data-dbc-next-page', nextPage);
+        loadMoreLink.setAttribute('data-dbc-load-more-url', partialUrl.replace(/page\/\d+\/posts$/, 'page/' + nextPage + '/posts'));
+        loadMoreLink.setAttribute('href', pageUrl.replace(/page\/\d+$/, 'page/' + nextPage));
+    }
+
+    function hideLoadMore(loadMoreLink) {
+        var wrapper = loadMoreLink.closest('.dbc-span-page-control-load-more');
+        if (wrapper) {
+            wrapper.remove();
+        } else {
+            loadMoreLink.remove();
+        }
+    }
+
+    function init() {
+        document.addEventListener('click', function (event) {
+            var loadMoreLink = event.target.closest('[data-dbc-load-more-posts="true"]');
+            if (!loadMoreLink) {
+                return;
+            }
+
+            var postsContainer = document.querySelector('[data-dbc-posts-container]');
+            if (!postsContainer) {
+                return;
+            }
+
+            event.preventDefault();
+
+            if (loadMoreLink.getAttribute('aria-busy') === 'true') {
+                return;
+            }
+
+            var originalText = loadMoreLink.textContent;
+            loadMoreLink.setAttribute('aria-busy', 'true');
+            loadMoreLink.classList.add('disabled');
+            loadMoreLink.textContent = 'Loading...';
+
+            fetch(loadMoreLink.getAttribute('data-dbc-load-more-url'), {
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest'
+                }
+            })
+                .then(function (response) {
+                    if (response.status === 204) {
+                        hideLoadMore(loadMoreLink);
+                        return null;
+                    }
+
+                    if (!response.ok) {
+                        window.location.href = loadMoreLink.getAttribute('href');
+                        return null;
+                    }
+
+                    return response.text();
+                })
+                .then(function (html) {
+                    if (!html) {
+                        return;
+                    }
+
+                    postsContainer.insertAdjacentHTML('beforeend', html);
+                    setNextPage(loadMoreLink);
+                })
+                .catch(function () {
+                    window.location.href = loadMoreLink.getAttribute('href');
+                })
+                .finally(function () {
+                    loadMoreLink.removeAttribute('aria-busy');
+                    loadMoreLink.classList.remove('disabled');
+                    loadMoreLink.textContent = originalText;
+                });
+        });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();
+
+(function () {
     var STORAGE_KEY = 'dasblog-theme';
 
     function getStoredTheme() {


### PR DESCRIPTION
Enable progressive front page loading with "Load more"

Adds EnableProgressiveFrontPageLoading config and admin UI. HomeController now supports partial post loading via AJAX. SitePageControlTagHelper renders a "Load more posts" button when enabled. Updated blog page views for dynamic insertion. Added JS for progressive loading and a unit test for the new UI.