### PR TITLE
Move DasBlog template to Templates/; update references

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -35,7 +35,7 @@ Projects under `source/`:
 | `Subtext.Akismet` | Spam-filtering integration |
 | `NetEscapades.Extensions.Logging.RollingFile` | Vendored rolling-file logger |
 | `DasBlog.CLI` | Command-line config/management tool |
-| `DasBlog.Template.csproj` + `.template.config` / `template-staging` | `dotnet new dasblog` template packaging |
+| `Templates/DasBlog.Template/DasBlog.Template.csproj` + `.template.config` / `template-staging` | `dotnet new dasblog` template packaging |
 | `DasBlog.Tests/UnitTests` | xUnit unit tests |
 | `DasBlog.Tests/DasBlog.Test.Integration` | Integration tests |
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -124,7 +124,7 @@ steps:
   inputs:
     command: custom
     custom: pack
-    projects: 'source/DasBlog.Template.csproj'
+    projects: 'source/Templates/DasBlog.Template/DasBlog.Template.csproj'
     arguments: '-p:PackageVersion=$(Build.BuildNumber) --output $(Build.ArtifactStagingDirectory)/nupkg'
 
 - task: NuGetCommand@2

--- a/source/Templates/DasBlog.Template/.template.config/template.json
+++ b/source/Templates/DasBlog.Template/.template.config/template.json
@@ -13,7 +13,7 @@
   "preferNameDirectory": true,
   "sources": [
     {
-      "source": "template-staging/",
+      "source": "../../template-staging/",
       "target": "./",
       "modifiers": [
         {

--- a/source/Templates/DasBlog.Template/DasBlog.Template.csproj
+++ b/source/Templates/DasBlog.Template/DasBlog.Template.csproj
@@ -20,10 +20,10 @@
     <NoDefaultExcludes>true</NoDefaultExcludes>
   </PropertyGroup>
   <ItemGroup>
-    <Content Include="template-staging\**" />
+    <Content Include="..\..\template-staging\**" />
     <Content Include=".template.config\**" />
     <Compile Remove="**" />
-    <None Include="..\images\dasblog-square-icon.jpg" Pack="true" PackagePath="" />
-    <None Include="NUGET_README.md" Pack="true" PackagePath="" />
+    <None Include="..\..\..\images\dasblog-square-icon.jpg" Pack="true" PackagePath="" />
+    <None Include="..\..\NUGET_README.md" Pack="true" PackagePath="" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Move DasBlog template to Templates/; update references

Relocated DasBlog.Template to source/Templates/DasBlog.Template for better organization. Updated azure-pipelines.yml, DasBlog.Template.csproj, and template.json to use new paths and ensure correct packaging. Adjusted copilot-instructions.md to reflect the new template project location. No functional changes to template content.